### PR TITLE
Add date ranges

### DIFF
--- a/gtfs.py
+++ b/gtfs.py
@@ -121,7 +121,7 @@ def validate(system):
     '''Checks that the GTFS for the given system is up-to-date'''
     if not system.gtfs_enabled:
         return True
-    end_dates = [s.schedule.end_date for s in system.get_services()]
+    end_dates = [s.schedule.date_range.end for s in system.get_services()]
     if len(end_dates) == 0:
         return True
     return Date.today(system.timezone) < max(end_dates) - timedelta(days=7)

--- a/helpers/sheet.py
+++ b/helpers/sheet.py
@@ -5,12 +5,12 @@ def combine(system, services, include_special=False):
     '''Returns a list of sheets made from services with overlapping start/end dates'''
     sheets = []
     cumulative_services = []
-    for service in sorted(services, key=lambda s: s.schedule.start_date):
+    for service in sorted(services, key=lambda s: s.schedule.date_range):
         if len(cumulative_services) == 0:
             cumulative_services.append(service)
         else:
-            end_date = max({s.schedule.end_date for s in cumulative_services})
-            if service.schedule.start_date <= end_date:
+            end_date = max({s.schedule.date_range.end for s in cumulative_services})
+            if service.schedule.date_range.start <= end_date:
                 cumulative_services.append(service)
             else:
                 sheets.append(Sheet.combine(system, cumulative_services, include_special))

--- a/models/daterange.py
+++ b/models/daterange.py
@@ -1,0 +1,50 @@
+
+from datetime import timedelta
+
+class DateRange:
+    '''A set of dates between starting and ending points'''
+    
+    __slots__ = ('start', 'end')
+    
+    @classmethod
+    def combine(cls, date_ranges):
+        '''Returns a date range that includes all the given date ranges'''
+        start = min({r.start for r in date_ranges})
+        end = max({r.end for r in date_ranges})
+        return cls(start, end)
+    
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+    
+    def __str__(self):
+        if self.start == self.end:
+            return str(self.start)
+        return f'{self.start} to {self.end}'
+    
+    def __hash__(self):
+        return hash((self.start, self.end))
+    
+    def __eq__(self, other):
+        return self.start == other.start and self.end == other.end
+    
+    def __lt__(self, other):
+        if self.start == other.start:
+            return self.end < other.end
+        return self.start < other.start
+    
+    def __len__(self):
+        return abs((self.end.datetime - self.start.datetime).days) + 1
+    
+    def __contains__(self, date):
+        return self.start <= date <= self.end
+    
+    def __iter__(self):
+        date = self.start
+        while date <= self.end:
+            yield date
+            date += timedelta(days=1)
+    
+    def overlaps(self, other):
+        '''Checks if this date range overlaps with the given date range'''
+        return self.start <= other.end and other.start <= self.end

--- a/models/service.py
+++ b/models/service.py
@@ -2,6 +2,7 @@
 from enum import IntEnum
 
 from models.date import Date
+from models.daterange import DateRange
 from models.schedule import Schedule
 from models.weekday import Weekday
 
@@ -44,6 +45,7 @@ class Service:
         id = row['service_id']
         start_date = Date.parse_csv(row['start_date'], system.timezone)
         end_date = Date.parse_csv(row['end_date'], system.timezone)
+        date_range = DateRange(start_date, end_date)
         mon = row['monday'] == '1'
         tue = row['tuesday'] == '1'
         wed = row['wednesday'] == '1'
@@ -56,16 +58,17 @@ class Service:
         service_exceptions = exceptions.get(id, [])
         modified_dates = {e.date for e in service_exceptions if e.type == ServiceExceptionType.INCLUDED}
         excluded_dates = {e.date for e in service_exceptions if e.type == ServiceExceptionType.EXCLUDED}
-        schedule = Schedule.process(start_date, end_date, weekdays, modified_dates, excluded_dates)
+        schedule = Schedule.process(date_range, weekdays, modified_dates, excluded_dates)
         return cls(system, id, schedule)
     
     @classmethod
     def combine(cls, system, id, exceptions):
         start_date = min({e.date for e in exceptions})
         end_date = max({e.date for e in exceptions})
+        date_range = DateRange(start_date, end_date)
         modified_dates = {e.date for e in exceptions if e.type == ServiceExceptionType.INCLUDED}
         excluded_dates = {e.date for e in exceptions if e.type == ServiceExceptionType.EXCLUDED}
-        schedule = Schedule.process(start_date, end_date, set(), modified_dates, excluded_dates)
+        schedule = Schedule.process(date_range, set(), modified_dates, excluded_dates)
         return cls(system, id, schedule)
     
     def __init__(self, system, id, schedule):

