### PR TITLE
Add duration to block, blocks, and trip views

### DIFF
--- a/formatting.py
+++ b/formatting.py
@@ -30,3 +30,14 @@ def format_time(time_string):
 
 def get_minutes(hours, minutes):
     return ((hours * 60) + minutes) % 1440 # For times past midnight
+
+'''
+Returns the time as a string in HH:mm from two times, also
+strings in HH:mm format.
+'''
+def duration_between_timestrs(start_time, end_time):
+    end_min = int(end_time[0:2]) * 60 + int(end_time[3:5])
+    start_min = int(start_time[0:2]) * 60 + int(start_time[3:5])
+    diff = abs(end_min - start_min)
+    return "{0:02d}:{1:02d}".format(diff // 60, diff % 60)
+

--- a/models/block.py
+++ b/models/block.py
@@ -1,4 +1,6 @@
 
+import formatting
+
 class Block:
     def __init__(self, system, block_id):
         self.system = system
@@ -51,8 +53,7 @@ class Block:
 
     @property
     def duration(self):
-    	  import formatting as fmt
-    	  return fmt.duration_between_timestrs(self.start_time, self.end_time)
+    	  return formatting.duration_between_timestrs(self.start_time, self.end_time)
     
     def add_trip(self, trip):
         self.trips.append(trip)

--- a/models/block.py
+++ b/models/block.py
@@ -48,6 +48,11 @@ class Block:
     @property
     def end_time(self):
         return self.available_trips[-1].end_time
+
+    @property
+    def duration(self):
+    		import formatting as fmt
+    		return fmt.duration_between_timestrs(self.start_time, self.end_time)
     
     def add_trip(self, trip):
         self.trips.append(trip)

--- a/models/block.py
+++ b/models/block.py
@@ -51,8 +51,8 @@ class Block:
 
     @property
     def duration(self):
-    		import formatting as fmt
-    		return fmt.duration_between_timestrs(self.start_time, self.end_time)
+    	  import formatting as fmt
+    	  return fmt.duration_between_timestrs(self.start_time, self.end_time)
     
     def add_trip(self, trip):
         self.trips.append(trip)

--- a/models/trip.py
+++ b/models/trip.py
@@ -57,8 +57,8 @@ class Trip:
 
     @property
     def duration(self):
-    		import formatting as fmt
-    		return fmt.duration_between_timestrs(self.start_time, self.end_time)
+        import formatting as fmt
+        return fmt.duration_between_timestrs(self.start_time, self.end_time)
     
     @property
     def points(self):

--- a/models/trip.py
+++ b/models/trip.py
@@ -54,6 +54,11 @@ class Trip:
     @property
     def end_time(self):
         return self.last_stop.time
+
+    @property
+    def duration(self):
+    		import formatting as fmt
+    		return fmt.duration_between_timestrs(self.start_time, self.end_time)
     
     @property
     def points(self):

--- a/models/trip.py
+++ b/models/trip.py
@@ -57,8 +57,7 @@ class Trip:
 
     @property
     def duration(self):
-        import formatting as fmt
-        return fmt.duration_between_timestrs(self.start_time, self.end_time)
+        return formatting.duration_between_timestrs(self.start_time, self.end_time)
     
     @property
     def points(self):

--- a/views/pages/block.tpl
+++ b/views/pages/block.tpl
@@ -25,6 +25,10 @@
             <div class="value">{{ block.end_time }}</div>
         </div>
         <div class="section">
+            <div class="name">Duration</div>
+            <div class="value">{{ block.duration }}</div>
+        </div>
+        <div class="section">
             <div class="name">Number of trips</div>
             <div class="value">{{ len(block.available_trips) }}</div>
         </div>
@@ -48,6 +52,7 @@
                 <th class="non-mobile">Start Time</th>
                 <th class="mobile-only">Start</th>
                 <th class="desktop-only">End Time</th>
+                <th class="desktop-only">Duration</th>
                 <th class=>Headsign</th>
                 <th class="desktop-only">Direction</th>
                 <th>Trip</th>
@@ -58,6 +63,7 @@
                 <tr>
                     <td>{{ trip.start_time }}</td>
                     <td class="desktop-only">{{ trip.end_time }}</td>
+                    <td class="desktop-only">{{ trip.duration }}</td>
                     <td>
                         {{ trip }}
                         <span class="mobile-only smaller-font">

--- a/views/pages/blocks.tpl
+++ b/views/pages/blocks.tpl
@@ -36,6 +36,7 @@
                             <th>Routes</th>
                             <th class="desktop-only">Start Time</th>
                             <th class="desktop-only">End Time</th>
+                            <th class="desktop-only">Duration</th>
                             <th class="non-desktop">Time</th>
                         </tr>
                     </thead>
@@ -47,6 +48,7 @@
                                 <td>{{ block.routes_string }}</td>
                                 <td class="desktop-only">{{ block.start_time }}</td>
                                 <td class="desktop-only">{{ block.end_time }}</td>
+                                <td class="desktop-only">{{ block.duration }}</td>
                                 <td class="non-desktop">{{ block.start_time }} - {{ block.end_time }}</td>
                             </tr>
                         % end

--- a/views/pages/trip.tpl
+++ b/views/pages/trip.tpl
@@ -23,6 +23,10 @@
             <div class="value">{{ trip.end_time }}</div>
         </div>
         <div class="section">
+            <div class="name">Duration</div>
+            <div class="value">{{ trip.duration }}</div>
+        </div>
+        <div class="section">
             <div class="name">Number of stops</div>
             <div class="value">{{ len(trip.stop_times) }}</div>
         </div>


### PR DESCRIPTION
## Description
This pull request adds a Duration field to the Block, Blocks, and Trip views. This makes it similar to [sorrybusfull.com's](https://sorrybusfull.com/) block views with its Duration columns. Where possible, the same element style was used as the "end time" field, in regards to mobile/non-desktop views.

Disclaimer: I do not use Python often so I apologize if there's weirdness. Specifically, `formatting.py`'s new function looks *really* janky but it seems to work.

## Screenshots
Blocks:
![image](https://user-images.githubusercontent.com/6299069/134286335-350798f7-9654-468d-9a61-d77b2bf3d6e9.png)

Block:
![image](https://user-images.githubusercontent.com/6299069/134286364-70a19526-17a7-452e-aa94-86701299910f.png)

Trip:
![image](https://user-images.githubusercontent.com/6299069/134286388-d9bfc0b6-da7b-4d32-a5d6-7a2b6d22279c.png)

Mobile Blocks view still looks the same:
![image](https://user-images.githubusercontent.com/6299069/134286424-baa128a4-6c64-42a8-98b9-da835579248e.png)

Mobile Block view will only have duration in the summary table:
![image](https://user-images.githubusercontent.com/6299069/134286451-c3057f12-8861-4b24-94f6-95bbd61de4ee.png)

Mobile Trip view only has duration in the summary table (effectively same as desktop):
![image](https://user-images.githubusercontent.com/6299069/134286520-653cbfda-9a27-4659-ad51-30f399830cf8.png)
