### PR TITLE
Page header and rebase improvements

### DIFF
--- a/style/devices/desktop.css
+++ b/style/devices/desktop.css
@@ -14,6 +14,11 @@ body {
     grid-template-rows: auto 1fr;
 }
 
+body.full-map .page-header {
+    display: inline-block;
+    border-bottom-width: 0px;
+}
+
 form {
     margin-bottom: 10px;
 }
@@ -255,10 +260,6 @@ table.striped th {
     display: none !important;
 }
 
-.page-header.map-page {
-    display: inline-block;
-}
-
 .sidebar table {
     width: 100%;
 }
@@ -267,8 +268,8 @@ table.striped th {
     font-size: 11pt;
 }
 
-.tab-button-bar {
-    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+.tab-button {
+    min-width: 100px;
 }
 
 .tablet-only {

--- a/style/devices/desktop.css
+++ b/style/devices/desktop.css
@@ -16,7 +16,6 @@ body {
 
 body.full-map .page-header {
     display: inline-block;
-    border-bottom-width: 0px;
 }
 
 form {

--- a/style/devices/desktop.css
+++ b/style/devices/desktop.css
@@ -268,12 +268,7 @@ table.striped th {
 }
 
 .tab-button-bar {
-    display: flex;
-    flex-direction: row;
-}
-
-.tab-button {
-    min-width: 100px;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
 }
 
 .tablet-only {

--- a/style/devices/mobile.css
+++ b/style/devices/mobile.css
@@ -225,6 +225,11 @@ table {
     font-size: 11pt;
 }
 
+.tab-button-bar {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+}
+
 .tablet-only {
     display: none !important;
 }

--- a/style/devices/mobile.css
+++ b/style/devices/mobile.css
@@ -225,17 +225,6 @@ table {
     font-size: 11pt;
 }
 
-.tab-button-bar {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    margin-bottom: -1px;
-}
-
-.tab-button {
-    flex: 1;
-}
-
 .tablet-only {
     display: none !important;
 }

--- a/style/devices/tablet.css
+++ b/style/devices/tablet.css
@@ -218,10 +218,8 @@ table {
 }
 
 .tab-button-bar {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    margin-bottom: -1px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
 }
 
 .tab-button {

--- a/style/main.css
+++ b/style/main.css
@@ -7,6 +7,11 @@ body {
     margin: 0px;
 }
 
+body.full-map .page-header {
+    position: relative;
+    z-index: 20;
+}
+
 input {
     -webkit-appearance: none;
 }
@@ -33,13 +38,6 @@ form .input-container {
 
 form .input-container input[type="text"] {
     flex: 1;
-}
-
-hr {
-    margin: 0px;
-    border-width: 0px;
-    border-top-width: 2px;
-    border-top-style: solid;
 }
 
 h1, h2, h3, h4 {
@@ -717,15 +715,8 @@ table.striped tr.section td {
 
 .page-header {
     margin-bottom: 20px;
-}
-
-.page-header.map-page {
-    position: relative;
-    z-index: 20;
-}
-
-.page-header.map-page .tab-button {
     border-bottom-width: 2px;
+    border-bottom-style: solid;
 }
 
 .page-header .subtitle {
@@ -834,18 +825,17 @@ table.striped tr.section td {
 }
 
 .tab-button-bar {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    display: inline-flex;
+    flex-direction: row;
     box-sizing: border-box;
-    margin-left: 1px;
+    margin-bottom: -1px;
+    gap: 1px;
+    border-width: 1px;
+    border-style: solid;
 }
 
 .tab-button {
-    border-width: 1px;
-    border-style: solid;
     padding: 10px;
-    margin-bottom: -1px;
-    margin-left: -1px;
     cursor: default;
     font-size: 13pt;
     font-weight: bold;

--- a/style/main.css
+++ b/style/main.css
@@ -10,6 +10,7 @@ body {
 body.full-map .page-header {
     position: relative;
     z-index: 20;
+    border-bottom-width: 0px;
 }
 
 input {

--- a/style/main.css
+++ b/style/main.css
@@ -833,12 +833,19 @@ table.striped tr.section td {
     text-align: center;
 }
 
+.tab-button-bar {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    box-sizing: border-box;
+    margin-left: 1px;
+}
+
 .tab-button {
     border-width: 1px;
     border-style: solid;
-    border-bottom-width: 0px;
     padding: 10px;
-    margin: 0px;
+    margin-bottom: -1px;
+    margin-left: -1px;
     cursor: default;
     font-size: 13pt;
     font-weight: bold;
@@ -846,10 +853,6 @@ table.striped tr.section td {
     font-family: Helvetica, sans-serif;
     text-align: center;
     text-decoration: none !important;
-}
-
-.tab-button ~ .tab-button {
-    border-left-width: 0px;
 }
 
 .tab-button:hover {

--- a/style/themes/bchydro.css
+++ b/style/themes/bchydro.css
@@ -35,10 +35,6 @@ form input[type="text"]:focus {
     border-color: #347800;
 }
 
-hr {
-    border-top-color: #666666;
-}
-
 table.striped {
     border-color: #666666;
 }
@@ -429,6 +425,10 @@ table.striped tr:nth-child(2n-1) {
     color: #666666;
 }
 
+.page-header {
+    border-bottom-color: #666666;
+}
+
 .positive {
     color: #1A671A;
 }
@@ -474,9 +474,13 @@ table.striped tr:nth-child(2n-1) {
     color: #000000;
 }
 
+.tab-button-bar {
+    background: #666666;
+    border-color: #666666;
+}
+
 .tab-button {
     background-color: #FFFFFF;
-    border-color: #666666;
     color: #026E6E;
 }
 

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -35,10 +35,6 @@ form input[type="text"]:focus {
     border-color: #7A0000;
 }
 
-hr {
-    border-top-color: #69BB65;
-}
-
 table.striped {
     border-color: #69BB65;
 }
@@ -429,6 +425,10 @@ table.striped tr:nth-child(2n-1) {
     color: #69BB65;
 }
 
+.page-header {
+    border-bottom-color: #69BB65;
+}
+
 .positive {
     color: #AB0000;
 }
@@ -474,9 +474,13 @@ table.striped tr:nth-child(2n-1) {
     color: #000000;
 }
 
+.tab-button-bar {
+    background: #69BB65;
+    border-color: #69BB65;
+}
+
 .tab-button {
     background-color: #FFFFFF;
-    border-color: #69BB65;
     color: #D70000;
 }
 

--- a/style/themes/classic.css
+++ b/style/themes/classic.css
@@ -35,10 +35,6 @@ form input[type="text"]:focus {
     border-color: #840000;
 }
 
-hr {
-    border-top-color: #666666;
-}
-
 table.striped {
     border-color: #666666;
 }
@@ -429,6 +425,10 @@ table.striped tr:nth-child(2n-1) {
     color: #666666;
 }
 
+.page-header {
+    border-bottom-color: #666666;
+}
+
 .positive {
     color: #1A671A;
 }
@@ -474,9 +474,13 @@ table.striped tr:nth-child(2n-1) {
     color: #000000;
 }
 
+.tab-button-bar {
+    background: #666666;
+    border-color: #666666;
+}
+
 .tab-button {
     background-color: #FFFFFF;
-    border-color: #666666;
     color: #023496;
 }
 

--- a/style/themes/contrast.css
+++ b/style/themes/contrast.css
@@ -35,10 +35,6 @@ form input[type="text"]:focus {
     border-color: #094409;
 }
 
-hr {
-    border-top-color: #666666;
-}
-
 table.striped {
     border-color: #666666;
 }
@@ -429,6 +425,10 @@ table.striped tr:nth-child(2n-1) {
     color: #666666;
 }
 
+.page-header {
+    border-bottom-color: #666666;
+}
+
 .positive {
     color: #1A671A;
 }
@@ -470,9 +470,13 @@ table.striped tr:nth-child(2n-1) {
     color: #000000;
 }
 
+.tab-button-bar {
+    background: #666666;
+    border-color: #666666;
+}
+
 .tab-button {
     background-color: #FFFFFF;
-    border-color: #666666;
     color: #0040FF;
 }
 

--- a/style/themes/dark.css
+++ b/style/themes/dark.css
@@ -39,10 +39,6 @@ form input[type="text"]:focus {
     border-color: #053305;
 }
 
-hr {
-    border-top-color: #565656;
-}
-
 iframe {
     color-scheme: light;
 }
@@ -434,6 +430,10 @@ table.striped tr:nth-child(2n-1) {
     color: #565656;
 }
 
+.page-header {
+    border-bottom-color: #565656;
+}
+
 .positive {
     color: #428342;
 }
@@ -479,9 +479,13 @@ table.striped tr:nth-child(2n-1) {
     color: #FFFFFF;
 }
 
+.tab-button-bar {
+    background: #565656;
+    border-color: #565656;
+}
+
 .tab-button {
     background-color: #2F2F2F;
-    border-color: #565656;
     color: #5CC3FF;
 }
 

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -35,10 +35,6 @@ form input[type="text"]:focus {
     border-color: #AAAAAA;
 }
 
-hr {
-    border-top-color: #EEEEEE;
-}
-
 table.striped {
     border-color: #FFFFFF;
 }
@@ -423,6 +419,10 @@ table.striped tr {
     color: #888888;
 }
 
+.page-header {
+    border-bottom-color: #EEEEEE;
+}
+
 .positive {
     color: #1A671A;
 }
@@ -468,9 +468,13 @@ table.striped tr {
     color: #000000;
 }
 
+.tab-button-bar {
+    background: #EEEEEE;
+    border-color: #EEEEEE;
+}
+
 .tab-button {
     background-color: #FFFFFF;
-    border-color: #EEEEEE;
     color: #0040FF;
 }
 

--- a/style/themes/light.css
+++ b/style/themes/light.css
@@ -35,10 +35,6 @@ form input[type="text"]:focus {
     border-color: #094409;
 }
 
-hr {
-    border-top-color: #666666;
-}
-
 table.striped {
     border-color: #666666;
 }
@@ -429,6 +425,10 @@ table.striped tr:nth-child(2n-1) {
     color: #666666;
 }
 
+.page-header {
+    border-bottom-color: #666666;
+}
+
 .positive {
     color: #1A671A;
 }
@@ -474,9 +474,13 @@ table.striped tr:nth-child(2n-1) {
     color: #000000;
 }
 
+.tab-button-bar {
+    background: #666666;
+    border-color: #666666;
+}
+
 .tab-button {
     background-color: #FFFFFF;
-    border-color: #666666;
     color: #0040FF;
 }
 

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -25,13 +25,9 @@ form input[type="text"]:focus {
     border-color: #000000;
 }
 
-hr {
-    border-top-color: #000000;
-}
-
 table.striped {
     border-color: #CCCCCC;
-    box-shadow: 0 1px 4px rgb(0 0 0 / 30%);;
+    box-shadow: 0 1px 4px rgb(0 0 0 / 30%);
 }
 
 table.striped tbody tr:hover {
@@ -71,7 +67,8 @@ table.striped tr {
 }
 
 #map.preview {
-    border-color: #000000;
+    border-color: #CCCCCC;
+    box-shadow: 0 1px 4px rgb(0 0 0 / 30%);
 }
 
 #map-toggle {
@@ -108,6 +105,7 @@ table.striped tr {
 
 #navigation-bar .navigation-item {
     color: #FFFFFF;
+    text-shadow: none;
 }
 
 #navigation-bar .navigation-item:hover {
@@ -145,7 +143,8 @@ table.striped tr {
     color: #222222;
     text-shadow: 0 1px 0 #FFFFFF;
     background-image: linear-gradient(#FFFFFF, #F1F1F1);
-    border-color: #000000;
+    border-color: #CCCCCC;
+    box-shadow: 0 1px 4px rgb(0 0 0 / 30%);
 }
 
 #search-desktop {
@@ -295,7 +294,7 @@ table.striped tr {
 #title a {
     background-color: #111111;
     background-image: linear-gradient(#3C3C3C, #111111);
-    text-shadow: 0 -1px 1px #000000;
+    text-shadow: none;
     color: #FFFFFF;
 }
 
@@ -430,7 +429,8 @@ table.striped tr {
     color: #222222;
     text-shadow: 0 1px 0 #FFFFFF;
     background-image: linear-gradient(#FFFFFF, #F1F1F1);
-    border-color: #000000;
+    border-color: #CCCCCC;
+    box-shadow: 0 1px 4px rgb(0 0 0 / 30%);
 }
 
 .info-box .section {
@@ -485,6 +485,7 @@ table.striped tr {
     color: #222222;
     text-shadow: 0 1px 0 #FFFFFF;
     background-image: linear-gradient( #FFFADF,#FFF3A5 );
+    box-shadow: 0 1px 4px rgb(0 0 0 / 30%);
 }
 
 .news-post .header {
@@ -493,7 +494,7 @@ table.striped tr {
     background-image: linear-gradient( #FFFADF,#FFF3A5 );
 }
 
-.page-header.map-page .tab-button {
+.page-header {
     border-bottom-color: #000000;
 }
 
@@ -552,12 +553,19 @@ table.striped tr {
     color: #000000;
 }
 
+.tab-button-bar {
+    background-color: #333333;
+    background-image: linear-gradient(#444444, #2D2D2D);
+    border-width: 0px;
+    margin-bottom: 0px;
+    gap: 0px;
+}
+
 .tab-button {
     background-color: #333333;
     background-image: linear-gradient(#444444, #2D2D2D);
     text-shadow: 0 -1px 1px #000000;
     color: #FFFFFF;
-    border-width: 0px;
 }
 
 .tab-button:hover {

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -35,10 +35,6 @@ form input[type="text"]:focus {
     border-color: #7E3704;
 }
 
-hr {
-    border-top-color: #666666;
-}
-
 table.striped {
     border-color: #666666;
 }
@@ -429,6 +425,10 @@ table.striped tr:nth-child(2n-1) {
     color: #666666;
 }
 
+.page-header {
+    border-bottom-color: #666666;
+}
+
 .positive {
     color: #1A671A;
 }
@@ -474,9 +474,13 @@ table.striped tr:nth-child(2n-1) {
     color: #000000;
 }
 
+.tab-button-bar {
+    background: #666666;
+    border-color: #666666;
+}
+
 .tab-button {
     background-color: #FFFFFF;
-    border-color: #666666;
     color: #7E3704;
 }
 

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -60,7 +60,7 @@
             </script>
         % end
         
-        % if get('include_maps', False):
+        % if include_maps:
             <script src="https://api.mapbox.com/mapbox-gl-js/v1.11.1/mapbox-gl.js"></script>
             <link href="https://api.mapbox.com/mapbox-gl-js/v1.11.1/mapbox-gl.css" rel="stylesheet" />
             
@@ -69,7 +69,7 @@
             </script>
         % end
         
-        % if (system is None or system.realtime_enabled) and get('enable_refresh', True):
+        % if enable_refresh and (system is None or system.realtime_enabled):
             <script>
                 const date = new Date();
                 const timeToNextUpdate = 60 - date.getSeconds();
@@ -117,7 +117,7 @@
         </script>
     </head>
     
-    <body class="{{ 'full-map' if get('full_map', False) else '' }}">
+    <body class="{{ 'full-map' if full_map else '' }}">
         <div id="title">
             <a href="{{ get_url(system) }}">
                 <img class="white" src="/img/white/bctracker.png" />

--- a/views/pages/about.tpl
+++ b/views/pages/about.tpl
@@ -3,7 +3,6 @@
 
 <div class="page-header">
     <h1 class="title">About</h1>
-    <hr />
 </div>
 
 <div class="flex-container">

--- a/views/pages/about.tpl
+++ b/views/pages/about.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='About', enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">About</h1>

--- a/views/pages/admin.tpl
+++ b/views/pages/admin.tpl
@@ -4,7 +4,6 @@
 <div class="page-header">
     <h1 class="title">Administration</h1>
     <h2 class="subtitle">Tools for server and system management</h2>
-    <hr />
 </div>
 
 <div class="container">

--- a/views/pages/admin.tpl
+++ b/views/pages/admin.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Administration', disable_indexing=True, enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Administration</h1>

--- a/views/pages/block/history.tpl
+++ b/views/pages/block/history.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title=f'Block {block.id}')
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Block {{ block.id }}</h1>

--- a/views/pages/block/history.tpl
+++ b/views/pages/block/history.tpl
@@ -8,7 +8,6 @@
         <a href="{{ get_url(system, f'blocks/{block.id}/map') }}" class="tab-button">Map</a>
         <span class="tab-button current">History</span>
     </div>
-    <hr />
 </div>
 
 % if system.realtime_enabled:

--- a/views/pages/block/map.tpl
+++ b/views/pages/block/map.tpl
@@ -1,7 +1,7 @@
 
-% rebase('base', title=f'Block {block.id}', include_maps=True, full_map=True)
+% rebase('base')
 
-<div class="page-header map-page">
+<div class="page-header">
     <h1 class="title">Block {{ block.id }}</h1>
     <div class="tab-button-bar">
         <a href="{{ get_url(system, f'blocks/{block.id}') }}" class="tab-button">Overview</a>

--- a/views/pages/block/overview.tpl
+++ b/views/pages/block/overview.tpl
@@ -10,7 +10,6 @@
             <a href="{{ get_url(system, f'blocks/{block.id}/history') }}" class="tab-button">History</a>
         % end
     </div>
-    <hr />
 </div>
 
 % sheets = block.sheets

--- a/views/pages/block/overview.tpl
+++ b/views/pages/block/overview.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title=f'Block {block.id}', include_maps=True)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Block {{ block.id }}</h1>

--- a/views/pages/blocks/date.tpl
+++ b/views/pages/blocks/date.tpl
@@ -1,7 +1,7 @@
 
 % from datetime import timedelta
 
-% rebase('base', title='Blocks', enable_reload=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Blocks</h1>

--- a/views/pages/blocks/date.tpl
+++ b/views/pages/blocks/date.tpl
@@ -5,7 +5,6 @@
 
 <div class="page-header">
     <h1 class="title">Blocks</h1>
-    <hr />
 </div>
 
 % if system is None:

--- a/views/pages/blocks/list.tpl
+++ b/views/pages/blocks/list.tpl
@@ -3,7 +3,6 @@
 
 <div class="page-header">
     <h1 class="title">Blocks</h1>
-    <hr />
 </div>
 
 % if system is None:

--- a/views/pages/blocks/list.tpl
+++ b/views/pages/blocks/list.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Blocks', enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Blocks</h1>

--- a/views/pages/bus/history.tpl
+++ b/views/pages/bus/history.tpl
@@ -17,7 +17,6 @@
         <a href="{{ get_url(system, f'bus/{bus.number}/map') }}" class="tab-button">Map</a>
         <span class="tab-button current">History</span>
     </div>
-    <hr />
 </div>
 
 <div class="flex-container">

--- a/views/pages/bus/history.tpl
+++ b/views/pages/bus/history.tpl
@@ -1,7 +1,7 @@
 
 % from models.model import ModelType
 
-% rebase('base', title=f'Bus {bus}')
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Bus {{ bus }}</h1>

--- a/views/pages/bus/map.tpl
+++ b/views/pages/bus/map.tpl
@@ -1,41 +1,25 @@
 
-% rebase('base', title=f'Bus {bus}', include_maps=True, full_map=True)
+% rebase('base')
+
+<div class="page-header">
+    <h1 class="title">Bus {{ bus }}</h1>
+    <h2 class="subtitle">
+        % if bus.order is None:
+            <span class="lighter-text">Unknown Year/Model</span>
+        % else:
+            {{! bus.order }}
+        % end
+    </h2>
+    <div class="tab-button-bar">
+        <a href="{{ get_url(system, f'bus/{bus.number}') }}" class="tab-button">Overview</a>
+        <span class="tab-button current">Map</span>
+        <a href="{{ get_url(system, f'bus/{bus.number}/history') }}" class="tab-button">History</a>
+    </div>
+</div>
 
 % if position is None:
-    <div class="page-header">
-        <h1 class="title">Bus {{ bus }}</h1>
-        <h2 class="subtitle">
-            % if bus.order is None:
-                <span class="lighter-text">Unknown Year/Model</span>
-            % else:
-                {{! bus.order }}
-            % end
-        </h2>
-        <div class="tab-button-bar">
-            <a href="{{ get_url(system, f'bus/{bus.number}') }}" class="tab-button">Overview</a>
-            <span class="tab-button current">Map</span>
-            <a href="{{ get_url(system, f'bus/{bus.number}/history') }}" class="tab-button">History</a>
-        </div>
-    </div>
-    
     <h3>Not in service</h3>
 % else:
-    <div class="page-header map-page">
-        <h1 class="title">Bus {{ bus }}</h1>
-        <h2 class="subtitle">
-            % if bus.order is None:
-                Unknown Year/Model
-            % else:
-                {{! bus.order }}
-            % end
-        </h2>
-        <div class="tab-button-bar">
-            <a href="{{ get_url(system, f'bus/{bus.number}') }}" class="tab-button">Overview</a>
-            <span class="tab-button current">Map</span>
-            <a href="{{ get_url(system, f'bus/{bus.number}/history') }}" class="tab-button">History</a>
-        </div>
-    </div>
-    
     % trip = position.trip
     % if trip is None:
         % include('components/map', is_preview=False, map_position=position)

--- a/views/pages/bus/map.tpl
+++ b/views/pages/bus/map.tpl
@@ -16,7 +16,6 @@
             <span class="tab-button current">Map</span>
             <a href="{{ get_url(system, f'bus/{bus.number}/history') }}" class="tab-button">History</a>
         </div>
-        <hr />
     </div>
     
     <h3>Not in service</h3>

--- a/views/pages/bus/overview.tpl
+++ b/views/pages/bus/overview.tpl
@@ -20,7 +20,6 @@
         <a href="{{ get_url(system, f'bus/{bus.number}/map') }}" class="tab-button">Map</a>
         <a href="{{ get_url(system, f'bus/{bus.number}/history') }}" class="tab-button">History</a>
     </div>
-    <hr />
 </div>
 
 <div class="flex-container">

--- a/views/pages/bus/overview.tpl
+++ b/views/pages/bus/overview.tpl
@@ -2,7 +2,7 @@
 % from models.date import Date
 % from models.model import ModelType
 
-% rebase('base', title=f'Bus {bus}', include_maps=True)
+% rebase('base')
 
 % model = bus.model
 

--- a/views/pages/errors/block_error.tpl
+++ b/views/pages/errors/block_error.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Error', enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Error: Block {{ block_id }} Not Found</h1>

--- a/views/pages/errors/block_error.tpl
+++ b/views/pages/errors/block_error.tpl
@@ -3,7 +3,6 @@
 
 <div class="page-header">
     <h1 class="title">Error: Block {{ block_id }} Not Found</h1>
-    <hr />
 </div>
 
 <p>The block you are looking for doesn't seem to exist!</p>

--- a/views/pages/errors/bus_error.tpl
+++ b/views/pages/errors/bus_error.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Error', enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Error: Bus {{ bus_number }} Not Found</h1>

--- a/views/pages/errors/bus_error.tpl
+++ b/views/pages/errors/bus_error.tpl
@@ -3,7 +3,6 @@
 
 <div class="page-header">
     <h1 class="title">Error: Bus {{ bus_number }} Not Found</h1>
-    <hr />
 </div>
 
 <p>The bus you are looking for doesn't seem to exist!</p>

--- a/views/pages/errors/route_error.tpl
+++ b/views/pages/errors/route_error.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Error', enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Error: Route {{ route_number }} Not Found</h1>

--- a/views/pages/errors/route_error.tpl
+++ b/views/pages/errors/route_error.tpl
@@ -3,7 +3,6 @@
 
 <div class="page-header">
     <h1 class="title">Error: Route {{ route_number }} Not Found</h1>
-    <hr />
 </div>
 
 <p>The route you are looking for doesn't seem to exist!</p>

--- a/views/pages/errors/stop_error.tpl
+++ b/views/pages/errors/stop_error.tpl
@@ -3,7 +3,6 @@
 
 <div class="page-header">
     <h1 class="title">Error: Stop {{ stop_number }} Not Found</h1>
-    <hr />
 </div>
 
 <p>The stop you are looking for doesn't seem to exist!</p>

--- a/views/pages/errors/stop_error.tpl
+++ b/views/pages/errors/stop_error.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Error', enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Error: Stop {{ stop_number }} Not Found</h1>

--- a/views/pages/errors/system_error.tpl
+++ b/views/pages/errors/system_error.tpl
@@ -4,7 +4,6 @@
 % if system_id is None:
     <div class="page-header">
         <h1 class="title">Error: System Required</h1>
-        <hr />
     </div>
     
     <p>The page you are trying to look at requires a system.</p>

--- a/views/pages/errors/system_error.tpl
+++ b/views/pages/errors/system_error.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Error', enable_refresh=False)
+% rebase('base')
 
 % if system_id is None:
     <div class="page-header">
@@ -11,7 +11,6 @@
 % else:
     <div class="page-header">
         <h1 class="title">Error: System {{ system_id }} Not Found</h1>
-        <hr />
     </div>
     
     <p>The system you are looking at doesn't seem to exist!</p>

--- a/views/pages/errors/trip_error.tpl
+++ b/views/pages/errors/trip_error.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Error', enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Error: Trip {{ trip_id }} Not Found</h1>

--- a/views/pages/errors/trip_error.tpl
+++ b/views/pages/errors/trip_error.tpl
@@ -3,7 +3,6 @@
 
 <div class="page-header">
     <h1 class="title">Error: Trip {{ trip_id }} Not Found</h1>
-    <hr />
 </div>
 
 <p>The trip you are looking for doesn't seem to exist!</p>

--- a/views/pages/fleet.tpl
+++ b/views/pages/fleet.tpl
@@ -3,7 +3,6 @@
 
 <div class="page-header">
     <h1 class="title">Fleet</h1>
-    <hr />
 </div>
 
 <p>

--- a/views/pages/fleet.tpl
+++ b/views/pages/fleet.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Fleet')
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Fleet</h1>

--- a/views/pages/history/first_seen.tpl
+++ b/views/pages/history/first_seen.tpl
@@ -8,7 +8,6 @@
         <span class="tab-button current">First Seen</span>
         <a href="{{ get_url(system, 'history/transfers') }}" class="tab-button">Transfers</a>
     </div>
-    <hr />
 </div>
 
 % if system is not None and not system.realtime_enabled:

--- a/views/pages/history/first_seen.tpl
+++ b/views/pages/history/first_seen.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Vehicle History')
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Vehicle History</h1>

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -8,7 +8,6 @@
         <a href="{{ get_url(system, 'history/first-seen') }}" class="tab-button">First Seen</a>
         <a href="{{ get_url(system, 'history/transfers') }}" class="tab-button">Transfers</a>
     </div>
-    <hr />
 </div>
 
 % if system is not None and not system.realtime_enabled:

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Vehicle History')
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Vehicle History</h1>

--- a/views/pages/history/transfers.tpl
+++ b/views/pages/history/transfers.tpl
@@ -8,7 +8,6 @@
         <a href="{{ get_url(system, 'history/first-seen') }}" class="tab-button">First Seen</a>
         <span class="tab-button current">Transfers</span>
     </div>
-    <hr />
 </div>
 
 % if system is not None and not system.realtime_enabled:

--- a/views/pages/history/transfers.tpl
+++ b/views/pages/history/transfers.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Vehicle History')
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Vehicle History</h1>

--- a/views/pages/home.tpl
+++ b/views/pages/home.tpl
@@ -8,7 +8,6 @@
     % else:
         <h2 class="subtitle">{{ system }} Transit Schedules and Bus Tracking</h2>
     % end
-    <hr />
 </div>
 
 <div class="flex-container">

--- a/views/pages/home.tpl
+++ b/views/pages/home.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Home', enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Welcome to BCTracker!</h1>

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -6,7 +6,6 @@
 % if len(positions) == 0:
     <div class="page-header">
         <h1 class="title">Map</h1>
-        <hr />
     </div>
 
     % if system is not None and not system.realtime_enabled:

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -1,36 +1,11 @@
 
 % import json
 
-% rebase('base', title='Map', include_maps=True, full_map=True)
+% rebase('base')
 
-% if len(positions) == 0:
-    <div class="page-header">
-        <h1 class="title">Map</h1>
-    </div>
-
-    % if system is not None and not system.realtime_enabled:
-        <p>
-            {{ system }} does not currently support realtime.
-            You can browse the schedule data for {{ system }} using the links above, or choose a different system that supports realtime.
-        </p>
-    % else:
-        % if system is None:
-            <p>
-                There are no buses out right now.
-                BC Transit does not have late night service, so this should be the case overnight.
-                If you look out your window and the sun is shining, there may be an issue with the GTFS getting up-to-date info.
-                Please check back later!
-            </p>
-        % else:
-            <p>
-                There are no buses out in {{ system }} right now.
-                Please choose a different system.
-            </p>
-        % end
-    % end
-% else:
-    <div class="page-header map-page">
-        <h1 class="title">Map</h1>
+<div class="page-header">
+    <h1 class="title">Map</h1>
+    % if len(positions) > 0:
         <div class="checkbox" onclick="toggleTripLines()">
             <div class="box">
                 <div id="checkbox-image" class="hidden">
@@ -58,8 +33,31 @@
             </div>
             <span class="checkbox-label">Show NIS Buses</span>
         </div>
-    </div>
-    
+    % end
+</div>
+
+% if len(positions) == 0:
+    % if system is not None and not system.realtime_enabled:
+        <p>
+            {{ system }} does not currently support realtime.
+            You can browse the schedule data for {{ system }} using the links above, or choose a different system that supports realtime.
+        </p>
+    % else:
+        % if system is None:
+            <p>
+                There are no buses out right now.
+                BC Transit does not have late night service, so this should be the case overnight.
+                If you look out your window and the sun is shining, there may be an issue with the GTFS getting up-to-date info.
+                Please check back later!
+            </p>
+        % else:
+            <p>
+                There are no buses out in {{ system }} right now.
+                Please choose a different system.
+            </p>
+        % end
+    % end
+% else:
     <div id="map" class="full-screen"></div>
     
     <script>

--- a/views/pages/news.tpl
+++ b/views/pages/news.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='News Archive', enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">News Archive</h1>

--- a/views/pages/news.tpl
+++ b/views/pages/news.tpl
@@ -4,7 +4,6 @@
 <div class="page-header">
     <h1 class="title">News Archive</h1>
     <a href="{{ get_url(system) }}">Return home</a>
-    <hr />
 </div>
 
 <div class="container">

--- a/views/pages/personalize.tpl
+++ b/views/pages/personalize.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Personalize', enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Personalize</h1>

--- a/views/pages/personalize.tpl
+++ b/views/pages/personalize.tpl
@@ -3,8 +3,8 @@
 
 <div class="page-header">
     <h1 class="title">Personalize</h1>
-    <hr />
 </div>
+
 <div class="flex-container">
     <div class="container flex-1">
         <div class="section">

--- a/views/pages/realtime/all.tpl
+++ b/views/pages/realtime/all.tpl
@@ -16,7 +16,6 @@
             <!-- Oh, hello there! It's cool to see buses grouped in different ways, but I recently watched the movie Speed (1994) starring Sandra Bullock and now I want to see how fast these buses are going... if only there was a way to see realtime info by "speed"... -->
         % end
     </div>
-    <hr />
 </div>
 
 % if len(positions) == 0:

--- a/views/pages/realtime/all.tpl
+++ b/views/pages/realtime/all.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Realtime')
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Realtime</h1>

--- a/views/pages/realtime/models.tpl
+++ b/views/pages/realtime/models.tpl
@@ -16,7 +16,6 @@
             <!-- Oh, hello there! It's cool to see buses grouped in different ways, but I recently watched the movie Speed (1994) starring Keanu Reeves and now I want to see how fast these buses are going... if only there was a way to see realtime info by "speed"... -->
         % end
     </div>
-    <hr />
 </div>
 
 % if len(positions) == 0:

--- a/views/pages/realtime/models.tpl
+++ b/views/pages/realtime/models.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Realtime')
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Realtime</h1>

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Realtime')
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Realtime</h1>

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -14,7 +14,6 @@
             <!-- Oh, hello there! It's cool to see buses grouped in different ways, but I recently watched the movie Speed (1994) starring Dennis Hopper and now I want to see how fast these buses are going... if only there was a way to see realtime info by "speed"... -->
         % end
     </div>
-    <hr />
 </div>
 
 % if len(positions) == 0:

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -12,7 +12,6 @@
         <a href="{{ get_url(system, 'realtime/models') }}" class="tab-button">By Model</a>
         <span class="tab-button current">By Speed</span>
     </div>
-    <hr />
 </div>
 
 % if len(positions) == 0:

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Realtime')
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Realtime</h1>

--- a/views/pages/route/date.tpl
+++ b/views/pages/route/date.tpl
@@ -15,7 +15,6 @@
         <a href="{{ get_url(system, f'routes/{route.number}/map') }}" class="tab-button">Map</a>
         <span class="tab-button current">Schedule</span>
     </div>
-    <hr />
 </div>
 
 <div class="flex-container">

--- a/views/pages/route/date.tpl
+++ b/views/pages/route/date.tpl
@@ -1,7 +1,7 @@
 
 % from datetime import timedelta
 
-% rebase('base', title=str(route), enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">

--- a/views/pages/route/map.tpl
+++ b/views/pages/route/map.tpl
@@ -1,21 +1,21 @@
 
-% rebase('base', title=str(route), include_maps=True, full_map=True)
+% rebase('base')
+
+<div class="page-header">
+    <h1 class="title">
+        <div class="flex-row">
+            % include('components/route_indicator')
+            <div class="flex-1">{{! route.display_name }}</div>
+        </div>
+    </h1>
+    <div class="tab-button-bar">
+        <a href="{{ get_url(system, f'routes/{route.number}') }}" class="tab-button">Overview</a>
+        <span class="tab-button current">Map</span>
+        <a href="{{ get_url(system, f'routes/{route.number}/schedule') }}" class="tab-button">Schedule</a>
+    </div>
+</div>
 
 % if len(route.trips) == 0:
-    <div class="page-header">
-        <h1 class="title">
-            <div class="flex-row">
-                % include('components/route_indicator')
-                <div class="flex-1">{{! route.display_name }}</div>
-            </div>
-        </h1>
-        <div class="tab-button-bar">
-            <a href="{{ get_url(system, f'routes/{route.number}') }}" class="tab-button">Overview</a>
-            <span class="tab-button current">Map</span>
-            <a href="{{ get_url(system, f'routes/{route.number}/schedule') }}" class="tab-button">Schedule</a>
-        </div>
-    </div>
-    
     <p>There are currently no trips for this route.</p>
     <p>
         There are a few reasons why that may be the case:
@@ -27,20 +27,6 @@
         Please check again later!
     </p>
 % else:
-    <div class="page-header map-page">
-        <h1 class="title">
-            <div class="flex-row">
-                % include('components/route_indicator')
-                {{! route.display_name }}
-            </div>
-        </h1>
-        <div class="tab-button-bar">
-            <a href="{{ get_url(system, f'routes/{route.number}') }}" class="tab-button">Overview</a>
-            <span class="tab-button current">Map</span>
-            <a href="{{ get_url(system, f'routes/{route.number}/schedule') }}" class="tab-button">Schedule</a>
-        </div>
-    </div>
-    
     % trips = route.trips
     % departures = [d for t in trips for d in t.departures]
     

--- a/views/pages/route/map.tpl
+++ b/views/pages/route/map.tpl
@@ -14,7 +14,6 @@
             <span class="tab-button current">Map</span>
             <a href="{{ get_url(system, f'routes/{route.number}/schedule') }}" class="tab-button">Schedule</a>
         </div>
-        <hr />
     </div>
     
     <p>There are currently no trips for this route.</p>

--- a/views/pages/route/overview.tpl
+++ b/views/pages/route/overview.tpl
@@ -13,7 +13,6 @@
         <a href="{{ get_url(system, f'routes/{route.number}/map') }}" class="tab-button">Map</a>
         <a href="{{ get_url(system, f'routes/{route.number}/schedule') }}" class="tab-button">Schedule</a>
     </div>
-    <hr />
 </div>
 
 <div class="flex-container">

--- a/views/pages/route/overview.tpl
+++ b/views/pages/route/overview.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title=str(route), include_maps=True)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">

--- a/views/pages/route/schedule.tpl
+++ b/views/pages/route/schedule.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title=str(route), enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">

--- a/views/pages/route/schedule.tpl
+++ b/views/pages/route/schedule.tpl
@@ -13,7 +13,6 @@
         <a href="{{ get_url(system, f'routes/{route.number}/map') }}" class="tab-button">Map</a>
         <span class="tab-button current">Schedule</span>
     </div>
-    <hr />
 </div>
 
 % if len(route.trips) == 0:

--- a/views/pages/routes/list.tpl
+++ b/views/pages/routes/list.tpl
@@ -7,7 +7,6 @@
         <span class="tab-button current">List</span>
         <a href="{{ get_url(system, 'routes/map') }}" class="tab-button">Map</a>
     </div>
-    <hr />
 </div>
 
 % if system is None:

--- a/views/pages/routes/list.tpl
+++ b/views/pages/routes/list.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Routes', enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Routes</h1>

--- a/views/pages/routes/map.tpl
+++ b/views/pages/routes/map.tpl
@@ -10,7 +10,6 @@
             <a href="{{ get_url(system, 'routes') }}" class="tab-button">List</a>
             <span class="tab-button current">Map</span>
         </div>
-        <hr />
     </div>
     
     <p>Choose a system to see individual routes.</p>
@@ -68,7 +67,6 @@
                 <a href="{{ get_url(system, 'routes') }}" class="tab-button">List</a>
                 <span class="tab-button current">Map</span>
             </div>
-            <hr />
         </div>
         
         <p>

--- a/views/pages/routes/map.tpl
+++ b/views/pages/routes/map.tpl
@@ -1,17 +1,17 @@
 
 % import json
 
-% if system is None:
-    % rebase('base', title='Routes', enable_refresh=False)
-    
-    <div class="page-header">
-        <h1 class="title">Routes</h1>
-        <div class="tab-button-bar">
-            <a href="{{ get_url(system, 'routes') }}" class="tab-button">List</a>
-            <span class="tab-button current">Map</span>
-        </div>
+% rebase('base')
+
+<div class="page-header">
+    <h1 class="title">Routes</h1>
+    <div class="tab-button-bar">
+        <a href="{{ get_url(system, 'routes') }}" class="tab-button">List</a>
+        <span class="tab-button current">Map</span>
     </div>
-    
+</div>
+
+% if system is None:
     <p>Choose a system to see individual routes.</p>
     <table class="striped">
         <thead>
@@ -57,31 +57,12 @@
         </tbody>
     </table>
 % else:
-    % rebase('base', title='Routes', include_maps=True, full_map=True, enable_refresh=False)
-    
-    % routes = system.get_routes()
     % if len(routes) == 0:
-        <div class="page-header">
-            <h1 class="title">Routes</h1>
-            <div class="tab-button-bar">
-                <a href="{{ get_url(system, 'routes') }}" class="tab-button">List</a>
-                <span class="tab-button current">Map</span>
-            </div>
-        </div>
-        
         <p>
             Route information is currently unavailable for {{ system }}.
             Please check again later!
         </p>
     % else:
-        <div class="page-header map-page">
-            <h1 class="title">Routes</h1>
-            <div class="tab-button-bar">
-                <a href="{{ get_url(system, 'routes') }}" class="tab-button">List</a>
-                <span class="tab-button current">Map</span>
-            </div>
-        </div>
-        
         <div id="map" class="full-screen"></div>
         
         <script>

--- a/views/pages/stop/date.tpl
+++ b/views/pages/stop/date.tpl
@@ -11,7 +11,6 @@
         <a href="{{ get_url(system, f'stops/{stop.number}/map') }}" class="tab-button">Map</a>
         <span class="tab-button current">Schedule</span>
     </div>
-    <hr />
 </div>
 
 <div class="flex-container">

--- a/views/pages/stop/date.tpl
+++ b/views/pages/stop/date.tpl
@@ -1,7 +1,7 @@
 
 % from datetime import timedelta
 
-% rebase('base', title=f'Stop {stop.number}', enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Stop {{ stop.number }}</h1>

--- a/views/pages/stop/map.tpl
+++ b/views/pages/stop/map.tpl
@@ -1,7 +1,7 @@
 
-% rebase('base', title=f'Stop {stop.number}', include_maps=True, full_map=True)
+% rebase('base')
 
-<div class="page-header map-page">
+<div class="page-header">
     <h1 class="title">Stop {{ stop.number }}</h1>
     <h2 class="subtitle">{{ stop }}</h2>
     <div class="tab-button-bar">

--- a/views/pages/stop/overview.tpl
+++ b/views/pages/stop/overview.tpl
@@ -14,7 +14,6 @@
         <a href="{{ get_url(system, f'stops/{stop.number}/map') }}" class="tab-button">Map</a>
         <a href="{{ get_url(system, f'stops/{stop.number}/schedule') }}" class="tab-button">Schedule</a>
     </div>
-    <hr />
 </div>
 
 <div class="flex-container">

--- a/views/pages/stop/overview.tpl
+++ b/views/pages/stop/overview.tpl
@@ -4,7 +4,7 @@
 
 % from models.date import Date
 
-% rebase('base', title=f'Stop {stop.number}', include_maps=True)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Stop {{ stop.number }}</h1>

--- a/views/pages/stop/schedule.tpl
+++ b/views/pages/stop/schedule.tpl
@@ -9,7 +9,6 @@
         <a href="{{ get_url(system, f'stops/{stop.number}/map') }}" class="tab-button">Map</a>
         <span class="tab-button current">Schedule</span>
     </div>
-    <hr />
 </div>
 
 % if len(stop.departures) == 0:

--- a/views/pages/stop/schedule.tpl
+++ b/views/pages/stop/schedule.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title=f'Stop {stop.number}')
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Stop {{ stop.number }}</h1>

--- a/views/pages/stops.tpl
+++ b/views/pages/stops.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Stops', enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Stops</h1>

--- a/views/pages/stops.tpl
+++ b/views/pages/stops.tpl
@@ -6,7 +6,6 @@
     % if search is not None:
         <h2 class="subtitle">Search results for "{{ search }}"</h2>
     % end
-    <hr />
 </div>
 
 % if system is None:

--- a/views/pages/systems.tpl
+++ b/views/pages/systems.tpl
@@ -3,7 +3,6 @@
 
 <div class="page-header">
     <h1 class="title">Systems</h1>
-    <hr />
 </div>
 
 <table class="striped">

--- a/views/pages/systems.tpl
+++ b/views/pages/systems.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title='Systems', enable_refresh=False)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Systems</h1>

--- a/views/pages/trip/history.tpl
+++ b/views/pages/trip/history.tpl
@@ -9,7 +9,6 @@
         <a href="{{ get_url(system, f'trips/{trip.id}/map') }}" class="tab-button">Map</a>
         <span class="tab-button current">History</span>
     </div>
-    <hr />
 </div>
 
 % if system.realtime_enabled:

--- a/views/pages/trip/history.tpl
+++ b/views/pages/trip/history.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title=f'Trip {trip.id}')
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Trip {{! trip.display_id }}</h1>

--- a/views/pages/trip/map.tpl
+++ b/views/pages/trip/map.tpl
@@ -1,7 +1,7 @@
 
-% rebase('base', title=f'Trip {trip.id}', include_maps=True, full_map=True)
+% rebase('base')
 
-<div class="page-header map-page">
+<div class="page-header">
     <h1 class="title">Trip {{! trip.display_id }}</h1>
     <h2 class="subtitle">{{ trip }}</h2>
     <div class="tab-button-bar">

--- a/views/pages/trip/overview.tpl
+++ b/views/pages/trip/overview.tpl
@@ -11,7 +11,6 @@
             <a href="{{ get_url(system, f'trips/{trip.id}/history') }}" class="tab-button">History</a>
         % end
     </div>
-    <hr />
 </div>
 
 <div class="flex-container">

--- a/views/pages/trip/overview.tpl
+++ b/views/pages/trip/overview.tpl
@@ -1,5 +1,5 @@
 
-% rebase('base', title=f'Trip {trip.id}', include_maps=True)
+% rebase('base')
 
 <div class="page-header">
     <h1 class="title">Trip {{! trip.display_id }}</h1>


### PR DESCRIPTION
- Removed `<hr />` tags from page headers, and now uses `border-bottom` styling directly
- Tab bars now use grid layout on mobile to allow for multiple rows, with various other styling improvements and simplifications
- Page properties such as the title and enabling map functionality is no longer done through the `rebase` command at the top of each file, and has instead been moved to the properties set within each `server.py` endpoint function
- Calls to the `page` and `error_page` functions in `server.py` have been broken into multiple lines to make them easier to read and modify
- A few other fixes and improvements