### PR TITLE
Datetime improvements

### DIFF
--- a/gtfs.py
+++ b/gtfs.py
@@ -33,12 +33,6 @@ def load(system, force_download=False, update_db=False):
     
     print(f'Loading GTFS data for {system}')
     try:
-        agencies = read_csv(system, 'agency', lambda r: r)
-        if len(agencies) > 0:
-            agency = agencies[0]
-            if 'agency_timezone' in agency:
-                system.timezone = agency['agency_timezone']
-        
         exceptions = read_csv(system, 'calendar_dates', lambda r: ServiceException.from_csv(r, system))
         service_exceptions = {}
         for exception in exceptions:

--- a/models/agency.py
+++ b/models/agency.py
@@ -8,7 +8,8 @@ class Agency:
         'gtfs_url',
         'realtime_url',
         'enabled',
-        'prefix_headsigns'
+        'prefix_headsigns',
+        'accurate_seconds'
     )
     
     @property
@@ -21,13 +22,14 @@ class Agency:
         '''Checks if realtime is enabled for this agency'''
         return self.enabled and self.realtime_url
     
-    def __init__(self, id, name, gtfs_url=None, realtime_url=None, enabled=True, prefix_headsigns=False):
+    def __init__(self, id, name, gtfs_url=None, realtime_url=None, enabled=True, prefix_headsigns=False, accurate_seconds=True):
         self.id = id
         self.name = name
         self.gtfs_url = gtfs_url
         self.realtime_url = realtime_url
         self.enabled = enabled
         self.prefix_headsigns = prefix_headsigns
+        self.accurate_seconds = accurate_seconds
     
     def __str__(self):
         return self.name

--- a/models/date.py
+++ b/models/date.py
@@ -17,15 +17,9 @@ class Date:
     )
     
     @classmethod
-    def parse_db(cls, date_string, timezone):
-        '''Returns a date parsed from the given string in YYYY-MM-DD format'''
-        date = datetime.strptime(date_string, '%Y-%m-%d')
-        return cls(date.year, date.month, date.day, timezone)
-    
-    @classmethod
-    def parse_csv(cls, date_string, timezone):
-        '''Returns a date parsed from the given string in YYYYMMDD format'''
-        date = datetime.strptime(date_string, '%Y%m%d')
+    def parse(cls, date_string, timezone=None, format='%Y-%m-%d'):
+        '''Returns a date parsed from a string in the given format'''
+        date = datetime.strptime(date_string, format)
         return cls(date.year, date.month, date.day, timezone)
     
     @classmethod
@@ -142,10 +136,7 @@ class Date:
             months = today.month - self.month
         if self.day > today.day:
             months -= 1
-            current_month = today.month - 1
-            if current_month == 0:
-                current_month = 12
-            days = (today.day + calendar.monthrange(today.year, current_month)[1]) - self.day
+            days = (today.day + calendar.monthrange(today.year, self.month)[1]) - self.day
         else:
             days = today.day - self.day
         parts = []

--- a/models/date.py
+++ b/models/date.py
@@ -20,6 +20,8 @@ class Date:
     def parse(cls, date_string, timezone=None, format='%Y-%m-%d'):
         '''Returns a date parsed from a string in the given format'''
         date = datetime.strptime(date_string, format)
+        if timezone is None:
+            timezone = pytz.timezone('America/Vancouver')
         return cls(date.year, date.month, date.day, timezone)
     
     @classmethod

--- a/models/date.py
+++ b/models/date.py
@@ -26,9 +26,8 @@ class Date:
     def today(cls, timezone=None):
         '''Returns the current date'''
         if timezone is None:
-            now = datetime.now()
-        else:
-            now = datetime.now(pytz.timezone(timezone))
+            timezone = pytz.timezone('America/Vancouver')
+        now = datetime.now(timezone)
         date = now if now.hour >= 4 else now - timedelta(days=1)
         return cls(date.year, date.month, date.day, timezone)
     
@@ -55,9 +54,7 @@ class Date:
     @property
     def timezone_name(self):
         '''Returns the name of this date's timezone'''
-        if self.timezone is None:
-            return None
-        return datetime.now(pytz.timezone(self.timezone)).tzname()
+        return datetime.now(self.timezone).tzname()
     
     @property
     def weekday(self):

--- a/models/departure.py
+++ b/models/departure.py
@@ -72,7 +72,7 @@ class Departure:
         trip_id = row[f'{prefix}_trip_id']
         sequence = row[f'{prefix}_sequence']
         stop_id = row[f'{prefix}_stop_id']
-        time = Time.parse(row[f'{prefix}_time'], system.timezone)
+        time = Time.parse(row[f'{prefix}_time'], system.timezone, system.agency.accurate_seconds)
         try:
             pickup_type = PickupType(row[f'{prefix}_pickup_type'])
         except:

