### PR TITLE
Add basic agency support and remove NextRide v1

### DIFF
--- a/helpers/agency.py
+++ b/helpers/agency.py
@@ -1,0 +1,30 @@
+
+import csv
+
+from models.agency import Agency
+
+agencies = {}
+
+def load():
+    '''Loads agency data from the static CSV file'''
+    with open(f'./static/agencies.csv', 'r') as file:
+        reader = csv.reader(file)
+        columns = next(reader)
+        for row in reader:
+            agency = Agency.from_csv(dict(zip(columns, row)))
+            agencies[agency.id] = agency
+
+def find(agency_id):
+    '''Returns the agency with the given ID'''
+    if agency_id is not None and agency_id in agencies:
+        return agencies[agency_id]
+    return None
+
+def find_all():
+    '''Returns all agencies'''
+    return agencies.values()
+
+def delete_all():
+    '''Deletes all agencies'''
+    global agencies
+    agencies = {}

--- a/models/agency.py
+++ b/models/agency.py
@@ -1,0 +1,57 @@
+
+class Agency:
+    '''A company or entity that runs transit'''
+    
+    __slots__ = (
+        'id',
+        'name',
+        'enabled',
+        'prefix_headsigns',
+        'gtfs_url',
+        'realtime_url'
+    )
+    
+    @classmethod
+    def from_csv(cls, row):
+        '''Returns an agency initialized from the given CSV row'''
+        id = row['agency_id']
+        name = row['name']
+        enabled = row['enabled'] == '1'
+        prefix_headsigns = row['prefix_headsigns'] == '1'
+        gtfs_url = row['gtfs_url']
+        if gtfs_url == '':
+            gtfs_url = None
+        realtime_url = row['realtime_url']
+        if realtime_url == '':
+            realtime_url = None
+        return cls(id, name, enabled, prefix_headsigns, gtfs_url, realtime_url)
+    
+    @property
+    def gtfs_enabled(self):
+        '''Checks if GTFS is enabled for this agency'''
+        return self.enabled and self.gtfs_url
+    
+    @property
+    def realtime_enabled(self):
+        '''Checks if realtime is enabled for this agency'''
+        return self.enabled and self.realtime_url
+    
+    def __init__(self, id, name, enabled, prefix_headsigns, gtfs_url, realtime_url):
+        self.id = id
+        self.name = name
+        self.enabled = enabled
+        self.prefix_headsigns = prefix_headsigns
+        self.gtfs_url = gtfs_url
+        self.realtime_url = realtime_url
+    
+    def __str__(self):
+        return self.name
+    
+    def __hash__(self):
+        return hash(self.id)
+    
+    def __eq__(self, other):
+        return self.id == other.id
+    
+    def __lt__(self, other):
+        return str(self) < str(other)

--- a/models/trip.py
+++ b/models/trip.py
@@ -160,7 +160,7 @@ class Trip:
         self._related_trips = None
     
     def __str__(self):
-        if self.system.prefix_headsign and self.route is not None:
+        if self.system.agency.prefix_headsigns and self.route is not None:
             return f'{self.route.number} {self.headsign}'
         return self.headsign
     

--- a/static/agencies.csv
+++ b/static/agencies.csv
@@ -1,0 +1,2 @@
+agency_id,name,enabled,prefix_headsigns,gtfs_url,realtime_url
+bc-transit,BC Transit,1,1,https://bct.tmix.se/Tmix.Cap.TdExport.WebApi/gtfs/?operatorIds=$REMOTE_ID,https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=$REMOTE_ID

