### PR TITLE
Order iteration improvements

### DIFF
--- a/helpers/order.py
+++ b/helpers/order.py
@@ -1,8 +1,6 @@
 
 import csv
 
-import helpers.adornment
-
 from models.match import Match
 from models.order import Order
 
@@ -36,19 +34,19 @@ def find_matches(query, recorded_bus_numbers):
         if order.is_test:
             continue
         order_string = str(order)
-        for bus_number in order.range:
-            bus_number_string = f'{bus_number:04d}'
-            adornment = helpers.adornment.find(bus_number)
-            if adornment is not None and adornment.enabled:
-                bus_number_string += f' {adornment}'
+        for bus in order:
+            bus_number_string = str(bus)
             value = 0
             if query in bus_number_string:
                 value += (len(query) / len(bus_number_string)) * 100
                 if bus_number_string.startswith(query):
                     value += len(query)
-            if bus_number not in recorded_bus_numbers:
+            if bus.number not in recorded_bus_numbers:
                 value /= 10
-            matches.append(Match('bus', bus_number_string, order_string, f'bus/{bus_number}', value))
+            adornment = bus.adornment
+            if adornment is not None and adornment.enabled:
+                bus_number_string += f' {adornment}'
+            matches.append(Match('bus', bus_number_string, order_string, f'bus/{bus.number}', value))
     return matches
 
 def delete_all():

--- a/models/bus.py
+++ b/models/bus.py
@@ -7,10 +7,16 @@ class Bus:
     
     __slots__ = ('number', 'order', 'adornment')
     
-    def __init__(self, bus_number):
-        self.number = bus_number
-        self.order = helpers.order.find(bus_number)
-        self.adornment = helpers.adornment.find(bus_number)
+    def __init__(self, number, order=None, adornment=None):
+        self.number = number
+        if order is None:
+            self.order = helpers.order.find(number)
+        else:
+            self.order = order
+        if adornment is None:
+            self.adornment = helpers.adornment.find(number)
+        else:
+            self.adornment = adornment
     
     def __str__(self):
         if self.is_known:

--- a/models/order.py
+++ b/models/order.py
@@ -48,6 +48,11 @@ class Order:
     def __lt__(self, other):
         return self.low < other.low
     
+    def __iter__(self):
+        for number in range(self.low, self.high + 1):
+            if number not in self.exceptions:
+                yield Bus(number, order=self)
+    
     @property
     def is_test(self):
         model = self.model
@@ -56,19 +61,14 @@ class Order:
         return model.is_test
     
     @property
-    def range(self):
-        '''The full range of every bus in the order'''
-        return (n for n in range(self.low, self.high + 1) if n not in self.exceptions)
-    
-    @property
     def first_bus(self):
         '''The first bus in the order'''
-        return Bus(self.low)
+        return Bus(self.low, order=self)
     
     @property
     def last_bus(self):
         '''The last bus in the order'''
-        return Bus(self.high)
+        return Bus(self.high, order=self)
     
     def previous_bus(self, bus_number):
         '''The previous bus before the given bus number'''
@@ -77,7 +77,7 @@ class Order:
         previous_bus_number = bus_number - 1
         if previous_bus_number in self.exceptions:
             return self.previous_bus(previous_bus_number)
-        return Bus(previous_bus_number)
+        return Bus(previous_bus_number, order=self)
     
     def next_bus(self, bus_number):
         '''The next bus following the given bus number'''
@@ -86,7 +86,7 @@ class Order:
         next_bus_number = bus_number + 1
         if next_bus_number in self.exceptions:
             return self.next_bus(next_bus_number)
-        return Bus(next_bus_number)
+        return Bus(next_bus_number, order=self)
     
     def contains(self, bus_number):
         '''Checks if this order contains the given bus number'''

--- a/views/pages/fleet.tpl
+++ b/views/pages/fleet.tpl
@@ -110,13 +110,12 @@
                                                     </td>
                                                 </tr>
                                                 <tr class="display-none"></tr>
-                                                % for number in order.range:
-                                                    % bus_number = f'{number:04d}'
-                                                    % if number in overviews:
-                                                        % overview = overviews[number]
+                                                % for bus in order:
+                                                    % if bus.number in overviews:
+                                                        % overview = overviews[bus.number]
                                                         <tr>
                                                             <td>
-                                                                <a href="{{ get_url(system, f'bus/{number}') }}">{{ bus_number }}</a>
+                                                                % include('components/bus', bus=bus)
                                                             </td>
                                                             <td class="desktop-only">{{ overview.first_seen_date.format_long() }}</td>
                                                             <td class="non-desktop">
@@ -137,7 +136,9 @@
                                                         </tr>
                                                     % else:
                                                         <tr>
-                                                            <td>{{ bus_number }}</td>
+                                                            <td>
+                                                                % include('components/bus', bus=bus, enable_link=False)
+                                                            </td>
                                                             <td class="lighter-text" colspan="4">Unavailable</td>
                                                         </tr>
                                                     % end


### PR DESCRIPTION
Adds the ability to iterate over buses in an order directly, rather than iterating over the numbers. This simplifies logic in numerous places, and also fixes an issue where adornments were not shown on the fleet list page.