--- a/models/overview.py
+++ b/models/overview.py
@@ -23,13 +23,13 @@ class Overview:
         '''Returns an overview initialized from the given database row'''
         bus = Bus(row[f'{prefix}_bus_number'])
         first_seen_system = helpers.system.find(row[f'{prefix}_first_seen_system_id'])
-        first_seen_date = Date.parse_db(row[f'{prefix}_first_seen_date'], first_seen_system.timezone)
+        first_seen_date = Date.parse(row[f'{prefix}_first_seen_date'], first_seen_system.timezone)
         if row[f'{prefix}_first_record_id'] is None:
             first_record = None
         else:
             first_record = Record.from_db(row, prefix=f'{prefix}_first_record')
         last_seen_system = helpers.system.find(row[f'{prefix}_last_seen_system_id'])
-        last_seen_date = Date.parse_db(row[f'{prefix}_last_seen_date'], last_seen_system.timezone)
+        last_seen_date = Date.parse(row[f'{prefix}_last_seen_date'], last_seen_system.timezone)
         if row[f'{prefix}_last_record_id'] is None:
             last_record = None
         else:

--- a/models/record.py
+++ b/models/record.py
@@ -28,13 +28,15 @@ class Record:
         id = row[f'{prefix}_id']
         bus = Bus(row[f'{prefix}_bus_number'])
         system = helpers.system.find(row[f'{prefix}_system_id'])
-        date = Date.parse_db(row[f'{prefix}_date'], system.timezone)
+        date = Date.parse(row[f'{prefix}_date'], system.timezone)
         block_id = row[f'{prefix}_block_id']
         route_numbers = [n.strip() for n in row[f'{prefix}_routes'].split(',')]
-        start_time = Time.parse(row[f'{prefix}_start_time'], system.timezone)
-        end_time = Time.parse(row[f'{prefix}_end_time'], system.timezone)
-        first_seen = Time.parse(row[f'{prefix}_first_seen'], system.timezone)
-        last_seen = Time.parse(row[f'{prefix}_last_seen'], system.timezone)
+        timezone = system.timezone
+        accurate_seconds = system.agency.accurate_seconds
+        start_time = Time.parse(row[f'{prefix}_start_time'], timezone, accurate_seconds)
+        end_time = Time.parse(row[f'{prefix}_end_time'], timezone, accurate_seconds)
+        first_seen = Time.parse(row[f'{prefix}_first_seen'], timezone, accurate_seconds)
+        last_seen = Time.parse(row[f'{prefix}_last_seen'], timezone, accurate_seconds)
         return cls(id, bus, date, system, block_id, route_numbers, start_time, end_time, first_seen, last_seen)
     
     @property

--- a/models/service.py
+++ b/models/service.py
@@ -23,7 +23,7 @@ class ServiceException:
     def from_csv(cls, row, system):
         '''Returns a service exception initialized from the given CSV row'''
         service_id = row['service_id']
-        date = Date.parse_csv(row['date'], system.timezone)
+        date = Date.parse(row['date'], system.timezone, '%Y%m%d')
         type = ServiceExceptionType(int(row['exception_type']))
         return cls(service_id, date, type)
     
@@ -51,8 +51,8 @@ class Service:
     def from_csv(cls, row, system, exceptions):
         '''Returns a service initialized from the given CSV row'''
         id = row['service_id']
-        start_date = Date.parse_csv(row['start_date'], system.timezone)
-        end_date = Date.parse_csv(row['end_date'], system.timezone)
+        start_date = Date.parse(row['start_date'], system.timezone, '%Y%m%d')
+        end_date = Date.parse(row['end_date'], system.timezone, '%Y%m%d')
         date_range = DateRange(start_date, end_date)
         mon = row['monday'] == '1'
         tue = row['tuesday'] == '1'

--- a/models/system.py
+++ b/models/system.py
@@ -1,4 +1,6 @@
 
+import pytz
+
 import helpers.departure
 import helpers.overview
 import helpers.position
@@ -14,11 +16,11 @@ class System:
         'region',
         'name',
         'remote_id',
+        'timezone',
         'colour_routes',
         'validation_errors',
         'last_updated_date',
         'last_updated_time',
-        'timezone',
         'blocks',
         'routes',
         'routes_by_number',
@@ -69,19 +71,18 @@ class System:
         '''The overall service schedule for this system'''
         return Schedule.combine(self.get_services())
     
-    def __init__(self, id, agency, region, name, remote_id=None, colour_routes=False):
+    def __init__(self, id, agency, region, name, remote_id=None, timezone='America/Vancouver', colour_routes=False):
         self.id = id
         self.agency = agency
         self.region = region
         self.name = name
         self.remote_id = remote_id
