### PR TITLE
Store map toggles as cookies

### DIFF
--- a/server.py
+++ b/server.py
@@ -249,6 +249,8 @@ def news_page(system):
 @endpoint('/map')
 def map_page(system):
     positions = helpers.position.find_all(system, has_location=True)
+    auto_refresh = query_cookie('auto_refresh', 'false') != 'false'
+    show_route_lines = query_cookie('show_route_lines', 'false') != 'false'
     show_nis = query_cookie('show_nis', 'true') != 'false'
     visible_positions = positions if show_nis else [p for p in positions if p.trip is not None]
     return page('map', system,
@@ -257,6 +259,8 @@ def map_page(system):
         include_maps=len(visible_positions) > 0,
         full_map=len(visible_positions) > 0,
         positions=sorted(positions, key=lambda p: p.lat),
+        auto_refresh=auto_refresh,
+        show_route_lines=show_route_lines,
         show_nis=show_nis,
         visible_positions=visible_positions
     )

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -7,23 +7,23 @@
     <h1 class="title">Map</h1>
     % if len(visible_positions) > 0:
         <div class="flex-column flex-gap-5">
-            <div class="checkbox" onclick="toggleTripLines()">
-                <div class="box">
-                    <div id="checkbox-image" class="hidden">
-                        <img class="white" src="/img/white/check.png" />
-                        <img class="black" src="/img/black/check.png" />
-                    </div>
-                </div>
-                <span class="checkbox-label">Show Route Lines</span>
-            </div>
             <div class="checkbox" onclick="toggleAutomaticRefresh()">
                 <div class="box">
-                    <div id="refresh-image" class="hidden">
+                    <div id="refresh-image" class="{{ '' if auto_refresh else 'hidden' }}">
                         <img class="white" src="/img/white/check.png" />
                         <img class="black" src="/img/black/check.png" />
                     </div>
                 </div>
                 <span class="checkbox-label">Automatically Refresh</span>
+            </div>
+            <div class="checkbox" onclick="toggleRouteLines()">
+                <div class="box">
+                    <div id="checkbox-image" class="{{ '' if show_route_lines else 'hidden' }}">
+                        <img class="white" src="/img/white/check.png" />
+                        <img class="black" src="/img/black/check.png" />
+                    </div>
+                </div>
+                <span class="checkbox-label">Show Route Lines</span>
             </div>
             <div class="checkbox" onclick="toggleNISBuses()">
                 <div class="box">
@@ -114,8 +114,8 @@
         let currentShapeIDs = [];
         let markers = [];
         let routeLayers = {};
-        let tripLinesVisible = false;
-        let automaticRefresh = false;
+        let automaticRefresh = "{{ auto_refresh }}" !== "False";
+        let showRouteLines = "{{ show_route_lines }}" !== "False";
         let showNISBuses = "{{ show_nis }}" !== "False";
         let hoverPosition = null;
         const busMarkerStyle = "{{ bus_marker_style }}";
@@ -127,6 +127,9 @@
         }
         
         updateMap(true);
+        if (showRouteLines) {
+            updateRouteData();
+        }
         
         function updateMap(resetCoordinates) {
             currentShapeIDs = [];
@@ -295,25 +298,10 @@
             
             for (const shapeID in shapes) {
                 if (currentShapeIDs.includes(shapeID)) {
-                    shapes[shapeID].setVisible(tripLinesVisible);
+                    shapes[shapeID].setVisible(showRouteLines);
                 } else {
                     shapes[shapeID].setVisible(false);
                 }
-            }
-        }
-        
-        function toggleTripLines() {
-            tripLinesVisible = !tripLinesVisible;
-            const checkboxImage = document.getElementById("checkbox-image");
-            checkboxImage.classList.toggle("hidden");
-            
-            for (const shapeID of currentShapeIDs) {
-                if (shapeID in shapes) {
-                    shapes[shapeID].setVisible(tripLinesVisible);
-                }
-            }
-            if (tripLinesVisible) {
-                updateRouteData();
             }
         }
         
@@ -321,9 +309,26 @@
             automaticRefresh = !automaticRefresh;
             const checkboxImage = document.getElementById("refresh-image");
             checkboxImage.classList.toggle("hidden");
+            setCookie("auto_refresh", automaticRefresh ? "true" : "false");
             
             if (automaticRefresh) {
                 updatePositionData();
+            }
+        }
+        
+        function toggleRouteLines() {
+            showRouteLines = !showRouteLines;
+            const checkboxImage = document.getElementById("checkbox-image");
+            checkboxImage.classList.toggle("hidden");
+            setCookie("show_route_lines", showRouteLines ? "true" : "false");
+            
+            for (const shapeID of currentShapeIDs) {
+                if (shapeID in shapes) {
+                    shapes[shapeID].setVisible(showRouteLines);
+                }
+            }
+            if (showRouteLines) {
+                updateRouteData();
             }
         }
         
@@ -354,7 +359,7 @@
                         element.innerHTML = "Updated " + lastUpdated;
                         positions = request.response.positions;
                         updateMap(false);
-                        if (tripLinesVisible) {
+                        if (showRouteLines) {
                             updateRouteData()
                         }
                     }
@@ -378,7 +383,7 @@
                 request.onload = function() {
                     if (request.status === 200) {
                         if (shapeID in shapes) {
-                            shapes[shapeID].setVisible(tripLinesVisible);
+                            shapes[shapeID].setVisible(showRouteLines);
                         } else {
                             const layer = new ol.layer.Vector({
                                 source: new ol.source.Vector({
@@ -399,7 +404,7 @@
                                         lineCap: "butt"
                                     })
                                 }),
-                                visible: tripLinesVisible
+                                visible: showRouteLines
                             })
                             shapes[shapeID] = layer;
                             map.addLayer(layer);
@@ -411,7 +416,7 @@
         }
         
         function setHoverPosition(position) {
-            if (tripLinesVisible) {
+            if (showRouteLines) {
                 return
             }
             if (hoverPosition !== null) {


### PR DESCRIPTION
- Automatic Refresh and Show Route Lines are now stored as cookies so their state is remembered when leaving and returning to the map page
- Swapped order of Automatic Refresh and Show Route Lines toggles/code
- Renamed some stuff for consistency
- Will conflict with Style Cleanup MR