### PR TITLE
Transfer improvements

### DIFF
--- a/realtime.py
+++ b/realtime.py
@@ -77,8 +77,6 @@ def update_records():
                     block = trip.block
                     if overview is not None and overview.last_record is not None:
                         last_record = overview.last_record
-                        if last_record.system != system and bus.visible:
-                            helpers.transfer.create(bus, date, last_record.system, system)
                         if last_record.date == date and last_record.block_id == block.id:
                             helpers.record.update(last_record.id, time)
                             trip_ids = helpers.record.find_trip_ids(last_record)
@@ -90,6 +88,8 @@ def update_records():
                     helpers.overview.create(bus, date, system, record_id)
                 else:
                     helpers.overview.update(overview, date, system, record_id)
+                    if overview.last_seen_system != system:
+                        helpers.transfer.create(bus, date, overview.last_seen_system, system)
             except Exception as e:
                 print(f'Failed to update records: {e}')
         database.commit()

--- a/server.py
+++ b/server.py
@@ -468,10 +468,11 @@ def history_first_seen_page(system_id=None):
     '/<system_id>/history/transfers/'
 ])
 def history_transfers_page(system_id=None):
+    transfers = helpers.transfer.find_all(system_id)
     return page('history/transfers', system_id,
         title='Vehicle History',
         path='history/transfers',
-        transfers=helpers.transfer.find_all(system_id)
+        transfers=[t for t in transfers if t.bus.visible]
     )
 
 @app.get([


### PR DESCRIPTION
Transfers are now created as soon as the bus appears in the feed for a different system, instead of the first time it logs into a trip in the new system. This means that the transfer is created quicker, and is created for buses that don't enter service at all. This behaviour is consistent with the discord bot, which sends a transfer alert as soon as a new system is detected.

Also, transfers are now created for buses that are hidden. When viewing the list of transfers, hidden buses are removed.