### PR TITLE
Adornments + Static Data Reloading

### DIFF
--- a/data/static/adornments.csv
+++ b/data/static/adornments.csv
@@ -1,0 +1,4 @@
+bus_number,enabled,text,description
+9093,1,⚡,Battery Demo Bus
+9387,1,🏳️‍🌈,Pride Bus
+9434,0,🎄,Christmas Bus

--- a/helpers/adornment.py
+++ b/helpers/adornment.py
@@ -19,3 +19,8 @@ def find(bus_number):
     if bus_number in adornments:
         return adornments[bus_number]
     return None
+
+def delete_all():
+    '''Deletes all adornments'''
+    global adornments
+    adornments = {}

--- a/helpers/adornment.py
+++ b/helpers/adornment.py
@@ -1,0 +1,21 @@
+
+import csv
+
+from models.adornment import Adornment
+
+adornments = {}
+
+def load():
+    '''Loads adornment data from the static CSV file'''
+    with open(f'./data/static/adornments.csv', 'r') as file:
+        reader = csv.reader(file)
+        columns = next(reader)
+        for row in reader:
+            adornment = Adornment.from_csv(dict(zip(columns, row)))
+            adornments[adornment.bus_number] = adornment
+
+def find(bus_number):
+    '''Returns the adornment with the given bus number'''
+    if bus_number in adornments:
+        return adornments[bus_number]
+    return None

--- a/helpers/model.py
+++ b/helpers/model.py
@@ -19,3 +19,8 @@ def find(model_id):
     if model_id in models:
         return models[model_id]
     return None
+
+def delete_all():
+    '''Deletes all models'''
+    global models
+    models = {}

--- a/helpers/order.py
+++ b/helpers/order.py
@@ -1,6 +1,8 @@
 
 import csv
 
+import helpers.adornment
+
 from models.match import Match
 from models.order import Order
 
@@ -36,6 +38,9 @@ def find_matches(query, recorded_bus_numbers):
         order_string = str(order)
         for bus_number in order.range:
             bus_number_string = f'{bus_number:04d}'
+            adornment = helpers.adornment.find(bus_number)
+            if adornment is not None and adornment.enabled:
+                bus_number_string += f' {adornment}'
             value = 0
             if query in bus_number_string:
                 value += (len(query) / len(bus_number_string)) * 100

--- a/helpers/order.py
+++ b/helpers/order.py
@@ -50,3 +50,8 @@ def find_matches(query, recorded_bus_numbers):
                 value /= 10
             matches.append(Match('bus', bus_number_string, order_string, f'bus/{bus_number}', value))
     return matches
+
+def delete_all():
+    '''Deletes all orders'''
+    global orders
+    orders = []

--- a/helpers/region.py
+++ b/helpers/region.py
@@ -23,3 +23,8 @@ def find(region_id):
 def find_all():
     '''Returns all regions'''
     return regions.values()
+
+def delete_all():
+    '''Deletes all regions'''
+    global regions
+    regions = {}

--- a/helpers/system.py
+++ b/helpers/system.py
@@ -23,3 +23,8 @@ def find(system_id):
 def find_all():
     '''Returns all systems'''
     return systems.values()
+
+def delete_all():
+    '''Deletes all systems'''
+    global systems
+    systems = {}

--- a/helpers/theme.py
+++ b/helpers/theme.py
@@ -23,3 +23,8 @@ def find(theme_id):
 def find_all():
     '''Returns all themes'''
     return themes.values()
+
+def delete_all():
+    '''Deletes all themes'''
+    global themes
+    themes = {}

--- a/models/adornment.py
+++ b/models/adornment.py
@@ -1,0 +1,32 @@
+
+class Adornment:
+    '''Text placed after a bus number'''
+    
+    __slots__ = ('bus_number', 'enabled', 'text', 'description')
+    
+    @classmethod
+    def from_csv(cls, row):
+        '''Returns an adornment initialized from the given CSV row'''
+        bus_number = int(row['bus_number'])
+        enabled = row['enabled'] == '1'
+        text = row['text']
+        if row['description'] == '':
+            description = None
+        else:
+            description = row['description']
+        return cls(bus_number, enabled, text, description)
+    
+    def __init__(self, bus_number, enabled, text, description):
+        self.bus_number = bus_number
+        self.enabled = enabled
+        self.text = text
+        self.description = description
+    
+    def __str__(self):
+        return self.text
+    
+    def __hash__(self):
+        return hash(self.bus_number)
+    
+    def __eq__(self, other):
+        return self.bus_number == other.bus_number

