### PR TITLE
Admin page

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Requires roughly Python 3.7 or higher, and pip.
 
 Uses the Bottle framework for web stuff and templates, and maps are done with MapBox.
 
-To run the project, create a file in the home directory called `server.conf`, with the following sample content:
+To run the project, start by creating a file in the home directory called `server.conf`, with the following sample content:
 
 ```
 [global]
@@ -74,6 +74,14 @@ If you plan on running multiple instances of BCTracker, you can set a unique cro
 
 ```
 cron_id: 'some-unique-id'
+```
+
+A secret key can also be configured to access the `/admin` page.
+When configured, you must go to `/admin/<key>` in order to access server management tools.
+To enable this, add the following to `server.conf`:
+
+```
+admin_key: 'some-admin-key'
 ```
 
 Once you've done that, run `setup.sh` to install packages and create directories, and then run `start.py` to load up the server.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ When configured, you must go to `/admin/<key>` in order to access server managem
 To enable this, add the following to `server.conf`:
 
 ```
-admin_key: 'some-admin-key'
+admin_key: '<key>'
 ```
 
 Once you've done that, run `setup.sh` to install packages and create directories, and then run `start.py` to load up the server.

--- a/cron.py
+++ b/cron.py
@@ -16,10 +16,13 @@ PID = os.getpid()
 CWD = os.path.dirname(__file__)
 EXC = sys.executable
 
-def start(cron_id):
-    '''Removes any old cron jobs and creates new jobs'''
+def setup():
+    '''Adds signal handlers'''
     signal.signal(signal.SIGUSR1, handle_gtfs)
     signal.signal(signal.SIGUSR2, handle_realtime)
+
+def start(cron_id):
+    '''Removes any old cron jobs and creates new jobs'''
     with CronTab(user=True) as cron:
         cron.remove_all(comment=cron_id)
         

--- a/server.py
+++ b/server.py
@@ -586,7 +586,7 @@ def admin_page(key=None, system_id=None):
         else:
             path = f'admin/{key}'
         return page('admin', system_id, path=path, key=key)
-    return 'Access denied'
+    return page('home', system_id)
 
 # =============================================================
 # JSON (API endpoints)

--- a/server.py
+++ b/server.py
@@ -30,10 +30,11 @@ no_system_domain = 'https://bctracker.ca/{0}'
 system_domain = 'https://{0}.bctracker.ca/{1}'
 system_domain_path = 'https://bctracker.ca/{0}/{1}'
 cookie_domain = None
+admin_key = None
 
 def start(args):
     '''Loads all required data and launches the server'''
-    global cron_id, mapbox_api_key, no_system_domain, system_domain, system_domain_path, cookie_domain
+    global cron_id, mapbox_api_key, no_system_domain, system_domain, system_domain_path, cookie_domain, admin_key
     
     database.connect()
     
@@ -60,6 +61,9 @@ def start(args):
             system.validation_errors += 1
     realtime.update_records()
     
+    cron.setup()
+    cron.start(cron_id)
+    
     cp.config.update('server.conf')
     cron_id = cp.config.get('cron_id', 'bctracker-muncher')
     mapbox_api_key = cp.config['mapbox_api_key']
@@ -67,13 +71,13 @@ def start(args):
     system_domain = cp.config['system_domain']
     system_domain_path = cp.config['system_domain_path']
     cookie_domain = cp.config.get('cookie_domain')
+    admin_key = cp.config.get('admin_key')
     
     handler = TimedRotatingFileHandler(filename='logs/access_log.log', when='d', interval=7)
     log = WSGILogger(app, [handler], ApacheFormatter())
     
     cp.tree.graft(log, '/')
     cp.server.start()
-    cron.start(cron_id)
 
 def stop():
     '''Terminates the server'''
@@ -96,6 +100,7 @@ def page(name, system_id, path='', **kwargs):
         version=VERSION,
         path=path,
         systems=[s for s in helpers.system.find_all() if s.enabled and s.visible],
+        admin_systems=helpers.system.find_all(),
         system_id=system_id,
         system=helpers.system.find(system_id),
         get_url=get_url,
@@ -564,6 +569,25 @@ def themes_page(system_id=None):
 def systems_page(system_id=None):
     return page('systems', system_id, path=request.query.get('path', ''))
 
+@app.get([
+    '/admin',
+    '/admin/',
+    '/admin/<key>',
+    '/admin/<key>/',
+    '/<system_id>/admin',
+    '/<system_id>/admin/',
+    '/<system_id>/admin/<key>',
+    '/<system_id>/admin/<key>/'
+])
+def admin_page(key=None, system_id=None):
+    if admin_key is None or key == admin_key:
+        if key is None:
+            path = 'admin'
+        else:
+            path = f'admin/{key}'
+        return page('admin', system_id, path=path, key=key)
+    return 'Access denied'
+
 # =============================================================
 # JSON (API endpoints)
 # =============================================================
@@ -615,3 +639,81 @@ def api_search(system_id=None):
         'results': [m.get_json(system, get_url) for m in matches[0:10]],
         'count': len(matches)
     }
+
+@app.post([
+    '/api/admin/restart-cron',
+    '/api/admin/restart-cron/',
+    '/api/admin/<key>/restart-cron',
+    '/api/admin/<key>/restart-cron/',
+    '/<system_id>/api/admin/restart-cron',
+    '/<system_id>/api/admin/restart-cron/',
+    '/<system_id>/api/admin/<key>/restart-cron',
+    '/<system_id>/api/admin/<key>/restart-cron/'
+])
+def api_admin_restart_cron(key=None, system_id=None):
+    if admin_key is None or key == admin_key:
+        cron.stop(cron_id)
+        cron.start(cron_id)
+        return 'Success'
+    return 'Access denied'
+
+@app.post([
+    '/api/admin/backup-database',
+    '/api/admin/backup-database/',
+    '/api/admin/<key>/backup-database',
+    '/api/admin/<key>/backup-database/',
+    '/<system_id>/api/admin/backup-database',
+    '/<system_id>/api/admin/backup-database/',
+    '/<system_id>/api/admin/<key>/backup-database',
+    '/<system_id>/api/admin/<key>/backup-database/'
+])
+def api_admin_backup_database(key=None, system_id=None):
+    if admin_key is None or key == admin_key:
+        database.backup()
+        return 'Success'
+    return 'Access denied'
+
+@app.post([
+    '/api/admin/reload-gtfs/<reload_system_id>',
+    '/api/admin/reload-gtfs/<reload_system_id>/',
+    '/api/admin/<key>/reload-gtfs/<reload_system_id>',
+    '/api/admin/<key>/reload-gtfs/<reload_system_id>/',
+    '/<system_id>/api/admin/reload-gtfs/<reload_system_id>',
+    '/<system_id>/api/admin/reload-gtfs/<reload_system_id>/',
+    '/<system_id>/api/admin/<key>/reload-gtfs/<reload_system_id>',
+    '/<system_id>/api/admin/<key>/reload-gtfs/<reload_system_id>/'
+])
+def api_admin_reload_gtfs(reload_system_id, key=None, system_id=None):
+    if admin_key is None or key == admin_key:
+        system = helpers.system.find(reload_system_id)
+        if system is None:
+            return 'Invalid system'
+        gtfs.update(system)
+        realtime.update(system)
+        if not realtime.validate(system):
+            system.validation_errors += 1
+        realtime.update_records()
+        return 'Success'
+    return 'Access denied'
+
+@app.post([
+    '/api/admin/reload-realtime/<reload_system_id>',
+    '/api/admin/reload-realtime/<reload_system_id>/',
+    '/api/admin/<key>/reload-realtime/<reload_system_id>',
+    '/api/admin/<key>/reload-realtime/<reload_system_id>/',
+    '/<system_id>/api/admin/reload-realtime/<reload_system_id>',
+    '/<system_id>/api/admin/reload-realtime/<reload_system_id>/',
+    '/<system_id>/api/admin/<key>/reload-realtime/<reload_system_id>',
+    '/<system_id>/api/admin/<key>/reload-realtime/<reload_system_id>/'
+])
+def api_admin_reload_gtfs(reload_system_id, key=None, system_id=None):
+    if admin_key is None or key == admin_key:
+        system = helpers.system.find(reload_system_id)
+        if system is None:
+            return 'Invalid system'
+        realtime.update(system)
+        if not realtime.validate(system):
+            system.validation_errors += 1
+        realtime.update_records()
+        return 'Success'
+    return 'Access denied'

--- a/style/main.css
+++ b/style/main.css
@@ -510,6 +510,10 @@ table.striped tr.section td {
     vertical-align: middle;
 }
 
+.negative {
+    font-weight: bold;
+}
+
 .news-post {
     margin-bottom: 20px;
     border-width: 1px;
@@ -567,6 +571,10 @@ table.striped tr.section td {
 
 .page-header .subtitle {
     font-weight: normal;
+}
+
+.positive {
+    font-weight: bold;
 }
 
 .route-number {

--- a/style/themes/bchydro.css
+++ b/style/themes/bchydro.css
@@ -340,6 +340,10 @@ table.striped tr:nth-child(2n-1) {
     display: none;
 }
 
+.negative {
+    color: #FF0000;
+}
+
 .news-post {
     background-color: #D8D8D8;
     border-color: #666666;
@@ -353,6 +357,10 @@ table.striped tr:nth-child(2n-1) {
 
 .order-indicator .content .separator {
     color: #666666;
+}
+
+.positive {
+    color: #1A671A;
 }
 
 .route-number {

--- a/style/themes/classic.css
+++ b/style/themes/classic.css
@@ -340,6 +340,10 @@ table.striped tr:nth-child(2n-1) {
     display: none;
 }
 
+.negative {
+    color: #FF0000;
+}
+
 .news-post {
     background-color: #E6E6E6;
     border-color: #666666;
@@ -353,6 +357,10 @@ table.striped tr:nth-child(2n-1) {
 
 .order-indicator .content .separator {
     color: #666666;
+}
+
+.positive {
+    color: #1A671A;
 }
 
 .route-number {

--- a/style/themes/dark.css
+++ b/style/themes/dark.css
@@ -338,6 +338,10 @@ table.striped tr:nth-child(2n-1) {
     display: none;
 }
 
+.negative {
+    color: #FF0000;
+}
+
 .news-post {
     background-color: #393939;
     border-color: #565656;
@@ -350,6 +354,10 @@ table.striped tr:nth-child(2n-1) {
 
 .order-indicator .content .separator {
     color: #565656;
+}
+
+.positive {
+    color: #428342;
 }
 
 .route-number {

--- a/style/themes/light.css
+++ b/style/themes/light.css
@@ -340,6 +340,10 @@ table.striped tr:nth-child(2n-1) {
     display: none;
 }
 
+.negative {
+    color: #FF0000;
+}
+
 .news-post {
     background-color: #E6E6E6;
     border-color: #989898;
@@ -353,6 +357,10 @@ table.striped tr:nth-child(2n-1) {
 
 .order-indicator .content .separator {
     color: #989898;
+}
+
+.positive {
+    color: #1A671A;
 }
 
 .route-number {

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -383,6 +383,10 @@ table.striped tr {
     display: none;
 }
 
+.negative {
+    color: #FF0000;
+}
+
 .news-post {
     background: #FFF9DF;
     border-color: #F7C942;
@@ -399,6 +403,10 @@ table.striped tr {
 
 .page-header.map-page .tab-button {
     border-bottom-color: #000000;
+}
+
+.positive {
+    color: #1A671A;
 }
 
 .route-number {

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -340,6 +340,10 @@ table.striped tr:nth-child(2n-1) {
     display: none;
 }
 
+.negative {
+    color: #FF0000;
+}
+
 .news-post {
     background-color: #E6E6E6;
     border-color: #666666;
@@ -353,6 +357,10 @@ table.striped tr:nth-child(2n-1) {
 
 .order-indicator .content .separator {
     color: #666666;
+}
+
+.positive {
+    color: #1A671A;
 }
 
 .route-number {

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -14,6 +14,10 @@
         
         <meta content="width=device-width, initial-scale=1" name="viewport" />
         
+        % if get('disable_indexing', False):
+            <meta name="robots" content="noindex">
+        % end
+        
         % if system is None:
             <meta property="og:title" content="BCTracker | {{ title }}">
             <meta property="og:description" content="Transit schedules and bus tracking for BC, Canada" />

--- a/views/pages/admin.tpl
+++ b/views/pages/admin.tpl
@@ -1,0 +1,151 @@
+
+% rebase('base', title='Administration')
+
+<div class="page-header">
+    <h1 class="title">Administration</h1>
+    <h2 class="subtitle">Tools for server and system management</h2>
+    <hr />
+</div>
+
+<div class="container no-inline">
+    <div class="section">
+        <h2 class="title">Server Management</h2>
+        <div class="button-container">
+            <div class="button" onclick="restartCron()">Restart Cron</div>
+            <div class="button" onclick="backupDatabase()">Backup Database</div>
+        </div>
+    </div>
+    <div class="section">
+        <h2 class="title">System Management</h2>
+        <div class="container no-inline">
+            % if system is None:
+                % for admin_system in admin_systems:
+                    <div class="section">
+                        <h3 class="title">{{ admin_system }}</h3>
+                        <div class="subtitle">
+                            <div>
+                                Enabled:
+                                % if admin_system.enabled:
+                                    <span class="positive">Yes</span>
+                                % else:
+                                    <span class="negative">No</span>
+                                % end
+                            </div>
+                            <div>
+                                Visible:
+                                % if admin_system.visible:
+                                    <span class="positive">Yes</span>
+                                % else:
+                                    <span class="negative">No</span>
+                                % end
+                            </div>
+                        </div>
+                        <div class="button-container">
+                            % if admin_system.gtfs_enabled:
+                                <div class="button" onclick="reloadGTFS('{{ admin_system.id }}')">Reload GTFS</div>
+                            % end
+                            % if admin_system.realtime_enabled:
+                                <div class="button" onclick="reloadRealtime('{{ admin_system.id }}')">Reload Realtime</div>
+                            % end
+                        </div>
+                    </div>
+                % end
+            % else:
+                <div class="section">
+                    <h3 class="title">{{ system }}</h3>
+                    <div class="subtitle">
+                        <div>
+                            Enabled:
+                            % if system.enabled:
+                                <span class="positive">Yes</span>
+                            % else:
+                                <span class="negative">No</span>
+                            % end
+                        </div>
+                        <div>
+                            Visible:
+                            % if system.visible:
+                                <span class="positive">Yes</span>
+                            % else:
+                                <span class="negative">No</span>
+                            % end
+                        </div>
+                    </div>
+                    <div class="button-container">
+                        % if system.gtfs_enabled:
+                            <div class="button">Reload GTFS</div>
+                        % end
+                        % if system.realtime_enabled:
+                            <div class="button">Reload Realtime</div>
+                        % end
+                    </div>
+                </div>
+            % end
+        </div>
+    </div>
+</div>
+
+<script>
+    let adminKey
+    let systemID
+    
+    function restartCron() {
+        const request = new XMLHttpRequest();
+        if (adminKey == null) {
+            request.open("POST", getUrl(systemID, "api/admin/restart-cron"), true);
+        } else {
+            request.open("POST", getUrl(systemID, "api/admin/" + adminKey + "/restart-cron"), true);
+        }
+        request.send();
+    }
+    
+    function backupDatabase() {
+        const request = new XMLHttpRequest();
+        if (adminKey == null) {
+            request.open("POST", getUrl(systemID, "api/admin/backup-database"), true);
+        } else {
+            request.open("POST", getUrl(systemID, "api/admin/" + adminKey + "/backup-database"), true);
+        }
+        request.send();
+    }
+    
+    function reloadGTFS(reloadSystemID) {
+        const request = new XMLHttpRequest();
+        if (adminKey == null) {
+            request.open("POST", getUrl(systemID, "api/admin/reload-gtfs/" + reloadSystemID), true);
+        } else {
+            request.open("POST", getUrl(systemID, "api/admin/" + adminKey + "/reload-gtfs/" + reloadSystemID), true);
+        }
+        request.send();
+    }
+    
+    function reloadRealtime(reloadSystemID) {
+        const request = new XMLHttpRequest();
+        if (adminKey == null) {
+            request.open("POST", getUrl(systemID, "api/admin/reload-realtime/" + reloadSystemID), true);
+        } else {
+            request.open("POST", getUrl(systemID, "api/admin/" + adminKey + "/reload-realtime/" + reloadSystemID), true);
+        }
+        request.send();
+    }
+</script>
+
+% if key is None:
+    <script>
+        adminKey = null;
+    </script>
+% else:
+    <script>
+        adminKey = "{{ key }}";
+    </script>
+% end
+
+% if system is None:
+    <script>
+        systemID = null;
+    </script>
+% else:
+    <script>
+        systemID = "{{ system.id }}"
+    </script>
+% end

--- a/views/pages/admin.tpl
+++ b/views/pages/admin.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Administration')
+% rebase('base', title='Administration', disable_indexing=True)
 
 <div class="page-header">
     <h1 class="title">Administration</h1>
@@ -73,10 +73,10 @@
                     </div>
                     <div class="button-container">
                         % if system.gtfs_enabled:
-                            <div class="button">Reload GTFS</div>
+                            <div class="button" onclick="reloadGTFS('{{ system.id }}')">Reload GTFS</div>
                         % end
                         % if system.realtime_enabled:
-                            <div class="button">Reload Realtime</div>
+                            <div class="button" onclick="reloadRealtime('{{ system.id }}')">Reload Realtime</div>
                         % end
                     </div>
                 </div>


### PR DESCRIPTION
This adds a new page for performing administrative actions:
- Restarting cron
- Backing up the database
- Reloading system GTFS
- Reloading system realtime

By default, this page is accessible to anyone by manually navigating to `/admin`. For extra security, a secret key can be added to the `server.conf` file:
```
admin_key: '<key>'
```
Once this is done, the admin page can only be accessed by manually navigating to `/admin/<key>`. Since the key is not included in the repo or available anywhere on the site, the page can only be accessed by people who know what it has been set to. The key is also required for the relevant API calls.