### PR TITLE
Update error page titles

### DIFF
--- a/server.py
+++ b/server.py
@@ -145,7 +145,7 @@ def page(name, system, title, path='', path_args=None, enable_refresh=True, incl
         **kwargs
     )
 
-def error_page(name, system, title='Error', path='', **kwargs):
+def error_page(name, system, title, path='', **kwargs):
     '''Returns an error page with the given name and details'''
     return page(f'errors/{name}', system,
         title=title,
@@ -332,6 +332,7 @@ def bus_overview_page(system, bus_number):
     overview = helpers.overview.find(bus)
     if (bus.order is None and overview is None) or not bus.visible:
         return error_page('invalid_bus', system,
+            title='Unknown Bus',
             bus_number=bus_number
         )
     position = helpers.position.find(bus)
@@ -351,6 +352,7 @@ def bus_map_page(system, bus_number):
     overview = helpers.overview.find(bus)
     if (bus.order is None and overview is None) or not bus.visible:
         return error_page('invalid_bus', system,
+            title='Unknown Bus',
             bus_number=bus_number
         )
     position = helpers.position.find(bus)
@@ -368,6 +370,7 @@ def bus_history_page(system, bus_number):
     overview = helpers.overview.find(bus)
     if (bus.order is None and overview is None) or not bus.visible:
         return error_page('invalid_bus', system,
+            title='Unknown Bus',
             bus_number=bus_number
         )
     records = helpers.record.find_all(bus=bus)
@@ -444,11 +447,13 @@ def routes_map_page(system):
 def route_overview_page(system, route_number):
     if system is None:
         return error_page('system_required', system,
+            title='System Required',
             path=f'routes/{route_number}'
         )
     route = system.get_route(number=route_number)
     if route is None:
         return error_page('invalid_route', system,
+            title='Unknown Route',
             route_number=route_number
         )
     trips = sorted(route.get_trips(date=Date.today()))
@@ -466,11 +471,13 @@ def route_overview_page(system, route_number):
 def route_map_page(system, route_number):
     if system is None:
         return error_page('system_required', system,
+            title='System Required',
             path=f'routes/{route_number}/map'
         )
     route = system.get_route(number=route_number)
     if route is None:
         return error_page('invalid_route', system,
+            title='Unknown Route',
             route_number=route_number
         )
     return page('route/map', system,
@@ -485,11 +492,13 @@ def route_map_page(system, route_number):
 def route_schedule_page(system, route_number):
     if system is None:
         return error_page('system_required', system,
+            title='System Required',
             path=f'routes/{route_number}/schedule'
         )
     route = system.get_route(number=route_number)
     if route is None:
         return error_page('invalid_route', system,
+            title='Unknown Route',
             route_number=route_number
         )
     return page('route/schedule', system,
@@ -502,11 +511,13 @@ def route_schedule_page(system, route_number):
 def route_schedule_date_page(system, route_number, date_string):
     if system is None:
         return error_page('system_required', system,
+            title='System Required',
             path=f'routes/{route_number}/schedule'
         )
     route = system.get_route(number=route_number)
     if route is None:
         return error_page('invalid_route', system,
+            title='Unknown Route',
             route_number=route_number
         )
     date = Date.parse_db(date_string, None)
@@ -539,11 +550,13 @@ def blocks_schedule_date_page(system, date_string):
 def block_overview_page(system, block_id):
     if system is None:
         return error_page('system_required', system,
+            title='System Required',
             path=f'blocks/{block_id}'
         )
     block = system.get_block(block_id)
     if block is None:
         return error_page('invalid_block', system,
+            title='Unknown Block',
             block_id=block_id
         )
     return page('block/overview', system,
@@ -557,11 +570,13 @@ def block_overview_page(system, block_id):
 def block_map_page(system, block_id):
     if system is None:
         return error_page('system_required', system,
+            title='System Required',
             path=f'blocks/{block_id}/map'
         )
     block = system.get_block(block_id)
     if block is None:
         return error_page('invalid_block', system,
+            title='Unknown Block',
             block_id=block_id
         )
     return page('block/map', system,
@@ -576,11 +591,13 @@ def block_map_page(system, block_id):
 def block_history_page(system, block_id):
     if system is None:
         return error_page('system_required', system,
+            title='System Required',
             path=f'blocks/{block_id}/history'
         )
     block = system.get_block(block_id)
     if block is None:
         return error_page('invalid_block', system,
+            title='Unknown Block',
             block_id=block_id
         )
     records = helpers.record.find_all(system, block=block)
@@ -599,11 +616,13 @@ def block_history_page(system, block_id):
 def trip_overview_page(system, trip_id):
     if system is None:
         return error_page('system_required', system,
+            title='System Required',
             path=f'trips/{trip_id}'
         )
     trip = system.get_trip(trip_id)
     if trip is None:
         return error_page('invalid_trip', system,
+            title='Unknown Trip',
             trip_id=trip_id
         )
     return page('trip/overview', system,
@@ -617,11 +636,13 @@ def trip_overview_page(system, trip_id):
 def trip_map_page(system, trip_id):
     if system is None:
         return error_page('system_required', system,
+            title='System Required',
             path=f'trips/{trip_id}/map'
         )
     trip = system.get_trip(trip_id)
     if trip is None:
         return error_page('invalid_trip', system,
+            title='Unknown Trip',
             trip_id=trip_id
         )
     return page('trip/map', system,
@@ -636,11 +657,13 @@ def trip_map_page(system, trip_id):
 def trip_history_page(system, trip_id):
     if system is None:
         return error_page('system_required', system,
+            title='System Required',
             path=f'trips/{trip_id}/history'
         )
     trip = system.get_trip(trip_id)
     if trip is None:
         return error_page('invalid_trip', system,
+            title='Unknown Trip',
             trip_id=trip_id
         )
     records = helpers.record.find_all(system, trip=trip)
@@ -672,11 +695,13 @@ def stops_page(system):
 def stop_overview_page(system, stop_number):
     if system is None:
         return error_page('system_required', system,
+            title='System Required',
             path=f'stops/{stop_number}'
         )
     stop = system.get_stop(number=stop_number)
     if stop is None:
         return error_page('invalid_stop', system,
+            title='Unknown Stop',
             stop_number=stop_number
         )
     departures = stop.find_departures(date=Date.today())
@@ -696,11 +721,13 @@ def stop_overview_page(system, stop_number):
 def stop_map_page(system, stop_number):
     if system is None:
         return error_page('system_required', system,
+            title='System Required',
             path=f'stops/{stop_number}/map'
         )
     stop = system.get_stop(number=stop_number)
     if stop is None:
         return error_page('invalid_stop', system,
+            title='Unknown Stop',
             stop_number=stop_number
         )
     return page('stop/map', system,
@@ -714,11 +741,13 @@ def stop_map_page(system, stop_number):
 def stop_schedule_page(system, stop_number):
     if system is None:
         return error_page('system_required', system,
+            title='System Required',
             path=f'stops/{stop_number}/schedule'
         )
     stop = system.get_stop(number=stop_number)
     if stop is None:
         return error_page('invalid_stop', system,
+            title='Unknown Stop',
             stop_number=stop_number
         )
     return page('stop/schedule', system,
@@ -731,11 +760,13 @@ def stop_schedule_page(system, stop_number):
 def stop_schedule_date_page(system, stop_number, date_string):
     if system is None:
         return error_page('system_required', system,
+            title='System Required',
             path=f'stops/{stop_number}/schedule'
         )
     stop = system.get_stop(number=stop_number)
     if stop is None:
         return error_page('invalid_stop', system,
+            title='Unknown Stop',
             stop_number=stop_number
         )
     date = Date.parse_db(date_string, None)
@@ -957,12 +988,12 @@ def api_admin_reload_realtime(system, reload_system_id):
 
 @app.error(403)
 def error_403_page(error):
-    return error_page('403', None, error=error)
+    return error_page('403', None, 'Forbidden', error=error)
 
 @app.error(404)
 def error_404_page(error):
-    return error_page('404', None, error=error)
+    return error_page('404', None, 'Not Found', error=error)
 
 @app.error(500)
 def error_500_page(error):
-    return error_page('500', None, error=error)
+    return error_page('500', None, 'Internal Error', error=error)


### PR DESCRIPTION
In analytics, page views are grouped together by page title. Currently all of our error page titles are just "Error" making it difficult to determine what error was encountered. This change updates the titles for all error pages to help differentiate between various errors.