--- a/models/sheet.py
+++ b/models/sheet.py
@@ -1,5 +1,6 @@
 
 from models.date import Date
+from models.daterange import DateRange
 from models.schedule import Schedule
 
 class Sheet:
@@ -33,7 +34,7 @@ class Sheet:
         self.service_groups = service_groups
     
     def __str__(self):
-        return self.schedule.date_string
+        return str(self.schedule.date_range)
     
     def __hash__(self):
         return hash(self.id)
@@ -42,7 +43,7 @@ class Sheet:
         return self.id == other.id
     
     def __lt__(self, other):
-        return self.schedule.start_date < other.schedule.start_date
+        return self.schedule.date_range < other.schedule.date_range
 
 class ServiceGroup:
     '''A collection of services represented as a single schedule'''
@@ -56,8 +57,7 @@ class ServiceGroup:
             return None
         id = '_'.join(sorted({s.id for s in services}))
         schedules = [s.schedule for s in services]
-        start_date = min({s.start_date for s in schedules})
-        end_date = max({s.end_date for s in schedules})
+        date_range = DateRange.combine([s.date_range for s in schedules])
         if weekdays is None:
             weekdays = {w for s in schedules for w in s.weekdays}
         if modified_dates is None:
@@ -67,7 +67,7 @@ class ServiceGroup:
         for date in excluded_dates:
             if len([s for s in schedules if date in s.excluded_dates]) < len([s for s in schedules if date.weekday in s.weekdays]):
                 modified_dates.add(date)
-        schedule = Schedule(start_date, end_date, weekdays, modified_dates, excluded_dates - modified_dates)
+        schedule = Schedule(date_range, weekdays, modified_dates, excluded_dates - modified_dates)
         return cls(system, id, schedule, services)
     
     def __init__(self, system, id, schedule, services):

--- a/views/components/schedules_indicator.tpl
+++ b/views/components/schedules_indicator.tpl
@@ -29,7 +29,7 @@
     % for (i, schedule) in enumerate(schedules):
         % if not schedule.special or show_special_schedules:
             <div class="schedule">
-                <div class="title">{{ schedule.date_string }}</div>
+                <div class="title">{{ schedule.date_range }}</div>
                 % include('components/weekdays_indicator', schedule=schedule, url_suffix='' if i == 0 else f'{i + 1}')
             </div>
         % end

--- a/views/pages/block/overview.tpl
+++ b/views/pages/block/overview.tpl
@@ -49,7 +49,7 @@
                                     % if len(service_groups) > 1:
                                         <div class="smaller-font lighter-text">
                                             % if len(sheets) > 1:
-                                                {{ service_group.schedule.date_string }}
+                                                {{ service_group.schedule.date_range }}
                                             % else:
                                                 {{ service_group }}
                                             % end
@@ -68,7 +68,7 @@
                                     % if len(service_groups) > 1:
                                         <div class="smaller-font lighter-text">
                                             % if len(sheets) > 1:
-                                                {{ service_group.schedule.date_string }}
+                                                {{ service_group.schedule.date_range }}
                                             % else:
                                                 {{ service_group }}
                                             % end
@@ -87,7 +87,7 @@
                                     % if len(service_groups) > 1:
                                         <div class="smaller-font lighter-text">
                                             % if len(sheets) > 1:
-                                                {{ service_group.schedule.date_string }}
+                                                {{ service_group.schedule.date_range }}
                                             % else:
                                                 {{ service_group }}
                                             % end
@@ -106,7 +106,7 @@
                                     % if len(service_groups) > 1:
                                         <div class="smaller-font lighter-text">
                                             % if len(sheets) > 1:
-                                                {{ service_group.schedule.date_string }}
+                                                {{ service_group.schedule.date_range }}
                                             % else:
                                                 {{ service_group }}
                                             % end
@@ -126,7 +126,7 @@
                                         % if len(service_groups) > 1:
                                             <div class="smaller-font lighter-text">
                                                 % if len(sheets) > 1:
-                                                    {{ service_group.schedule.date_string }}
+                                                    {{ service_group.schedule.date_range }}
                                                 % else:
                                                     {{ service_group }}
                                                 % end


### PR DESCRIPTION
This is one of a few steps towards eventual schedule/service refactoring. It's a change that is straightforward and decoupled enough from everything else that it can be implemented separately, making it easier for review and testing. With the current implementation of schedules, services, and sheets, it may seem like an unnecessary amount of overhead to introduce, but down the road there will be additional functionality added that is much more easily done with explicit date range objects.

Main change is very simple - added new `DateRange` class with `start` and `end` dates, which provides functionality for comparing date ranges, checking if a date is within the range, and simple iteration across all dates within the range. It also provides a string representation of itself so that other types do not need to declare their own `date_string` properties.