### PR TITLE
Fix scheduled/recorded today bus query order

### DIFF
--- a/helpers/record.py
+++ b/helpers/record.py
@@ -95,7 +95,8 @@ def find_recorded_today(system, trips):
             'record.system_id': system.id,
             'record.date': today.format_db(),
             'trip_record.trip_id': [t.id for t in trips]
-        })
+        },
+        order_by='record.last_seen ASC')
     return {row['trip_id']: Bus(row['bus_number']) for row in rows}
 
 def find_scheduled_today(system, trips):
@@ -105,6 +106,7 @@ def find_scheduled_today(system, trips):
         columns={
             'record.bus_number': 'bus_number',
             'record.block_id': 'block_id',
+            'record.last_seen': 'last_seen',
             'ROW_NUMBER() OVER(PARTITION BY record.block_id ORDER BY record.record_id DESC)': 'row_number'
         },
         filters={
@@ -123,5 +125,6 @@ def find_scheduled_today(system, trips):
         filters={
             'numbered_record.row_number': 1
         },
+        order_by='numbered_record.last_seen ASC',
         custom_args=args)
     return {row['block_id']: Bus(row['bus_number']) for row in rows}


### PR DESCRIPTION
If multiple buses log into the same trip/block, the Route and Stop overview pages may incorrectly show what bus did the trip and what buses are scheduled for trips on the rest of the block. The latter case is more likely, as multiple buses may swap onto a block throughout the day without being logged into the same trip, and is also the easier option to fix - ordering the buses by the time they were last seen ensures that the most recent bus to log into the block will be shown as scheduled. The case where multiple buses logged into a trip is a bit trickier, as we don't really have a way to confirm which bus actually did the trip - or in some cases, it's possible that *both* did and we have no way to properly associate each bus with a subset of stops that it did. For this scenario I have decided to just mimic the logic for the scheduled buses, and show whichever bus was doing the block more recently. It may not be correct in all scenarios but it will be more consistent. There is also no way to go back and see history for full routes and stops, only blocks and trips, so the accuracy is not important for more than the current date.