--- a/static/systems.csv
+++ b/static/systems.csv
@@ -1,36 +1,36 @@
-system_id,name,region_id,enabled,visible,prefix_headsign,recolour_black,version,remote_id,gtfs_url,realtime_url
-100-mile-house,100 Mile House,northern-bc,1,1,1,1,2,34,,
-ashcroft-clinton,Ashcroft-Clinton,southern-interior,1,1,1,1,2,38,,
-bella-coola,Bella Coola,northern-bc,1,1,1,1,2,30,,
-campbell-river,Campbell River,vancouver-island,1,1,1,0,2,12,,
-clearwater,Clearwater,southern-interior,1,1,1,1,2,35,,
-comox,Comox Valley,vancouver-island,1,1,1,0,2,45,,
-cowichan-valley,Cowichan Valley,vancouver-island,1,1,1,0,2,10,,
-creston-valley,Creston Valley,southern-interior,1,1,1,0,2,16,,
-dawson-creek,Dawson Creek,northern-bc,1,1,1,0,2,27,,
-east-kootenay,East Kootenay,southern-interior,1,1,1,1,2,21,,
-fort-st-john,Fort St. John,northern-bc,1,1,1,0,2,28,,
-fraser-valley,Fraser Valley,southern-coast,1,1,1,0,2,13,,
-kamloops,Kamloops,southern-interior,1,1,1,0,2,46,,
-kelowna,Kelowna,southern-interior,1,1,1,0,2,47,,
-kitimat,Kitimat-Stikine,northern-bc,1,1,1,1,2,26,,
-merritt,Merritt,southern-interior,1,1,1,1,2,37,,
-mount-waddington,Mount Waddington,vancouver-island,1,1,1,0,2,17,,
-nanaimo,Nanaimo,vancouver-island,1,1,1,0,2,41,,
-north-okanagan,North Okanagan,southern-interior,1,1,1,0,2,14,,
-pemberton,Pemberton Valley,southern-coast,1,1,1,1,2,50,,
-port-alberni,Port Alberni,vancouver-island,1,1,1,0,2,11,,
-powell-river,Powell River,southern-coast,1,1,1,1,2,29,,
-prince-george,Prince George,northern-bc,1,1,1,1,2,22,,
-prince-rupert,Prince Rupert,northern-bc,1,1,1,0,2,23,,
-quesnel,Quesnel,northern-bc,1,1,1,1,2,32,,
-revelstoke,Revelstoke,southern-interior,1,1,1,1,2,36,,
-salt-spring,Salt Spring Island,vancouver-island,1,1,1,1,2,39,,
-smithers,Smithers,northern-bc,1,1,1,1,2,31,,
-south-okanagan,South Okanagan,southern-interior,1,1,1,0,2,15,,
-squamish,Squamish,southern-coast,1,1,1,0,2,43,,
-sunshine-coast,Sunshine Coast,southern-coast,1,1,1,1,2,18,,
-victoria,Victoria,vancouver-island,1,1,1,0,2,48,,
-west-kootenay,West Kootenay,southern-interior,1,1,1,1,2,20,,
-whistler,Whistler,southern-coast,1,1,1,0,2,44,,
-williams-lake,Williams Lake,northern-bc,1,1,1,1,2,33,,
+system_id,name,agency_id,region_id,recolour_black,remote_id
+100-mile-house,100 Mile House,bc-transit,northern-bc,1,34
+ashcroft-clinton,Ashcroft-Clinton,bc-transit,southern-interior,1,38
+bella-coola,Bella Coola,bc-transit,northern-bc,1,30
+campbell-river,Campbell River,bc-transit,vancouver-island,0,12
+clearwater,Clearwater,bc-transit,southern-interior,1,35
+comox,Comox Valley,bc-transit,vancouver-island,0,45
+cowichan-valley,Cowichan Valley,bc-transit,vancouver-island,0,10
+creston-valley,Creston Valley,bc-transit,southern-interior,0,16
+dawson-creek,Dawson Creek,bc-transit,northern-bc,0,27
+east-kootenay,East Kootenay,bc-transit,southern-interior,1,21
+fort-st-john,Fort St. John,bc-transit,northern-bc,0,28
+fraser-valley,Fraser Valley,bc-transit,southern-coast,0,13
+kamloops,Kamloops,bc-transit,southern-interior,0,46
+kelowna,Kelowna,bc-transit,southern-interior,0,47
+kitimat,Kitimat-Stikine,bc-transit,northern-bc,1,26
+merritt,Merritt,bc-transit,southern-interior,1,37
+mount-waddington,Mount Waddington,bc-transit,vancouver-island,0,17
+nanaimo,Nanaimo,bc-transit,vancouver-island,0,41
+north-okanagan,North Okanagan,bc-transit,southern-interior,0,14
+pemberton,Pemberton Valley,bc-transit,southern-coast,1,50
+port-alberni,Port Alberni,bc-transit,vancouver-island,0,11
+powell-river,Powell River,bc-transit,southern-coast,1,29
+prince-george,Prince George,bc-transit,northern-bc,1,22
+prince-rupert,Prince Rupert,bc-transit,northern-bc,0,23
+quesnel,Quesnel,bc-transit,northern-bc,1,32
+revelstoke,Revelstoke,bc-transit,southern-interior,1,36
+salt-spring,Salt Spring Island,bc-transit,vancouver-island,1,39
+smithers,Smithers,bc-transit,northern-bc,1,31
+south-okanagan,South Okanagan,bc-transit,southern-interior,0,15
+squamish,Squamish,bc-transit,southern-coast,0,43
+sunshine-coast,Sunshine Coast,bc-transit,southern-coast,1,18
+victoria,Victoria,bc-transit,vancouver-island,0,48
+west-kootenay,West Kootenay,bc-transit,southern-interior,1,20
+whistler,Whistler,bc-transit,southern-coast,0,44
+williams-lake,Williams Lake,bc-transit,northern-bc,1,33