+        self.timezone = pytz.timezone(timezone)
         self.colour_routes = colour_routes
         
         self.validation_errors = 0
         self.last_updated_date = None
         self.last_updated_time = None
-        
-        self.timezone = None
         
         self.blocks = {}
         self.routes = {}
@@ -183,8 +184,6 @@ class System:
         if date is None or time is None:
             return 'N/A'
         if date.is_today:
-            if time.timezone is None:
-                return f'at {time.format_web(time_format)}'
             return f'at {time.format_web(time_format)} {time.timezone_name}'
         return date.format_since()
     

--- a/models/time.py
+++ b/models/time.py
@@ -31,9 +31,8 @@ class Time:
     def now(cls, timezone=None, accurate_seconds=True):
         '''Returns the current time'''
         if timezone is None:
-            now = datetime.now()
-        else:
-            now = datetime.now(pytz.timezone(timezone))
+            timezone = pytz.timezone('America/Vancouver')
+        now = datetime.now(timezone)
         hour = now.hour
         if hour < 4:
             hour += 24
@@ -82,9 +81,7 @@ class Time:
     @property
     def timezone_name(self):
         '''Returns the name of this time's timezone'''
-        if self.timezone is None:
-            return None
-        return datetime.now(pytz.timezone(self.timezone)).tzname()
+        return datetime.now(self.timezone).tzname()
     
     def __init__(self, hour, minute, second, timezone):
         self.hour = hour

--- a/models/time.py
+++ b/models/time.py
@@ -15,6 +15,8 @@ class Time:
     @classmethod
     def parse(cls, time_string, timezone=None, accurate_seconds=False):
         '''Returns a time parsed from the given string in HH:MM:SS format'''
+        if timezone is None:
+            timezone = pytz.timezone('America/Vancouver')
         if time_string is None or time_string == '':
             return cls.unknown(timezone)
         time_parts = time_string.split(':')
@@ -45,6 +47,8 @@ class Time:
     @classmethod
     def unknown(cls, timezone=None):
         '''Returns an unknown time'''
+        if timezone is None:
+            timezone = pytz.timezone('America/Vancouver')
         return cls(None, None, None, timezone)
     
     @property

--- a/models/transfer.py
+++ b/models/transfer.py
@@ -22,7 +22,7 @@ class Transfer:
         bus = Bus(row[f'{prefix}_bus_number'])
         old_system = helpers.system.find(row[f'{prefix}_old_system_id'])
         new_system = helpers.system.find(row[f'{prefix}_new_system_id'])
-        date = Date.parse_db(row[f'{prefix}_date'], new_system.timezone)
+        date = Date.parse(row[f'{prefix}_date'], new_system.timezone)
         return cls(id, bus, date, old_system, new_system)
     
     def __init__(self, id, bus, date, old_system, new_system):

--- a/realtime.py
+++ b/realtime.py
@@ -55,7 +55,7 @@ def update(system):
                 bus_number = -(index + 1)
             helpers.position.create(system, bus_number, vehicle)
         last_updated_date = Date.today()
-        last_updated_time = Time.now()
+        last_updated_time = Time.now(accurate_seconds=False)
         system.last_updated_date = Date.today(system.timezone)
         system.last_updated_time = Time.now(system.timezone, system.agency.accurate_seconds)
     except Exception as e:
@@ -106,8 +106,6 @@ def get_last_updated(time_format):
     if date is None or time is None:
         return 'N/A'
     if date.is_today:
-        if time.timezone is None:
-            return f'at {time.format_web(time_format)}'
         return f'at {time.format_web(time_format)} {time.timezone_name}'
     return date.format_since()
 

--- a/realtime.py
+++ b/realtime.py
@@ -54,10 +54,10 @@ def update(system):
             except:
                 bus_number = -(index + 1)
             helpers.position.create(system, bus_number, vehicle)
-        last_updated_date = Date.today('America/Vancouver')
-        last_updated_time = Time.now('America/Vancouver', False)
+        last_updated_date = Date.today()
+        last_updated_time = Time.now()
         system.last_updated_date = Date.today(system.timezone)
-        system.last_updated_time = Time.now(system.timezone, False)
+        system.last_updated_time = Time.now(system.timezone, system.agency.accurate_seconds)
     except Exception as e:
         print(f'Failed to update realtime for {system}: {e}')
 

--- a/server.py
+++ b/server.py
@@ -520,7 +520,7 @@ def route_schedule_date_page(system, route_number, date_string):
             title='Unknown Route',
             route_number=route_number
         )