--- a/models/bus.py
+++ b/models/bus.py
@@ -1,14 +1,16 @@
 
+import helpers.adornment
 import helpers.order
 
 class Bus:
     '''A public transportation vehicle'''
     
-    __slots__ = ('number', 'order')
+    __slots__ = ('number', 'order', 'adornment')
     
     def __init__(self, bus_number):
         self.number = bus_number
         self.order = helpers.order.find(bus_number)
+        self.adornment = helpers.adornment.find(bus_number)
     
     def __str__(self):
         if self.is_known:

--- a/models/position.py
+++ b/models/position.py
@@ -114,6 +114,9 @@ class Position:
             data['bus_order'] = 'Unknown Year/Model'
         else:
             data['bus_order'] = str(order).replace("'", '&apos;')
+        adornment = self.bus.adornment
+        if adornment is not None and adornment.enabled:
+            data['adornment'] = str(adornment)
         trip = self.trip
         if trip is None:
             data['headsign'] = 'Not In Service'

--- a/server.py
+++ b/server.py
@@ -4,6 +4,7 @@ from requestlogger import WSGILogger, ApacheFormatter
 from bottle import Bottle, static_file, template, request, response, debug, redirect
 import cherrypy as cp
 
+import helpers.adornment
 import helpers.model
 import helpers.order
 import helpers.overview
@@ -51,6 +52,7 @@ def start(args):
     if args.reload:
         print('Forcing GTFS redownload')
     
+    helpers.adornment.load()
     helpers.model.load()
     helpers.order.load()
     helpers.region.load()

