### PR TITLE
Update maps provider from MapBox to OpenLayers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Also has been tested and confirmed to work on macOS.
 Not tested on Windows.
 Requires roughly Python 3.7 or higher, and pip.
 
-Uses the Bottle framework for web stuff and templates, and maps are done with MapBox.
+Uses the [Bottle](https://bottlepy.org) framework for web stuff and templates, and maps are done with [OpenLayers](https://openlayers.org).
 
 Before running the server, some configuration needs to be set up first by following the steps in the Configuration section below.
 Once you've done that, run `setup.sh` to install packages and create directories, and then run `start.py` to load up the server.
@@ -117,12 +117,6 @@ cookie_domain: 'example.com'
 ```
 
 ### Key Configuration
-
-In order to display maps, BCTracker **requires** a MapBox API Key:
-
-```
-mapbox_api_key: '<key>'
-```
 
 If analytics is enabled (see below), a Google Analytics tag must be included:
 

--- a/config.py
+++ b/config.py
@@ -10,7 +10,6 @@ system_domain_path = None
 cookie_domain = None
 
 # Key config
-mapbox_api_key = None
 analytics_key = None
 
 # Functionality config
@@ -30,8 +29,7 @@ def setup(config):
     system_domain_path = config['system_domain_path']
     cookie_domain = config.get('cookie_domain')
     
-    global mapbox_api_key, analytics_key
-    mapbox_api_key = config['mapbox_api_key']
+    global analytics_key
     analytics_key = config.get('analytics_key')
     
     global enable_analytics, enable_gtfs_backups, enable_realtime_backups, enable_database_backups

--- a/models/theme.py
+++ b/models/theme.py
@@ -5,7 +5,6 @@ class Theme:
     __slots__ = (
         'id',
         'name',
-        'map_style',
         'visible'
     )
     
@@ -14,14 +13,12 @@ class Theme:
         '''Returns a theme initialized from the given CSV row'''
         id = row['id']
         name = row['name']
-        map_style = row['map_style']
         visible = row['visible'] == '1'
-        return cls(id, name, map_style, visible)
+        return cls(id, name, visible)
     
-    def __init__(self, id, name, map_style, visible):
+    def __init__(self, id, name, visible):
         self.id = id
         self.name = name
-        self.map_style = map_style
         self.visible = visible
     
     def __str__(self):

--- a/server.py
+++ b/server.py
@@ -257,7 +257,7 @@ def map_page(system):
         path='map',
         include_maps=len(visible_positions) > 0,
         full_map=len(visible_positions) > 0,
-        positions=sorted(positions, key=lambda p: p.lat, reverse=True),
+        positions=sorted(positions, key=lambda p: p.lat),
         show_nis=show_nis,
         visible_positions=visible_positions
     )
@@ -832,7 +832,7 @@ def api_map(system):
         last_updated = realtime.get_last_updated(time_format)
     else:
         last_updated = system.get_last_updated(time_format)
-    positions = sorted(helpers.position.find_all(system, has_location=True), key=lambda p: p.lat, reverse=True)
+    positions = sorted(helpers.position.find_all(system, has_location=True), key=lambda p: p.lat)
     return {
         'positions': [p.get_json() for p in positions],
         'last_updated': last_updated

--- a/static/themes.csv
+++ b/static/themes.csv
@@ -1,11 +1,11 @@
-id,name,visible,map_style
-light,BC Transit (Light),1,light-v10
-dark,BC Transit (Dark),1,dark-v10
-classic,BC Transit Classic,1,light-v10
-bchydro,BC Hydro,1,light-v10
-uta,Urban Transit Authority,1,light-v10
-contrast,High Contrast,1,light-v10
-tcomm,T-Comm,0,streets-v11
-christmas,Christmas,0,streets-v11
-halloween,Halloween,0,dark-v10
-ghost,Ghost,0,light-v10
+id,name,visible
+light,BC Transit (Light),1,
+dark,BC Transit (Dark),1
+classic,BC Transit Classic,1
+bchydro,BC Hydro,1
+uta,Urban Transit Authority,1
+contrast,High Contrast,1
+tcomm,T-Comm,0
+christmas,Christmas,0
+halloween,Halloween,0
+ghost,Ghost,0

--- a/style/main.css
+++ b/style/main.css
@@ -147,11 +147,27 @@ ul {
     z-index: 30;
 }
 
+#map .ol-zoom {
+    top: unset;
+    bottom: 0.5em;
+}
+
+#map .ol-rotate {
+    top: unset;
+    right: unset;
+    left: 0.5em;
+    bottom: 4em;
+}
+
+#map .ol-touch .ol-rotate {
+    bottom: 5em;
+}
+
 #map-toggle {
     position: absolute;
     z-index: 10;
     border-radius: 50%;
-    bottom: 40px;
+    bottom: 30px;
     right: 15px;
 }
 

--- a/style/main.css
+++ b/style/main.css
@@ -638,6 +638,7 @@ ul {
 
 .marker {
     position: relative;
+    font-family: Helvetica, sans-serif;
 }
 
 .marker:hover {
@@ -831,6 +832,10 @@ ul {
 
 .no-wrap {
     white-space: nowrap;
+}
+
+.ol-overlay-container:hover {
+    z-index: 10;
 }
 
 .order-indicator .content {

--- a/style/themes/dark.css
+++ b/style/themes/dark.css
@@ -431,12 +431,17 @@ table.striped tr:nth-child(2n-1) {
 }
 
 .marker .details {
-    background-color: rgba(30, 30, 30, 0.8);
+    background-color: rgba(255, 255, 255, 0.8);
+    color: #000000;
+}
+
+.marker .details .lighter-text {
+    color: #666666;
 }
 
 .marker .icon {
     background-color: #276227;
-    border-color: #393939;
+    border-color: #FFFFFF;
 }
 
 .marker .icon.route .number {

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -431,12 +431,17 @@ table.striped tr:nth-child(2n-1) {
 }
 
 .marker .details {
-    background-color: rgba(30, 30, 30, 0.8);
+    background-color: rgba(255, 255, 255, 0.8);
+    color: #000000;
+}
+
+.marker .details .lighter-text {
+    color: #666666;
 }
 
 .marker .icon {
     background-color: #FF6C00;
-    border-color: #393939;
+    border-color: #FFFFFF;
 }
 
 .marker .icon.route .number {

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -51,34 +51,16 @@
         <link rel="stylesheet" media="screen and (min-width: 501px) and (max-width: 1000px)" href="/style/devices/tablet.css?version={{ version }}" />
         <link rel="stylesheet" media="screen and (max-width: 500px)" href="/style/devices/mobile.css?version={{ version }}" />
         
-        <script>
-            let mapStyle
-        </script>
-        
         % if theme is None:
             <link rel="stylesheet" media="screen and (prefers-color-scheme: light)" href="/style/themes/light.css?version={{ version }}" />
             <link rel="stylesheet" media="screen and (prefers-color-scheme: dark)" href="/style/themes/dark.css?version={{ version }}" />
-            <script>
-                if (window.matchMedia("screen and (prefers-color-scheme: light)").matches) {
-                    mapStyle = "mapbox://styles/mapbox/light-v10";
-                } else {
-                    mapStyle = "mapbox://styles/mapbox/dark-v10";
-                }
-            </script>
         % else:
             <link rel="stylesheet" href="/style/themes/{{ theme.id }}.css?version={{ version }}" />
-            <script>
-                mapStyle = "mapbox://styles/mapbox/{{ theme.map_style }}";
-            </script>
         % end
         
         % if include_maps:
-            <script src="https://api.mapbox.com/mapbox-gl-js/v1.11.1/mapbox-gl.js"></script>
-            <link href="https://api.mapbox.com/mapbox-gl-js/v1.11.1/mapbox-gl.css" rel="stylesheet" />
-            
-            <script>
-                mapboxgl.accessToken = "{{ config.mapbox_api_key }}";
-            </script>
+            <script src="https://cdn.jsdelivr.net/npm/ol@v8.2.0/dist/ol.js"></script>
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v8.2.0/ol.css">
         % end
         
         % if enable_refresh and (system is None or system.realtime_enabled):
@@ -564,7 +546,7 @@
             setCookie("hide_systems", "yes");
         }
         if (map !== undefined) {
-            map.resize();
+            map.updateSize();
         }
     }
 </script>

--- a/views/components/map.tpl
+++ b/views/components/map.tpl
@@ -315,7 +315,7 @@
         map.updateSize();
         if (lons.length === 1 && lats.length === 1) {
             map.getView().setCenter(ol.proj.fromLonLat([lons[0], lats[0]]));
-            map.getView().setZoom(14);
+            map.getView().setZoom(15);
         } else if (lons.length > 0 && lats.length > 0) {
             const minLon = Math.min.apply(Math, lons);
             const maxLon = Math.max.apply(Math, lons);

--- a/views/components/map.tpl
+++ b/views/components/map.tpl
@@ -21,7 +21,8 @@
         }),
         interactions: interactive ? ol.interaction.defaults.defaults() : [],
         controls: ol.control.defaults.defaults({
-            zoom: false
+            zoom: false,
+            rotate: false
         })
     });
     

--- a/views/components/map.tpl
+++ b/views/components/map.tpl
@@ -19,10 +19,12 @@
             zoom: 1,
             maxZoom: 22
         }),
-        interactions: interactive ? ol.interaction.defaults.defaults() : [],
+        interactions: interactive ? ol.interaction.defaults.defaults().extend([
+            new ol.interaction.DblClickDragZoom()
+        ]) : [],
         controls: ol.control.defaults.defaults({
-            zoom: false,
-            rotate: false
+            zoom: interactive,
+            rotate: interactive
         })
     });
     

--- a/views/components/map.tpl
+++ b/views/components/map.tpl
@@ -17,7 +17,7 @@
         view: new ol.View({
             center: [0, 0],
             zoom: 1,
-            maxZoom: 18
+            maxZoom: 22
         }),
         interactions: interactive ? ol.interaction.defaults.defaults() : [],
         controls: ol.control.defaults.defaults({

--- a/views/components/map_toggle.tpl
+++ b/views/components/map_toggle.tpl
@@ -18,7 +18,7 @@
             whiteIconElement.src = "/img/white/open-fullscreen.png";
             blackIconElement.src = "/img/black/open-fullscreen.png";
         }
-        map.resize();
+        map.updateSize();
     }
 </script>
 

--- a/views/pages/home.tpl
+++ b/views/pages/home.tpl
@@ -169,6 +169,33 @@
                 <div class="container">
                     <div class="news-post">
                         <div class="header">
+                            <h3>Change to Maps</h3>
+                            January 27, 2024
+                        </div>
+                        <div class="content">
+                            <p>
+                                Hi everyone, quick announcement about some changes to the map screens.
+                                After Victoria's NextRide website was shut down last week, we've seen some big increases to how much our site is being used (which is great to see - welcome newcomers!!).
+                                The downside is the increase in site visits has put us well over the threshold for unpaid MapBox usage, and racked up some not-insignificant fees.
+                                As a one-time thing that's not a problem, but we'd rather not be paying double for maps what we pay for the rest of the website hosting every month.
+                            </p>
+                            <p>
+                                As a result, we've decided to change the provider of our maps from MapBox to OpenLayers.
+                                If you've used the T-Comm site for Vancouver before this should look familiar - it uses the same OpenStreetMaps source.
+                                Overall everything should work more or less the same, with a couple of exceptions:
+                            </p>
+                            <ul>
+                                <li>The appearance of the map is now different, no longer as minimalist and no longer light/dark mode-dependent</li>
+                                <li>The geotracker for your current location, which was built-in with MapBox, is no longer available</li>
+                            </ul>
+                            <p>
+                                Down the road as we get more used to this provider we hope to be able to undo those changes to get maps as close to how they used to be as possible.
+                                For now we thank you for your patience and understanding!
+                            </p>
+                        </div>
+                    </div>
+                    <div class="news-post">
+                        <div class="header">
                             <h3>Winter Update</h3>
                             January 14, 2024
                         </div>
@@ -234,30 +261,6 @@
                             <p>
                                 TL;DR - we've added some cool stuff and we're looking forward to adding more cool stuff!
                                 Happy New Year to everyone and, as always, stay safe out there!
-                            </p>
-                        </div>
-                    </div>
-                    <div class="news-post">
-                        <div class="header">
-                            <h3>BCTracker Survey</h3>
-                            December 18, 2023
-                        </div>
-                        <div class="content">
-                            <p>
-                                We're running a quick survey over the next few weeks to get a better sense of who is using BCTracker, and for what purpose.
-                                This information will help us understand what new features should have the highest priority, as well as what improvements can be made to existing features.
-                                It's also a great opportunity for you to give us general feedback about things you like and things you think could be better.
-                            </p>
-                            <p>
-                                If you've been here long enough, you may remember a similar survey we ran in 2021.
-                                It was very helpful for us and since then we've addressed nearly every suggestion and request!
-                            </p>
-                            <p>
-                                If you have a couple spare minutes, we would very much appreciate hearing from you.
-                                Thanks for supporting BCTracker!
-                            </p>
-                            <p>
-                                <button class="button survey-button" onclick="openSurvey()">Take the survey!</button>
                             </p>
                         </div>
                     </div>

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -106,7 +106,8 @@
                 maxZoom: 22
             }),
             controls: ol.control.defaults.defaults({
-                zoom: false
+                zoom: false,
+                rotate: false
             })
         });
         

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -280,7 +280,7 @@
             if (resetCoordinates) {
                 if (lons.length === 1 && lats.length === 1) {
                     map.getView().setCenter(ol.proj.fromLonLat([lons[0], lats[0]]));
-                    map.getView().setZoom(14);
+                    map.getView().setZoom(15);
                 } else if (lons.length > 0 && lats.length > 0) {
                     const minLon = Math.min.apply(Math, lons);
                     const maxLon = Math.max.apply(Math, lons);

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -105,10 +105,9 @@
                 zoom: 1,
                 maxZoom: 22
             }),
-            controls: ol.control.defaults.defaults({
-                zoom: false,
-                rotate: false
-            })
+            interactions: ol.interaction.defaults.defaults().extend([
+                new ol.interaction.DblClickDragZoom()
+            ])
         });
         
         let positions = JSON.parse('{{! json.dumps([p.get_json() for p in positions]) }}');

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -152,7 +152,7 @@
                 if (position.shape_id === null || position.shape_id === undefined) {
                     element.classList.add("nis-bus");
                     if (!showNISBuses) {
-                        element.classList.add("hidden");
+                        element.classList.add("display-none");
                     }
                 }
                 if (position.bearing !== undefined) {
@@ -335,9 +335,9 @@
             
             for (const element of document.getElementsByClassName("nis-bus")) {
                 if (showNISBuses) {
-                    element.classList.remove("hidden");
+                    element.classList.remove("display-none");
                 } else {
-                    element.classList.add("hidden");
+                    element.classList.add("display-none");
                 }
             }
         }

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -93,44 +93,45 @@
     <div id="map" class="full-screen"></div>
     
     <script>
-        const map = new mapboxgl.Map({
-            container: "map",
-            center: [0, 0],
-            zoom: 1,
-            style: mapStyle
-        });
-        
-        map.addControl(
-            new mapboxgl.GeolocateControl({
-                positionOptions: {
-                    enableHighAccuracy: true
-                },
-                trackUserLocation: true,
-                showUserHeading: true
+        const map = new ol.Map({
+            target: 'map',
+            layers: [
+                new ol.layer.Tile({
+                    source: new ol.source.OSM(),
+                }),
+            ],
+            view: new ol.View({
+                center: [0, 0],
+                zoom: 1,
+                maxZoom: 18
             }),
-            'bottom-left'
-        );
+            controls: ol.control.defaults.defaults({
+                zoom: false
+            })
+        });
         
         let positions = JSON.parse('{{! json.dumps([p.get_json() for p in positions]) }}');
         let currentShapeIDs = [];
         let markers = [];
+        let routeLayers = {};
         let tripLinesVisible = false;
         let automaticRefresh = false;
         let showNISBuses = "{{ show_nis }}" !== "False";
         let hoverPosition = null;
         const busMarkerStyle = "{{ bus_marker_style }}";
         
-        const shapeIDs = [];
+        const shapes = {};
         
-        map.on("load", function() {
-            map.resize();
-            updateMap(true);
-        })
+        document.body.onload = function() {
+            map.updateSize();
+        }
+        
+        updateMap(true);
         
         function updateMap(resetCoordinates) {
             currentShapeIDs = [];
             for (const marker of markers) {
-                marker.remove();
+                map.removeOverlay(marker);
             }
             markers = [];
             
@@ -266,32 +267,37 @@
                     lats.push(position.lat);
                 }
                 
-                markers.push(new mapboxgl.Marker(element).setLngLat([position.lon, position.lat]).addTo(map));
+                const marker = new ol.Overlay({
+                    position: ol.proj.fromLonLat([position.lon, position.lat]),
+                    positioning: 'center-center',
+                    element: element,
+                    stopEvent: false,
+                });
+                map.addOverlay(marker);
+                markers.push(marker);
             }
             
             if (resetCoordinates) {
                 if (lons.length === 1 && lats.length === 1) {
-                    map.jumpTo({
-                        center: [lons[0], lats[0]],
-                        zoom: 14
-                    });
+                    map.getView().setCenter(ol.proj.fromLonLat([lons[0], lats[0]]));
+                    map.getView().setZoom(14);
                 } else if (lons.length > 0 && lats.length > 0) {
                     const minLon = Math.min.apply(Math, lons);
                     const maxLon = Math.max.apply(Math, lons);
                     const minLat = Math.min.apply(Math, lats);
                     const maxLat = Math.max.apply(Math, lats);
-                    map.fitBounds([[minLon, minLat], [maxLon, maxLat]], {
-                        duration: 0,
-                        padding: 100
+                    
+                    map.getView().fit(ol.proj.transformExtent([minLon, minLat, maxLon, maxLat], ol.proj.get("EPSG:4326"), ol.proj.get("EPSG:3857")), {
+                        padding: [100, 100, 100, 100]
                     });
                 }
             }
             
-            for (const shapeID of shapeIDs) {
+            for (const shapeID in shapes) {
                 if (currentShapeIDs.includes(shapeID)) {
-                    map.setLayoutProperty(shapeID, "visibility", tripLinesVisible ? "visible" : "none");
+                    shapes[shapeID].setVisible(tripLinesVisible);
                 } else {
-                    map.setLayoutProperty(shapeID, "visibility", "none");
+                    shapes[shapeID].setVisible(false);
                 }
             }
         }
@@ -302,8 +308,8 @@
             checkboxImage.classList.toggle("hidden");
             
             for (const shapeID of currentShapeIDs) {
-                if (shapeIDs.includes(shapeID)) {
-                    map.setLayoutProperty(shapeID, "visibility", tripLinesVisible ? "visible" : "none");
+                if (shapeID in shapes) {
+                    shapes[shapeID].setVisible(tripLinesVisible);
                 }
             }
             if (tripLinesVisible) {
@@ -363,7 +369,7 @@
                     continue;
                 }
                 const shapeID = position.system_id + "_" + position.shape_id
-                if (shapeIDs.includes(shapeID)) {
+                if (shapeID in shapes) {
                     continue;
                 }
                 const request = new XMLHttpRequest();
@@ -371,36 +377,32 @@
                 request.responseType = "json";
                 request.onload = function() {
                     if (request.status === 200) {
-                        if (shapeIDs.includes(shapeID)) {
-                            map.setLayoutProperty(shapeID, "visibility", "visible");
+                        if (shapeID in shapes) {
+                            shapes[shapeID].setVisible(tripLinesVisible);
                         } else {
-                            shapeIDs.push(shapeID);
-                            map.addSource(shapeID, {
-                                'type': 'geojson',
-                                'data': {
-                                    'type': 'Feature',
-                                    'properties': {},
-                                    'geometry': {
-                                        'type': 'LineString',
-                                        'coordinates': request.response.points.map(function (point) { return [point.lon, point.lat] })
-                                    }
-                                }
-                            });
-                            map.addLayer({
-                                'id': shapeID,
-                                'type': 'line',
-                                'source': shapeID,
-                                'minzoom': 8,
-                                'layout': {
-                                    'line-join': 'round',
-                                    'line-cap': 'round',
-                                    'visibility':  tripLinesVisible ? 'visible' : 'none'
-                                },
-                                'paint': {
-                                    'line-color': '#' + position.colour,
-                                    'line-width': 4
-                                }
-                            });
+                            const layer = new ol.layer.Vector({
+                                source: new ol.source.Vector({
+                                    features: [
+                                        new ol.Feature({
+                                            geometry: new ol.geom.LineString(request.response.points.map(function (point) {
+                                                return ol.proj.fromLonLat([point.lon, point.lat])
+                                            })),
+                                            name: shapeID
+                                        })
+                                    ],
+                                    wrapX: false
+                                }),
+                                style: new ol.style.Style({
+                                    stroke: new ol.style.Stroke({
+                                        color: "#" + position.colour,
+                                        width: 4,
+                                        lineCap: "butt"
+                                    })
+                                }),
+                                visible: tripLinesVisible
+                            })
+                            shapes[shapeID] = layer;
+                            map.addLayer(layer);
                         }
                     }
                 };
@@ -414,8 +416,8 @@
             }
             if (hoverPosition !== null) {
                 const shapeID = hoverPosition.system_id + "_" + hoverPosition.shape_id
-                if (shapeIDs.includes(shapeID)) {
-                    map.setLayoutProperty(shapeID, "visibility", "none");
+                if (shapeID in shapes) {
+                    shapes[shapeID].setVisible(false);
                 }
             }
             if (position !== null) {
@@ -423,44 +425,40 @@
                     return;
                 }
                 const shapeID = position.system_id + "_" + position.shape_id
-                if (shapeIDs.includes(shapeID)) {
-                    map.setLayoutProperty(shapeID, "visibility", "visible");
+                if (shapeID in shapes) {
+                    shapes[shapeID].setVisible(true);
                 } else {
                     const request = new XMLHttpRequest();
                     request.open("GET", getUrl(position.system_id, "api/shape/" + position.shape_id + ".json"), true);
                     request.responseType = "json";
                     request.onload = function() {
                         if (request.status === 200) {
-                            if (shapeIDs.includes(shapeID)) {
-                                map.setLayoutProperty(shapeID, "visibility", "visible");
+                            if (shapeID in shapes) {
+                                shapes[shapeID].setVisible(shapeID, hoverPosition == position);
                             } else {
-                                shapeIDs.push(shapeID);
-                                map.addSource(shapeID, {
-                                    'type': 'geojson',
-                                    'data': {
-                                        'type': 'Feature',
-                                        'properties': {},
-                                        'geometry': {
-                                            'type': 'LineString',
-                                            'coordinates': request.response.points.map(function (point) { return [point.lon, point.lat] })
-                                        }
-                                    }
-                                });
-                                map.addLayer({
-                                    'id': shapeID,
-                                    'type': 'line',
-                                    'source': shapeID,
-                                    'minzoom': 8,
-                                    'layout': {
-                                        'line-join': 'round',
-                                        'line-cap': 'round',
-                                        'visibility': (hoverPosition === position) ? 'visible' : 'none'
-                                    },
-                                    'paint': {
-                                        'line-color': '#' + position.colour,
-                                        'line-width': 4
-                                    }
-                                });
+                                const layer = new ol.layer.Vector({
+                                    source: new ol.source.Vector({
+                                        features: [
+                                            new ol.Feature({
+                                                geometry: new ol.geom.LineString(request.response.points.map(function (point) {
+                                                    return ol.proj.fromLonLat([point.lon, point.lat])
+                                                })),
+                                                name: shapeID
+                                            })
+                                        ],
+                                        wrapX: false
+                                    }),
+                                    style: new ol.style.Style({
+                                        stroke: new ol.style.Stroke({
+                                            color: "#" + position.colour,
+                                            width: 4,
+                                            lineCap: "butt"
+                                        })
+                                    }),
+                                    visible: hoverPosition == position
+                                })
+                                shapes[shapeID] = layer;
+                                map.addLayer(layer);
                             }
                         }
                     };

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -103,7 +103,7 @@
             view: new ol.View({
                 center: [0, 0],
                 zoom: 1,
-                maxZoom: 18
+                maxZoom: 22
             }),
             controls: ol.control.defaults.defaults({
                 zoom: false

--- a/views/pages/nearby.tpl
+++ b/views/pages/nearby.tpl
@@ -90,12 +90,22 @@
 </div>
             
 <script>
-    const map = new mapboxgl.Map({
-        container: "map",
-        center: [0, 0],
-        zoom: 1,
-        style: mapStyle,
-        interactive: false
+    const map = new ol.Map({
+        target: 'map',
+        layers: [
+            new ol.layer.Tile({
+                source: new ol.source.OSM()
+            }),
+        ],
+        view: new ol.View({
+            center: [0, 0],
+            zoom: 1,
+            maxZoom: 18
+        }),
+        interactions: [],
+        controls: ol.control.defaults.defaults({
+            zoom: false
+        })
     });
     
     const systemSelected = "{{ system is not None }}" == "True";
@@ -120,7 +130,12 @@
         
         element.appendChild(icon);
         
-        new mapboxgl.Marker(element).setLngLat([lon, lat]).addTo(map);
+        map.addOverlay(new ol.Overlay({
+            position: ol.proj.fromLonLat([lon, lat]),
+            positioning: "center-center",
+            element: element,
+            stopEvent: false
+        }));
         
         updateMap();
         
@@ -186,7 +201,12 @@
                     element.appendChild(icon);
                     element.appendChild(details);
                     
-                    new mapboxgl.Marker(element).setLngLat([stop.lon, stop.lat]).addTo(map);
+                    map.addOverlay(new ol.Overlay({
+                        position: ol.proj.fromLonLat([stop.lon, stop.lat]),
+                        positioning: "center-center",
+                        element: element,
+                        stopEvent: false
+                    }));
                 }
             }
         };
@@ -226,18 +246,16 @@
         setStatus("error", "Error loading upcoming departures", "Location is not supported, make sure you're using a device that has GPS");
     }
     
-    map.on("load", function() {
-        map.resize();
+    document.body.onload = function() {
+        map.updateSize();
         updateMap();
-    });
+    }
     
     function updateMap() {
         if (lat !== null && lon !== null) {
             document.getElementById("current-location").classList.remove("display-none");
-            map.jumpTo({
-                center: [lon, lat],
-                zoom: 16
-            });
+            map.getView().setCenter(ol.proj.fromLonLat([lon, lat]));
+            map.getView().setZoom(17);
         }
     }
 </script>

--- a/views/pages/nearby.tpl
+++ b/views/pages/nearby.tpl
@@ -104,7 +104,8 @@
         }),
         interactions: [],
         controls: ol.control.defaults.defaults({
-            zoom: false
+            zoom: false,
+            rotate: false
         })
     });
     

--- a/views/pages/nearby.tpl
+++ b/views/pages/nearby.tpl
@@ -100,7 +100,7 @@
         view: new ol.View({
             center: [0, 0],
             zoom: 1,
-            maxZoom: 18
+            maxZoom: 22
         }),
         interactions: [],
         controls: ol.control.defaults.defaults({

--- a/views/pages/news.tpl
+++ b/views/pages/news.tpl
@@ -9,6 +9,30 @@
 <div class="container">
     <div class="news-post">
         <div class="header">
+            <h3>BCTracker Survey</h3>
+            December 18, 2023
+        </div>
+        <div class="content">
+            <p>
+                We're running a quick survey over the next few weeks to get a better sense of who is using BCTracker, and for what purpose.
+                This information will help us understand what new features should have the highest priority, as well as what improvements can be made to existing features.
+                It's also a great opportunity for you to give us general feedback about things you like and things you think could be better.
+            </p>
+            <p>
+                If you've been here long enough, you may remember a similar survey we ran in 2021.
+                It was very helpful for us and since then we've addressed nearly every suggestion and request!
+            </p>
+            <p>
+                If you have a couple spare minutes, we would very much appreciate hearing from you.
+                Thanks for supporting BCTracker!
+            </p>
+            <p>
+                <button class="button survey-button" onclick="openSurvey()">Take the survey!</button>
+            </p>
+        </div>
+    </div>
+    <div class="news-post">
+        <div class="header">
             <h3>Summer Update</h3>
             August 15, 2023
         </div>

--- a/views/pages/routes/map.tpl
+++ b/views/pages/routes/map.tpl
@@ -90,10 +90,9 @@
                     zoom: 1,
                     maxZoom: 22
                 }),
-                controls: ol.control.defaults.defaults({
-                    zoom: false,
-                    rotate: false
-                })
+                interactions: ol.interaction.defaults.defaults().extend([
+                    new ol.interaction.DblClickDragZoom()
+                ])
             });
             
             const lats = [];

--- a/views/pages/routes/map.tpl
+++ b/views/pages/routes/map.tpl
@@ -88,7 +88,7 @@
                 view: new ol.View({
                     center: [0, 0],
                     zoom: 1,
-                    maxZoom: 18
+                    maxZoom: 22
                 }),
                 controls: ol.control.defaults.defaults({
                     zoom: false

--- a/views/pages/routes/map.tpl
+++ b/views/pages/routes/map.tpl
@@ -78,24 +78,22 @@
         <div id="map" class="full-screen"></div>
         
         <script>
-            const map = new mapboxgl.Map({
-                container: "map",
-                center: [0, 0],
-                zoom: 1,
-                style: mapStyle,
-                interactive: true
-            });
-            
-            map.addControl(
-                new mapboxgl.GeolocateControl({
-                    positionOptions: {
-                        enableHighAccuracy: true
-                    },
-                    trackUserLocation: true,
-                    showUserHeading: true
+            const map = new ol.Map({
+                target: 'map',
+                layers: [
+                    new ol.layer.Tile({
+                        source: new ol.source.OSM(),
+                    }),
+                ],
+                view: new ol.View({
+                    center: [0, 0],
+                    zoom: 1,
+                    maxZoom: 18
                 }),
-                'bottom-left'
-            );
+                controls: ol.control.defaults.defaults({
+                    zoom: false
+                })
+            });
             
             const lats = [];
             const lons = [];
@@ -115,59 +113,53 @@
             <script>
                 const trips = JSON.parse('{{! json.dumps([t.get_json() for t in shape_trips]) }}');
                 
-                map.on("load", function() {
-                    for (const trip of trips) {
-                        const shapeID = String(trip.shape_id);
-                        map.addSource(shapeID, {
-                            "type": "geojson",
-                            "data": {
-                                "type": "Feature",
-                                "properties": {},
-                                "geometry": {
-                                    "type": "LineString",
-                                    "coordinates": trip.points.map(function (point) { return [point.lon, point.lat] })
-                                }
-                            }
-                        });
-                        map.addLayer({
-                            "id": shapeID,
-                            "type": "line",
-                            "source": shapeID,
-                            "layout": {
-                                "line-join": "round",
-                                "line-cap": "round"
-                            },
-                            "paint": {
-                                "line-color": "#" + trip.colour,
-                                "line-width": 4
-                            }
-                        });
-                        
-                        for (const point of trip.points) {
-                            lats.push(point.lat);
-                            lons.push(point.lon);
-                        }
+                for (const trip of trips) {
+                    map.addLayer(new ol.layer.Vector({
+                        source: new ol.source.Vector({
+                            features: [
+                                new ol.Feature({
+                                    geometry: new ol.geom.LineString(trip.points.map(function (point) {
+                                        return ol.proj.fromLonLat([point.lon, point.lat])
+                                    })),
+                                    name: String(trip.shape_id)
+                                })
+                            ],
+                            wrapX: false
+                        }),
+                        style: new ol.style.Style({
+                            stroke: new ol.style.Stroke({
+                                color: "#" + trip.colour,
+                                width: 4,
+                                lineCap: "butt"
+                            })
+                        })
+                    }));
+                    
+                    for (const point of trip.points) {
+                        lats.push(point.lat);
+                        lons.push(point.lon);
                     }
+                }
+                
+                document.body.onload = function() {
+                    map.updateSize();
                     if (lons.length === 1 && lats.length === 1) {
-                        map.jumpTo({
-                            center: [lons[0], lats[0]],
-                            zoom: 14
-                        });
-                    } else {
+                        map.getView().setCenter(ol.proj.fromLonLat([lons[0], lats[0]]));
+                        map.getView().setZoom(14);
+                    } else if (lons.length > 0 && lats.length > 0) {
                         const minLon = Math.min.apply(Math, lons);
                         const maxLon = Math.max.apply(Math, lons);
                         const minLat = Math.min.apply(Math, lats);
                         const maxLat = Math.max.apply(Math, lats);
                         
-                        map.fitBounds([[minLon, minLat], [maxLon, maxLat]], {
-                            duration: 0,
-                            padding: 100
-                        });
+                        map.getView().fit(ol.proj.transformExtent([minLon, minLat, maxLon, maxLat], ol.proj.get("EPSG:4326"), ol.proj.get("EPSG:3857")), {
+                            padding: [100, 100, 100, 100]
+                        })
                     }
-                });
+                }
             </script>
             
-            % routes_json = [j for r in routes for j in r.get_indicator_json()]
+            % routes_json = sorted([j for r in routes for j in r.get_indicator_json()], key=lambda j: j['lat'])
             <script>
                 const routes = JSON.parse('{{! json.dumps(routes_json) }}');
                 
@@ -188,7 +180,12 @@
                     element.appendChild(icon);
                     element.appendChild(details);
                     
-                    new mapboxgl.Marker(element).setLngLat([route.lon, route.lat]).addTo(map);
+                    map.addOverlay(new ol.Overlay({
+                        position: ol.proj.fromLonLat([route.lon, route.lat]),
+                        positioning: "center-center",
+                        element: element,
+                        stopEvent: false
+                    }));
                 }
             </script>
         % end

--- a/views/pages/routes/map.tpl
+++ b/views/pages/routes/map.tpl
@@ -91,7 +91,8 @@
                     maxZoom: 22
                 }),
                 controls: ol.control.defaults.defaults({
-                    zoom: false
+                    zoom: false,
+                    rotate: false
                 })
             });
             

--- a/views/pages/routes/map.tpl
+++ b/views/pages/routes/map.tpl
@@ -145,7 +145,7 @@
                     map.updateSize();
                     if (lons.length === 1 && lats.length === 1) {
                         map.getView().setCenter(ol.proj.fromLonLat([lons[0], lats[0]]));
-                        map.getView().setZoom(14);
+                        map.getView().setZoom(15);
                     } else if (lons.length > 0 && lats.length > 0) {
                         const minLon = Math.min.apply(Math, lons);
                         const maxLon = Math.max.apply(Math, lons);


### PR DESCRIPTION
- Replaces all MapBox functionality with OpenLayers functionalty (https://openlayers.org)
- For the most part all of the logic remains the same in terms of adding markers and lines to the map
- Logic for geolocation and map themes is removed for now, as more work will need to be done in order to have those features again
- Config for the mapbox key is also removed
- The order of adding markers in most places has been inverted as OpenLayers adds things differently from MapBox
- In the future we can probably add some helper functions to simplify some of the more complex code (particularly around the logic for projections - https://openlayers.org/doc/faq.html)
- Upated README
- Added newspost to let users know why the maps have changed
- Changed a couple CSS lines (was setting to an undesired font, and hover z-index was not behaving as we want on one of OpenLayer's classes)
- Currently the JS/CSS is being loaded from jsDelivr. OpenLayers empasizes that using this is not recommended for production scenarios, however a stack overflow post does also note:
> Using jsDelivr should be the right way to do. Downloading the whole package and hosting the content yourself will yield functionally equivalent results compared to loading them from jsDelivr, but with the added responsibility of managing dependencies on your own.

> OpenLayer recommend against using a 3rd-party CDN on production for partially this reason, as enterprise-level software may frown upon external dependencies. For most personal to small-mid business applications, reputable CDN like jsDelivr shouldn't cause reliability issues, and saves you a lot of hassle managing everything.