-    date = Date.parse(date_string)
+    date = Date.parse(date_string, system.timezone)
     return page('route/date', system,
         title=str(route),
         enable_refresh=False,
@@ -538,7 +538,10 @@ def blocks_page(system):
 
 @endpoint('/blocks/schedule/<date_string:re:\\d{4}-\\d{2}-\\d{2}>')
 def blocks_schedule_date_page(system, date_string):
-    date = Date.parse(date_string)
+    if system is None:
+        date = Date.parse(date_string)
+    else:
+        date = Date.parse(date_string, system.timezone)
     return page('blocks/date', system,
         title='Blocks',
         enable_reload=False,
@@ -769,7 +772,7 @@ def stop_schedule_date_page(system, stop_number, date_string):
             title='Unknown Stop',
             stop_number=stop_number
         )
-    date = Date.parse(date_string)
+    date = Date.parse(date_string, system.timezone)
     return page('stop/date', system,
         title=f'Stop {stop.number}',
         enable_refresh=False,

--- a/server.py
+++ b/server.py
@@ -520,7 +520,7 @@ def route_schedule_date_page(system, route_number, date_string):
             title='Unknown Route',
             route_number=route_number
         )
-    date = Date.parse_db(date_string, None)
+    date = Date.parse(date_string)
     return page('route/date', system,
         title=str(route),
         enable_refresh=False,
@@ -538,7 +538,7 @@ def blocks_page(system):
 
 @endpoint('/blocks/schedule/<date_string:re:\\d{4}-\\d{2}-\\d{2}>')
 def blocks_schedule_date_page(system, date_string):
-    date = Date.parse_db(date_string, None)
+    date = Date.parse(date_string)
     return page('blocks/date', system,
         title='Blocks',
         enable_reload=False,
@@ -769,7 +769,7 @@ def stop_schedule_date_page(system, stop_number, date_string):
             title='Unknown Stop',
             stop_number=stop_number
         )
-    date = Date.parse_db(date_string, None)
+    date = Date.parse(date_string)
     return page('stop/date', system,
         title=f'Stop {stop.number}',
         enable_refresh=False,

--- a/static/agencies.json
+++ b/static/agencies.json
@@ -3,6 +3,7 @@
         "name": "BC Transit",
         "gtfs_url": "https://bct.tmix.se/Tmix.Cap.TdExport.WebApi/gtfs/?operatorIds=$REMOTE_ID",
         "realtime_url": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=$REMOTE_ID",
-        "prefix_headsigns": true
+        "prefix_headsigns": true,
+        "accurate_seconds": false
     }
 }

--- a/static/systems.json
+++ b/static/systems.json
@@ -77,11 +77,14 @@
             },
             "creston-valley": {
                 "name": "Creston Valley",
-                "remote_id": 16
+                "remote_id": 16,
+                "timezone": "America/Creston"
             },
             "east-kootenay": {
                 "name": "East Kootenay",
-                "remote_id": 21
+                "remote_id": 21,
+                "timezone": "America/Edmonton",
+                "colour_routes": true
             },
             "kamloops": {
                 "name": "Kamloops",
@@ -127,11 +130,13 @@
             },
             "dawson-creek": {
                 "name": "Dawson Creek",
-                "remote_id": 27
+                "remote_id": 27,
+                "timezone": "America/Dawson_Creek"
             },
             "fort-st-john": {
                 "name": "Fort St. John",
-                "remote_id": 28
+                "remote_id": 28,
+                "timezone": "America/Dawson_Creek"
             },
             "kitimat": {
                 "name": "Kitimat-Stikine",

--- a/static/systems.json
+++ b/static/systems.json
@@ -88,8 +88,7 @@
             },
             "kamloops": {
                 "name": "Kamloops",
-                "remote_id": 46,
-                "colour_routes": true
+                "remote_id": 46
             },
             "kelowna": {
                 "name": "Kelowna",


### PR DESCRIPTION
- System timezones are now set by us rather than read from the GTFS
  - BCT is bad about having the correct timezone for some systems (cough Creston, Smithers)
  - Defaults to `America/Vancouver`, can be set to other values in `systems.json`
- Agencies now determine value for `accurate_seconds`
  - BCT doesn't have accurate seconds (ie all times in the GTFS end in :00) but other agencies in the future may
  - Defaults to `True`, can be set to other values in `agencies.json`
- `Date.parse_db` and `Date.parse_csv` are now replaced by `Date.parse`
  - Takes a new `format` parameter which defaults to `%Y-%m-%d`
- Time logic for `None` values is updated
  - "Unknown" times now have `None` for hour/minute instead of `-1` for the hour
  - `accurate_seconds` is no longer a property; instead `second` is set to `None`
- Dates and times can no longer have `None` timezones
  - Defaults to `America/Vancouver` when not passed in (this should only be the case for internal/global things)
- Other various minor fixes and improvements