--- a/server.py
+++ b/server.py
@@ -980,6 +980,78 @@ def api_search(system_id=None):
     }
 
 @app.post([
+    '/api/admin/reload-adornments',
+    '/api/admin/reload-adornments/',
+    '/api/admin/<key>/reload-adornments',
+    '/api/admin/<key>/reload-adornments/',
+    '/<system_id>/api/admin/reload-adornments',
+    '/<system_id>/api/admin/reload-adornments/',
+    '/<system_id>/api/admin/<key>/reload-adornments',
+    '/<system_id>/api/admin/<key>/reload-adornments/'
+])
+def api_admin_reload_adornments(key=None, system_id=None):
+    if admin_key is None or key == admin_key:
+        helpers.adornment.delete_all()
+        helpers.adornment.load()
+        return 'Success'
+    return 'Access denied'
+
+@app.post([
+    '/api/admin/reload-orders',
+    '/api/admin/reload-orders/',
+    '/api/admin/<key>/reload-orders',
+    '/api/admin/<key>/reload-orders/',
+    '/<system_id>/api/admin/reload-orders',
+    '/<system_id>/api/admin/reload-orders/',
+    '/<system_id>/api/admin/<key>/reload-orders',
+    '/<system_id>/api/admin/<key>/reload-orders/'
+])
+def api_admin_reload_orders(key=None, system_id=None):
+    if admin_key is None or key == admin_key:
+        helpers.model.delete_all()
+        helpers.order.delete_all()
+        helpers.model.load()
+        helpers.order.load()
+        return 'Success'
+    return 'Access denied'
+
+@app.post([
+    '/api/admin/reload-systems',
+    '/api/admin/reload-systems/',
+    '/api/admin/<key>/reload-systems',
+    '/api/admin/<key>/reload-systems/',
+    '/<system_id>/api/admin/reload-systems',
+    '/<system_id>/api/admin/reload-systems/',
+    '/<system_id>/api/admin/<key>/reload-systems',
+    '/<system_id>/api/admin/<key>/reload-systems/'
+])
+def api_admin_reload_systems(key=None, system_id=None):
+    if admin_key is None or key == admin_key:
+        helpers.region.delete_all()
+        helpers.system.delete_all()
+        helpers.region.load()
+        helpers.system.load()
+        return 'Success'
+    return 'Access denied'
+
+@app.post([
+    '/api/admin/reload-themes',
+    '/api/admin/reload-themes/',
+    '/api/admin/<key>/reload-themes',
+    '/api/admin/<key>/reload-themes/',
+    '/<system_id>/api/admin/reload-themes',
+    '/<system_id>/api/admin/reload-themes/',
+    '/<system_id>/api/admin/<key>/reload-themes',
+    '/<system_id>/api/admin/<key>/reload-themes/'
+])
+def api_admin_reload_themes(key=None, system_id=None):
+    if admin_key is None or key == admin_key:
+        helpers.theme.delete_all()
+        helpers.theme.load()
+        return 'Success'
+    return 'Access denied'
+
+@app.post([
     '/api/admin/restart-cron',
     '/api/admin/restart-cron/',
     '/api/admin/<key>/restart-cron',

--- a/style/main.css
+++ b/style/main.css
@@ -291,6 +291,10 @@ table.striped tr.section td {
     padding: 3px 6px;
 }
 
+.adornment {
+    user-select: none;
+}
+
 .banner {
     margin: 0px;
     padding: 10px 20px;
@@ -908,6 +912,7 @@ table.striped tr.section td {
     text-align: left;
     width: max-content;
     max-width: 300px;
+    font-weight: normal;
 }
 
 .tooltip-anchor .tooltip::after {

--- a/views/components/adherence_indicator.tpl
+++ b/views/components/adherence_indicator.tpl
@@ -2,8 +2,6 @@
 % if adherence is not None:
     <div class="tooltip-anchor adherence-indicator {{ adherence.status_class }} {{ get('size', '') }}">
         {{ adherence }}
-        <div class="tooltip">
-            <div class="title">{{ adherence.description }}</div>
-        </div>
+        <div class="tooltip">{{ adherence.description }}</div>
     </div>
 % end

--- a/views/components/bus.tpl
+++ b/views/components/bus.tpl
@@ -1,0 +1,16 @@
+<div class="flex-row">
+    % if bus.is_known and get('enable_link', True):
+        <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
+    % else:
+        <div>{{ bus }}</div>
+    % end
+    % adornment = bus.adornment
+    % if adornment is not None and adornment.enabled:
+        <div class="adornment tooltip-anchor">
+            {{ adornment }}
+            % if adornment.description is not None:
+                <div class="tooltip">{{ adornment.description }}</div>
+            % end
+        </div>
+    % end
+</div>

--- a/views/components/map.tpl
+++ b/views/components/map.tpl
@@ -264,6 +264,10 @@
                 title.innerHTML = position.bus_number;
             }
             
+            if (position.adornment != null) {
+                title.innerHTML += " <span class='adornment'>" + position.adornment + "</span>";
+            }
+            
             details.appendChild(title);
             details.appendChild(content);
             element.appendChild(details);

--- a/views/components/order.tpl
+++ b/views/components/order.tpl
@@ -1,0 +1,5 @@
+% if order is None:
+    <span class="lighter-text">Unknown Year/Model</span>
+% else:
+    <span>{{! order }}</span>
+% end

--- a/views/components/order_indicator.tpl
+++ b/views/components/order_indicator.tpl
@@ -5,25 +5,27 @@
         % if bus.number > order.low:
             % first_bus = order.first_bus
             % previous_bus = order.previous_bus(bus.number)
-            <a href="{{ get_url(system, f'bus/{first_bus.number}') }}" class="bus">{{ first_bus }}</a>
+            % include('components/bus', bus=first_bus)
             % if previous_bus.number > order.low:
                 <span class="separator">&lt;&lt;&lt;</span>
-                <a href="{{ get_url(system, f'bus/{previous_bus.number}') }}" class="bus">{{ previous_bus }}</a>
+                % include('components/bus', bus=previous_bus)
             % end
             <span class="separator">&lt;</span>
         % end
         
-        <span class="bus">{{ bus }}</span>
+        <span class="bus">
+            % include('components/bus', bus=bus, enable_link=False)
+        </span>
         
         % if bus.number < order.high:
             % last_bus = order.last_bus
             % next_bus = order.next_bus(bus.number)
             <span class="separator">&gt;</span>
             % if next_bus.number < order.high:
-                <a href="{{ get_url(system, f'bus/{next_bus.number}') }}" class="bus">{{ next_bus }}</a>
+                 % include('components/bus', bus=next_bus)
                 <span class="separator">&gt;&gt;&gt;</span>
             % end
-            <a href="{{ get_url(system, f'bus/{last_bus.number}') }}" class="bus">{{ last_bus }}</a>
+            % include('components/bus', bus=last_bus)
         % end
     </div>
 </div>

--- a/views/components/route_indicator.tpl
+++ b/views/components/route_indicator.tpl
@@ -6,9 +6,7 @@
             <span class="route-number" style="background-color: #{{ route.colour }};">{{ route.number }}</span>
         % end
         % if get('include_tooltip', False):
-            <div class="tooltip">
-                <div class="title">{{ route }}</div>
-            </div>
+            <div class="tooltip">{{ route }}</div>
         % end
     </span>
 % end

--- a/views/pages/admin.tpl
+++ b/views/pages/admin.tpl
@@ -13,6 +13,10 @@
         </div>
         <div class="content">
             <div class="button-container">
+                <div class="button" onclick="reloadAdornments()">Reload Adornments</div>
+                <div class="button" onclick="reloadOrders()">Reload Orders</div>
+                <div class="button" onclick="reloadSystems()">Reload Systems</div>
+                <div class="button" onclick="reloadThemes()">Reload Themes</div>
                 <div class="button" onclick="restartCron()">Restart Cron</div>
                 <div class="button" onclick="backupDatabase()">Backup Database</div>
             </div>
@@ -99,6 +103,46 @@
 <script>
     let adminKey
     let systemID
+    
+    function reloadAdornments() {
+        const request = new XMLHttpRequest();
+        if (adminKey == null) {
+            request.open("POST", getUrl(systemID, "api/admin/reload-adornments"), true);
+        } else {
+            request.open("POST", getUrl(systemID, "api/admin/" + adminKey + "/reload-adornments"), true);
+        }
+        request.send();
+    }
+    
+    function reloadOrders() {
+        const request = new XMLHttpRequest();
+        if (adminKey == null) {
+            request.open("POST", getUrl(systemID, "api/admin/reload-orders"), true);
+        } else {
+            request.open("POST", getUrl(systemID, "api/admin/" + adminKey + "/reload-orders"), true);
+        }
+        request.send();
+    }
+    
+    function reloadSystems() {
+        const request = new XMLHttpRequest();
+        if (adminKey == null) {
+            request.open("POST", getUrl(systemID, "api/admin/reload-systems"), true);
+        } else {
+            request.open("POST", getUrl(systemID, "api/admin/" + adminKey + "/reload-systems"), true);
+        }
+        request.send();
+    }
+    
+    function reloadThemes() {
+        const request = new XMLHttpRequest();
+        if (adminKey == null) {
+            request.open("POST", getUrl(systemID, "api/admin/reload-themes"), true);
+        } else {
+            request.open("POST", getUrl(systemID, "api/admin/" + adminKey + "/reload-themes"), true);
+        }
+        request.send();
+    }
     
     function restartCron() {
         const request = new XMLHttpRequest();

--- a/views/pages/block/history.tpl
+++ b/views/pages/block/history.tpl
@@ -84,28 +84,16 @@
                                         <td>
                                             <div class="flex-column">
                                                 <div class="flex-row left">
-                                                    % if bus.is_known:
-                                                        <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                                                    % else:
-                                                        <span>{{ bus }}</span>
-                                                    % end
+                                                    % include('components/bus', bus=bus)
                                                     % include('components/record_warnings_indicator', record=record)
                                                 </div>
                                                 <span class="non-desktop smaller-font">
-                                                    % if order is None:
-                                                        <span class="lighter-text">Unknown Year/Model</span>
-                                                    % else:
-                                                        {{! order }}
-                                                    % end
+                                                    % include('components/order', order=order)
                                                 </span>
                                             </div>
                                         </td>
                                         <td class="desktop-only">
-                                            % if order is None:
-                                                <span class="lighter-text">Unknown Year/Model</span>
-                                            % else:
-                                                {{! order }}
-                                            % end
+                                            % include('components/order', order=order)
                                         </td>
                                         <td class="non-mobile">{{ record.first_seen.format_web(time_format) }}</td>
                                         <td>{{ record.last_seen.format_web(time_format) }}</td>

--- a/views/pages/block/overview.tpl
+++ b/views/pages/block/overview.tpl
@@ -201,28 +201,16 @@
                                     <td>
                                         <div class="flex-column">
                                             <div class="flex-row left">
-                                                % if bus.is_known:
-                                                    <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                                                % else:
-                                                    <span>{{ bus }}</span>
-                                                % end
+                                                % include('components/bus', bus=bus)
                                                 % include('components/adherence_indicator', adherence=position.adherence)
                                             </div>
                                             <span class="non-desktop smaller-font">
-                                                % if order is None:
-                                                    <span class="lighter-text">Unknown Year/Model</span>
-                                                % else:
-                                                    {{! order }}
-                                                % end
+                                                % include('components/order', order=order)
                                             </span>
                                         </div>
                                     </td>
                                     <td class="desktop-only">
-                                        % if order is None:
-                                            <span class="lighter-text">Unknown Year/Model</span>
-                                        % else:
-                                            {{! order }}
-                                        % end
+                                        % include('components/order', order=order)
                                     </td>
                                     <td>
                                         <div class="flex-column">

--- a/views/pages/bus/history.tpl
+++ b/views/pages/bus/history.tpl
@@ -4,7 +4,10 @@
 % rebase('base')
 
 <div class="page-header">
-    <h1 class="title">Bus {{ bus }}</h1>
+    <h1 class="title flex-row">
+        <span>Bus</span>
+        % include('components/bus', bus=bus, enable_link=False)
+    </h1>
     <h2 class="subtitle">
         % if bus.order is None:
             <span class="lighter-text">Unknown Year/Model</span>

--- a/views/pages/bus/map.tpl
+++ b/views/pages/bus/map.tpl
@@ -2,7 +2,10 @@
 % rebase('base')
 
 <div class="page-header">
-    <h1 class="title">Bus {{ bus }}</h1>
+    <h1 class="title flex-row">
+        <span>Bus</span>
+        % include('components/bus', bus=bus, enable_link=False)
+    </h1>
     <h2 class="subtitle">
         % if bus.order is None:
             <span class="lighter-text">Unknown Year/Model</span>

--- a/views/pages/bus/overview.tpl
+++ b/views/pages/bus/overview.tpl
@@ -7,7 +7,10 @@
 % model = bus.model
 
 <div class="page-header">
-    <h1 class="title">Bus {{ bus }}</h1>
+    <h1 class="title flex-row">
+        <span>Bus</span>
+        % include('components/bus', bus=bus, enable_link=False)
+    </h1>
     <h2 class="subtitle">
         % if bus.order is None:
             <span class="lighter-text">Unknown Year/Model</span>

--- a/views/pages/history/first_seen.tpl
+++ b/views/pages/history/first_seen.tpl
@@ -49,26 +49,14 @@
                     </td>
                     <td>
                         <div class="flex-column">
-                            % if bus.is_known:
-                                <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                            % else:
-                                <span>{{ bus }}</span>
-                            % end
+                            % include('components/bus', bus=bus)
                             <span class="non-desktop smaller-font">
-                                % if order is None:
-                                    <span class="lighter-text">Unknown Year/Model</span>
-                                % else:
-                                    {{! order }}
-                                % end
+                                % include('components/order', order=order)
                             </span>
                         </div>
                     </td>
                     <td class="desktop-only">
-                        % if order is None:
-                            <span class="lighter-text">Unknown Year/Model</span>
-                        % else:
-                            {{! order }}
-                        % end
+                        % include('components/order', order=order)
                     </td>
                     % if system is None:
                         <td class="non-mobile">{{ record.system }}</td>

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -47,11 +47,7 @@
                     % bus = overview.bus
                     <tr>
                         <td>
-                            % if bus.is_known:
-                                <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                            % else:
-                                <span>{{ bus }}</span>
-                            % end
+                            % include('components/bus', bus=bus)
                         </td>
                         <td class="desktop-only">{{ record.date.format_long() }}</td>
                         <td class="non-desktop">
@@ -95,11 +91,7 @@
                     % bus = overview.bus
                     <tr>
                         <td>
-                            % if bus.is_known:
-                                <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                            % else:
-                                <span>{{ bus }}</span>
-                            % end
+                            % include('components/bus', bus=bus)
                         </td>
                         <td class="desktop-only">{{ record.date.format_long() }}</td>
                         <td class="non-desktop">

--- a/views/pages/history/transfers.tpl
+++ b/views/pages/history/transfers.tpl
@@ -45,26 +45,14 @@
                     <td class="non-desktop">{{ transfer.date.format_short() }}</td>
                     <td>
                         <div class="flex-column">
-                            % if bus.is_known:
-                                <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                            % else:
-                                <span>{{ bus }}</span>
-                            % end
+                            % include('components/bus', bus=bus)
                             <span class="non-desktop smaller-font">
-                                % if order is None:
-                                    <span class="lighter-text">Unknown Year/Model</span>
-                                % else:
-                                    {{! order }}
-                                % end
+                                % include('components/order', order=order)
                             </span>
                         </div>
                     </td>
                     <td class="desktop-only">
-                        % if order is None:
-                            <span class="lighter-text">Unknown Year/Model</span>
-                        % else:
-                            {{! order }}
-                        % end
+                        % include('components/order', order=order)
                     </td>
                     <td class="non-mobile">{{ transfer.old_system }}</td>
                     <td class="non-mobile">{{ transfer.new_system }}</td>

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -201,6 +201,10 @@
                     
                     title.innerHTML = position.bus_number;
                 }
+            
+                if (position.adornment != null) {
+                    title.innerHTML += " <span class='adornment'>" + position.adornment + "</span>";
+                }
                 
                 details.appendChild(title);
                 details.appendChild(content);

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -97,28 +97,16 @@
                                     <td>
                                         <div class="flex-column">
                                             <div class="flex-row left">
-                                                % if bus.is_known:
-                                                    <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                                                % else:
-                                                    <span>{{ bus }}</span>
-                                                % end
+                                                % include('components/bus', bus=bus)
                                                 % include('components/adherence_indicator', adherence=position.adherence)
                                             </div>
                                             <span class="non-desktop smaller-font">
-                                                % if order is None:
-                                                    <span class="lighter-text">Unknown Year/Model</span>
-                                                % else:
-                                                    {{! order }}
-                                                % end
+                                                % include('components/order', order=order)
                                             </span>
                                         </div>
                                     </td>
                                     <td class="desktop-only">
-                                        % if order is None:
-                                            <span class="lighter-text">Unknown Year/Model</span>
-                                        % else:
-                                            {{! order }}
-                                        % end
+                                        % include('components/order', order=order)
                                     </td>
                                     % if system is None:
                                         <td class="desktop-only">{{ position.system }}</td>
@@ -195,26 +183,14 @@
                                 <tr class="{{'' if same_order else 'divider'}}">
                                     <td>
                                         <div class="flex-column">
-                                            % if bus.is_known:
-                                                <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                                            % else:
-                                                <span>{{ bus }}</span>
-                                            % end
+                                            % include('components/bus', bus=bus)
                                             <span class="non-desktop smaller-font">
-                                                % if order is None:
-                                                    <span class="lighter-text">Unknown Year/Model</span>
-                                                % else:
-                                                    {{! order }}
-                                                % end
+                                                % include('components/order', order=order)
                                             </span>
                                         </div>
                                     </td>
                                     <td class="desktop-only">
-                                        % if order is None:
-                                            <span class="lighter-text">Unknown Year/Model</span>
-                                        % else:
-                                            {{! order }}
-                                        % end
+                                        % include('components/order', order=order)
                                     </td>
                                     % if system is None:
                                         <td>{{ position.system }}</td>

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -62,28 +62,16 @@
                     <td>
                         <div class="flex-column">
                             <div class="flex-row left">
-                                % if bus.is_known:
-                                    <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                                % else:
-                                    <span>{{ bus }}</span>
-                                % end
+                                % include('components/bus', bus=bus)
                                 % include('components/adherence_indicator', adherence=position.adherence)
                             </div>
                             <span class="non-desktop smaller-font">
-                                % if order is None:
-                                    <span class="lighter-text">Unknown Year/Model</span>
-                                % else:
-                                    {{! order }}
-                                % end
+                                % include('components/order', order=order)
                             </span>
                         </div>
                     </td>
                     <td class="desktop-only">
-                        % if order is None:
-                            <span class="lighter-text">Unknown Year/Model</span>
-                        % else:
-                            {{! order }}
-                        % end
+                        % include('components/order', order=order)
                     </td>
                     % if system is None:
                         <td class="desktop-only">{{ position.system }}</td>

--- a/views/pages/route/overview.tpl
+++ b/views/pages/route/overview.tpl
@@ -71,28 +71,16 @@
                                     <td>
                                         <div class="flex-column">
                                             <div class="flex-row left">
-                                                % if bus.is_known:
-                                                    <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                                                % else:
-                                                    <span>{{ bus }}</span>
-                                                % end
+                                                % include('components/bus', bus=bus)
                                                 % include('components/adherence_indicator', adherence=position.adherence)
                                             </div>
                                             <span class="non-desktop smaller-font">
-                                                % if order is None:
-                                                    <span class="lighter-text">Unknown Year/Model</span>
-                                                % else:
-                                                    {{! order }}
-                                                % end
+                                                % include('components/order', order=order)
                                             </span>
                                         </div>
                                     </td>
                                     <td class="desktop-only">
-                                        % if order is None:
-                                            <span class="lighter-text">Unknown Year/Model</span>
-                                        % else:
-                                            {{! order }}
-                                        % end
+                                        % include('components/order', order=order)
                                     </td>
                                     <td>
                                         <div class="flex-column">
@@ -191,31 +179,19 @@
                                                                 <td>
                                                                     <div class="flex-column">
                                                                         <div class="flex-row left">
-                                                                            % if bus.is_known:
-                                                                                <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                                                                            % else:
-                                                                                <span>{{ bus }}</span>
-                                                                            % end
+                                                                            % include('components/bus', bus=bus)
                                                                             % if trip.id in trip_positions:
                                                                                 % position = trip_positions[trip.id]
                                                                                 % include('components/adherence_indicator', adherence=position.adherence)
                                                                             % end
                                                                         </div>
                                                                         <span class="non-desktop smaller-font">
-                                                                            % if order is None:
-                                                                                <span class="lighter-text">Unknown Year/Model</span>
-                                                                            % else:
-                                                                                {{! order }}
-                                                                            % end
+                                                                            % include('components/order', order=order)
                                                                         </span>
                                                                     </div>
                                                                 </td>
                                                                 <td class="desktop-only">
-                                                                    % if order is None:
-                                                                        <span class="lighter-text">Unknown Year/Model</span>
-                                                                    % else:
-                                                                        {{! order }}
-                                                                    % end
+                                                                    % include('components/order', order=order)
                                                                 </td>
                                                             % elif trip.block_id in scheduled_today and trip.start_time.is_later:
                                                                 % bus = scheduled_today[trip.block_id]
@@ -223,34 +199,20 @@
                                                                 <td>
                                                                     <div class="flex-column">
                                                                         <div class="flex-row left">
-                                                                            % if bus.is_known:
-                                                                                <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                                                                            % else:
-                                                                                <span>{{ bus }}</span>
-                                                                            % end
+                                                                            % include('components/bus', bus=bus)
                                                                             <div class="tooltip-anchor">
                                                                                 <img class="middle-align white" src="/img/white/schedule.png" />
                                                                                 <img class="middle-align black" src="/img/black/schedule.png" />
-                                                                                <div class="tooltip">
-                                                                                    <div class="title">Bus is scheduled</div>
-                                                                                </div>
+                                                                                <div class="tooltip">Bus is scheduled</div>
                                                                             </div>
                                                                         </div>
                                                                         <span class="non-desktop smaller-font">
-                                                                            % if order is None:
-                                                                                <span class="lighter-text">Unknown Year/Model</span>
-                                                                            % else:
-                                                                                {{! order }}
-                                                                            % end
+                                                                            % include('components/order', order=order)
                                                                         </span>
                                                                     </div>
                                                                 </td>
                                                                 <td class="desktop-only">
-                                                                    % if order is None:
-                                                                        <span class="lighter-text">Unknown Year/Model</span>
-                                                                    % else:
-                                                                        {{! order }}
-                                                                    % end
+                                                                    % include('components/order', order=order)
                                                                 </td>
                                                             % else:
                                                                 <td class="desktop-only lighter-text" colspan="2">Unavailable</td>

--- a/views/pages/trip/history.tpl
+++ b/views/pages/trip/history.tpl
@@ -85,28 +85,16 @@
                                         <td>
                                             <div class="flex-column">
                                                 <div class="flex-row left">
-                                                    % if bus.is_known:
-                                                        <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                                                    % else:
-                                                        <span>{{ bus }}</span>
-                                                    % end
+                                                    % include('components/bus', bus=bus)
                                                     % include('components/record_warnings_indicator', record=record)
                                                 </div>
                                                 <span class="non-desktop smaller-font">
-                                                    % if order is None:
-                                                        <span class="lighter-text">Unknown Year/Model</span>
-                                                    % else:
-                                                        {{! order }}
-                                                    % end
+                                                    % include('components/order', order=order)
                                                 </span>
                                             </div>
                                         </td>
                                         <td class="desktop-only">
-                                            % if order is None:
-                                                <span class="lighter-text">Unknown Year/Model</span>
-                                            % else:
-                                                {{! order }}
-                                            % end
+                                            % include('components/order', order=order)
                                         </td>
                                         <td class="non-mobile">{{ record.first_seen.format_web(time_format) }}</td>
                                         <td>{{ record.last_seen.format_web(time_format) }}</td>

--- a/views/pages/trip/overview.tpl
+++ b/views/pages/trip/overview.tpl
@@ -137,28 +137,16 @@
                                     <td>
                                         <div class="flex-column">
                                             <div class="flex-row left">
-                                                % if bus.is_known:
-                                                    <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                                                % else:
-                                                    <span>{{ bus }}</span>
-                                                % end
+                                                % include('components/bus', bus=bus)
                                                 % include('components/adherence_indicator', adherence=position.adherence)
                                             </div>
                                             <span class="mobile-only smaller-font">
-                                                % if order is None:
-                                                    <span class="lighter-text">Unknown Year/Model</span>
-                                                % else:
-                                                    {{! order }}
-                                                % end
+                                                % include('components/order', order=order)
                                             </span>
                                         </div>
                                     </td>
                                     <td class="non-mobile">
-                                        % if order is None:
-                                            <span class="lighter-text">Unknown Year/Model</span>
-                                        % else:
-                                            {{! order }}
-                                        % end
+                                        % include('components/order', order=order)
                                     </td>
                                     <td>
                                         % if stop is None:

--- a/views/rows/departure.tpl
+++ b/views/rows/departure.tpl
@@ -13,31 +13,19 @@
             <td>
                 <div class="flex-column">
                     <div class="flex-row left">
-                        % if bus.is_known:
-                            <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                        % else:
-                            <span>{{ bus }}</span>
-                        % end
+                        % include('components/bus', bus=bus)
                         % if trip.id in positions:
                             % position = positions[trip.id]
                             % include('components/adherence_indicator', adherence=position.adherence)
                         % end
                     </div>
                     <span class="non-desktop smaller-font">
-                        % if order is None:
-                            <span class="lighter-text">Unknown Year/Model</span>
-                        % else:
-                            {{! order }}
-                        % end
+                        % include('components/order', order=order)
                     </span>
                 </div>
             </td>
             <td class="desktop-only">
-                % if order is None:
-                    <span class="lighter-text">Unknown Year/Model</span>
-                % else:
-                    {{! order }}
-                % end
+                % include('components/order', order=order)
             </td>
         % elif trip.block_id in scheduled_today and trip.start_time.is_later:
             % bus = scheduled_today[trip.block_id]
@@ -45,34 +33,20 @@
             <td>
                 <div class="flex-column">
                     <div class="flex-row left">
-                        % if bus.is_known:
-                            <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                        % else:
-                            <span>{{ bus }}</span>
-                        % end
+                        % include('components/bus', bus=bus)
                         <div class="tooltip-anchor">
                             <img class="middle-align white" src="/img/white/schedule.png" />
                             <img class="middle-align black" src="/img/black/schedule.png" />
-                            <div class="tooltip">
-                                <div class="title">Bus is scheduled</div>
-                            </div>
+                            <div class="tooltip">Bus is scheduled</div>
                         </div>
                     </div>
                     <span class="non-desktop smaller-font">
-                        % if order is None:
-                            <span class="lighter-text">Unknown Year/Model</span>
-                        % else:
-                            {{! order }}
-                        % end
+                        % include('components/order', order=order)
                     </span>
                 </div>
             </td>
             <td class="desktop-only">
-                % if order is None:
-                    <span class="lighter-text">Unknown Year/Model</span>
-                % else:
-                    {{! order }}
-                % end
+                % include('components/order', order=order)
             </td>
         % else:
             <td class="desktop-only lighter-text" colspan="2">Unavailable</td>

--- a/views/rows/realtime.tpl
+++ b/views/rows/realtime.tpl
@@ -6,11 +6,7 @@
     <td>
         <div class="flex-column">
             <div class="flex-row left">
-                % if bus.is_known:
-                    <a href="{{ get_url(system, f'bus/{bus.number}') }}">{{ bus }}</a>
-                % else:
-                    <span>{{ bus }}</span>
-                % end
+                % include('components/bus', bus=bus)
                 % include('components/adherence_indicator', adherence=position.adherence)
             </div>
             % if system is None:


### PR DESCRIPTION
Adds support for adornments, which are text (primarily intended to be emojis) shown after specific bus numbers. Includes support for descriptions that can be shown in tooltips on hover.

Another major addition is support for reloading any static data, including adornments, orders (+ models), systems (+ regions), and themes. This allows us to make changes to the static CSV files and get those changes live on the site without having to restart the server.

Makes some other minor adjustments, including removing title classes from some tooltips where unnecessary, and adding bus/order components to reduce duplication.