### PR TITLE
Fix block services

### DIFF
--- a/gtfs.py
+++ b/gtfs.py
@@ -174,7 +174,7 @@ def load_trips(system):
             continue
         block_id = values['block_id']
         if block_id not in system.blocks:
-            system.blocks[block_id] = Block(system, block_id, service_id)
+            system.blocks[block_id] = Block(system, block_id)
         direction_id = int(values['direction_id'])
         shape_id = values['shape_id']
         headsign = values['trip_headsign']

--- a/models/block.py
+++ b/models/block.py
@@ -1,9 +1,8 @@
 
 class Block:
-    def __init__(self, system, block_id, service_id):
+    def __init__(self, system, block_id):
         self.system = system
         self.id = block_id
-        self.service_id = service_id
 
         self.trips = []
     
@@ -11,18 +10,25 @@ class Block:
         return self.id == other.id
     
     def __lt__(self, other):
-        if self.service == other.service:
-            return self.id < other.id
-        else:
-            return self.service < other.service
+        return self.id < other.id
+    
+    @property
+    def is_current(self):
+        for trip in self.trips:
+            if trip.service.is_current:
+                return True
+        return False
 
     @property
-    def service(self):
-        return self.system.get_service(self.service_id)
+    def services(self):
+        if self.is_current:
+            return sorted({ t.service for t in self.trips if t.service.is_current })
+        else:
+            return sorted({ t.service for t in self.trips })
     
     @property
     def available_trips(self):
-        if self.service.is_current:
+        if self.is_current:
             return [t for t in self.trips if t.service.is_current]
         else:
             return self.trips

--- a/models/block_history.py
+++ b/models/block_history.py
@@ -29,8 +29,8 @@ class BlockHistory:
         return get_system(self.system_id)
     
     @property
-    def is_current(self):
-        return self.feed_version == self.system.feed_version or (self.block is not None and self.block.is_current)
+    def is_available(self):
+        return self.block is not None
     
     @property
     def block(self):

--- a/models/block_history.py
+++ b/models/block_history.py
@@ -30,7 +30,7 @@ class BlockHistory:
     
     @property
     def is_current(self):
-        return self.feed_version == self.system.feed_version or (self.block is not None and self.block.service.is_current)
+        return self.feed_version == self.system.feed_version or (self.block is not None and self.block.is_current)
     
     @property
     def block(self):

--- a/models/bus_history.py
+++ b/models/bus_history.py
@@ -22,8 +22,8 @@ class BusHistory:
         return get_system(self.system_id)
     
     @property
-    def is_current(self):
-        return self.feed_version == self.system.feed_version or (self.block is not None and self.block.is_current)
+    def is_available(self):
+        return self.block is not None
     
     @property
     def block(self):

--- a/models/bus_history.py
+++ b/models/bus_history.py
@@ -23,7 +23,7 @@ class BusHistory:
     
     @property
     def is_current(self):
-        return self.feed_version == self.system.feed_version or (self.block is not None and self.block.service.is_current)
+        return self.feed_version == self.system.feed_version or (self.block is not None and self.block.is_current)
     
     @property
     def block(self):

--- a/templates/block.tpl
+++ b/templates/block.tpl
@@ -6,7 +6,12 @@
 <div class="sidebar">
   <div class="info-box">
     <div class="info-box-section">
-      % include('components/service_indicator', service=block.service)
+      % services = block.services
+      % if len(services) == 1:
+        % include('components/service_indicator', service=services[0])
+      % else:
+        % include('components/services_indicator', services=services)
+      % end
     </div>
     <div class="info-box-section">
       <div class="info-box-name">Start time</div>

--- a/templates/blocks.tpl
+++ b/templates/blocks.tpl
@@ -11,7 +11,7 @@
   % include('components/systems')
 % else:
   % blocks = system.all_blocks()
-  % services = sorted({ b.service for b in blocks if b.service.is_current })
+  % services = sorted({ s for b in blocks for s in b.services if s.is_current })
 
   <div class="list-container">
     <div class="list-navigation">
@@ -36,7 +36,7 @@
             </tr>
           </thead>
           <tbody>
-            % service_blocks = [block for block in blocks if block.service == service]
+            % service_blocks = [block for block in blocks if service in block.services]
             % for block in service_blocks:
               <tr>
                 <td><a href="{{ get_url(block.system, f'blocks/{block.id}') }}">{{ block.id }}</a></td>

--- a/templates/bus.tpl
+++ b/templates/bus.tpl
@@ -124,7 +124,7 @@
             <td class="mobile-only no-wrap">{{ format_date_mobile(block_history.date) }}</td>
             <td>{{ block_history.system }}</td>
             <td>
-              % if block_history.is_current:
+              % if block_history.is_available:
                 % block = block_history.block
                 <a href="{{ get_url(block.system, f'blocks/{block.id}') }}">{{ block.id }}</a>
               % else:

--- a/templates/history.tpl
+++ b/templates/history.tpl
@@ -57,7 +57,7 @@
               <td class="desktop-only">{{ history.system }}</td>
             % end
             <td>
-              % if history.is_current:
+              % if history.is_available:
                 % block = history.block
                 <a href="{{ get_url(block.system, f'blocks/{block.id}') }}">{{ block.id }}</a>
               % else:


### PR DESCRIPTION
Blocks have typically always been associated with a single service; however, recent GTFS changes with Victoria have indicated that the same block ID may be reused with multiple services if the data is changed in the middle of the sheet. Therefore, it makes more sense to add in assumptions that a block can have multiple associated services, but continue to display only the current service when possible.