--- a/views/pages/admin.tpl
+++ b/views/pages/admin.tpl
@@ -35,22 +35,6 @@
                                 <h3>{{ admin_system }}</h3>
                             </div>
                             <div class="content">
-                                <div>
-                                    Enabled:
-                                    % if admin_system.enabled:
-                                        <span class="positive">Yes</span>
-                                    % else:
-                                        <span class="negative">No</span>
-                                    % end
-                                </div>
-                                <div>
-                                    Visible:
-                                    % if admin_system.visible:
-                                        <span class="positive">Yes</span>
-                                    % else:
-                                        <span class="negative">No</span>
-                                    % end
-                                </div>
                                 <div class="button-container">
                                     % if admin_system.gtfs_enabled:
                                         <div class="button" onclick="reloadGTFS('{{ admin_system.id }}')">Reload GTFS</div>
@@ -68,22 +52,6 @@
                             <h3>{{ system }}</h3>
                         </div>
                         <div class="content">
-                            <div>
-                                Enabled:
-                                % if system.enabled:
-                                    <span class="positive">Yes</span>
-                                % else:
-                                    <span class="negative">No</span>
-                                % end
-                            </div>
-                            <div>
-                                Visible:
-                                % if system.visible:
-                                    <span class="positive">Yes</span>
-                                % else:
-                                    <span class="negative">No</span>
-                                % end
-                            </div>
                             <div class="button-container">
                                 % if system.gtfs_enabled:
                                     <div class="button" onclick="reloadGTFS('{{ system.id }}')">Reload GTFS</div>


### PR DESCRIPTION
- Adds basic support for agencies with a helper file and model
- Agencies are currently not affecting anything public-facing on the website, just a more convenient place to store config shared by all related systems
  - GTFS/realtime URLs are determined at the agency level, with the ability to sub in remote ID variables
  - Individual systems are no longer enabled/visible, however agencies can be enabled or disabled (currently does nothing)
  - Some config such as headsign prefixing is moved from systems to agencies
- Currently BC Transit is the only agency, but we can add more in the future!
- Full implementation of agencies still requires a lot of work, including on the UI level to support navigation between agencies, and at the database level to differentiate between agency fleets