### PR TITLE
Add order/agency association (part 1)

### DIFF
--- a/helpers/adornment.py
+++ b/helpers/adornment.py
@@ -10,13 +10,19 @@ def load():
     global adornments
     adornments = {}
     with open(f'./static/adornments.json', 'r') as file:
-        for (bus_number, values) in json.load(file).items():
-            bus_number = int(bus_number)
-            adornments[bus_number] = Adornment(bus_number, **values)
+        for (agency_id, agency_values) in json.load(file).items():
+            agency_adornments = {}
+            for (bus_number, values) in agency_values.items():
+                bus_number = int(bus_number)
+                agency_adornments[bus_number] = Adornment(agency_id, bus_number, **values)
+            adornments[agency_id] = agency_adornments
 
-def find(bus):
+def find(agency, bus):
     '''Returns the adornments with the given bus number'''
+    agency_id = getattr(agency, 'id', agency)
     bus_number = getattr(bus, 'number', bus)
-    if bus_number in adornments:
-        return adornments[bus_number]
+    if agency_id in adornments:
+        agency_adornments = adornments[agency_id]
+        if bus_number in agency_adornments:
+            return agency_adornments[bus_number]
     return None

--- a/helpers/order.py
+++ b/helpers/order.py
@@ -4,38 +4,49 @@ import json
 from models.match import Match
 from models.order import Order
 
+import helpers.agency
 import helpers.model
 
-orders = []
+orders = {}
 
 def load():
     '''Loads order data from the static JSON file'''
     global orders
-    orders = []
+    orders = {}
+    helpers.agency.load()
     helpers.model.load()
     with open(f'./static/orders.json', 'r') as file:
-        for (model_id, model_values) in json.load(file).items():
-            model = helpers.model.find(model_id)
-            for values in model_values:
-                orders.append(Order(model=model, **values))
+        for (agency_id, agency_values) in json.load(file).items():
+            agency = helpers.agency.find(agency_id)
+            agency_orders = []
+            for (model_id, model_values) in agency_values.items():
+                model = helpers.model.find(model_id)
+                for values in model_values:
+                    agency_orders.append(Order(agency, model, **values))
+            orders[agency_id] = agency_orders
 
-def find(bus):
+def find(agency, bus):
     '''Returns the order containing the given bus number'''
+    agency_id = getattr(agency, 'id', agency)
     bus_number = getattr(bus, 'number', bus)
-    if bus_number < 0:
-        return None
-    for order in orders:
-        if bus_number in order:
-            return order
+    if agency_id in orders and bus_number >= 0:
+        agency_orders = orders[agency_id]
+        for order in agency_orders:
+            if bus_number in order:
+                return order
     return None
 
-def find_all():
+def find_all(agency=None):
     '''Returns all orders'''
-    return orders
+    agency_id = getattr(agency, 'id', agency)
+    if agency_id is None:
+        return [o for a in orders.values() for o in a]
+    return orders[agency_id]
 
-def find_matches(query, recorded_bus_numbers):
+def find_matches(agency, query, recorded_bus_numbers):
     '''Returns matching buses for a given query'''
     matches = []
+    orders = find_all(agency)
     for order in orders:
         if not order.visible:
             continue
@@ -53,7 +64,7 @@ def find_matches(query, recorded_bus_numbers):
                     value += len(query)
             if bus.number not in recorded_bus_numbers:
                 value /= 10
-            adornment = bus.adornment
+            adornment = bus.find_adornment()
             if adornment is not None and adornment.enabled:
                 bus_number_string += f' {adornment}'
             matches.append(Match('bus', bus_number_string, order_string, model_icon, f'bus/{bus.number}', value))

--- a/helpers/record.py
+++ b/helpers/record.py
@@ -1,4 +1,6 @@
 
+import helpers.agency
+
 from models.bus import Bus
 from models.date import Date
 from models.record import Record
@@ -112,7 +114,8 @@ def find_recorded_today(system, trips):
         },
         order_by='record.last_seen ASC'
     )
-    return {row['trip_id']: Bus(row['bus_number']) for row in rows}
+    agency = helpers.agency.find('bc-transit')
+    return {row['trip_id']: Bus.find(agency, row['bus_number']) for row in rows}
 
 def find_scheduled_today(system, trips):
     '''Returns all bus numbers matching the given system and trips that are scheduled to run on the current date'''
@@ -146,4 +149,5 @@ def find_scheduled_today(system, trips):
         order_by='numbered_record.last_seen ASC',
         custom_args=args
     )
-    return {row['block_id']: Bus(row['bus_number']) for row in rows}
+    agency = helpers.agency.find('bc-transit')
+    return {row['block_id']: Bus.find(agency, row['bus_number']) for row in rows}

--- a/models/adornment.py
+++ b/models/adornment.py
@@ -3,13 +3,15 @@ class Adornment:
     '''Text placed after a bus number'''
     
     __slots__ = (
+        'agency_id',
         'bus_number',
         'text',
         'description',
         'enabled'
     )
     
-    def __init__(self, bus_number, text, description=None, enabled=True):
+    def __init__(self, agency_id, bus_number, text, description=None, enabled=True):
+        self.agency_id = agency_id
         self.bus_number = bus_number
         self.text = text
         self.description = description
@@ -19,7 +21,7 @@ class Adornment:
         return self.text
     
     def __hash__(self):
-        return hash(self.bus_number)
+        return hash((self.agency_id, self.bus_number))
     
     def __eq__(self, other):
-        return self.bus_number == other.bus_number
+        return self.agency_id == other.agency_id and self.bus_number == other.bus_number

--- a/models/agency.py
+++ b/models/agency.py
@@ -8,7 +8,8 @@ class Agency:
         'gtfs_url',
         'realtime_url',
         'enabled',
-        'prefix_headsigns'
+        'prefix_headsigns',
+        'vehicle_name_length'
     )
     
     @property
@@ -21,13 +22,14 @@ class Agency:
         '''Checks if realtime is enabled for this agency'''
         return self.enabled and self.realtime_url
     
-    def __init__(self, id, name, gtfs_url=None, realtime_url=None, enabled=True, prefix_headsigns=False):
+    def __init__(self, id, name, gtfs_url=None, realtime_url=None, enabled=True, prefix_headsigns=False, vehicle_name_length=None):
         self.id = id
         self.name = name
         self.gtfs_url = gtfs_url
         self.realtime_url = realtime_url
         self.enabled = enabled
         self.prefix_headsigns = prefix_headsigns
+        self.vehicle_name_length = vehicle_name_length
     
     def __str__(self):
         return self.name

--- a/models/bus.py
+++ b/models/bus.py
@@ -10,6 +10,12 @@ class Bus:
         'order'
     )
     
+    @classmethod
+    def find(cls, agency, number):
+        '''Returns a bus for the given agency with the given number'''
+        order = helpers.order.find(agency, number)
+        return cls(number, order)
+    
     @property
     def is_known(self):
         '''Checks if the bus number is known'''
@@ -30,11 +36,6 @@ class Bus:
         if order is None:
             return None
         return order.model
-    
-    @classmethod
-    def find(cls, agency, number):
-        order = helpers.order.find(agency, number)
-        return cls(number, order)
     
     def __init__(self, number, order):
         self.number = number
@@ -57,6 +58,7 @@ class Bus:
         return self.number < other.number
     
     def find_adornment(self):
+        '''Returns the adornment for this bus, if one exists'''
         if self.order is None:
             return None
         return helpers.adornment.find(self.order.agency, self)

--- a/models/bus.py
+++ b/models/bus.py
@@ -7,34 +7,8 @@ class Bus:
     
     __slots__ = (
         'number',
-        'order',
-        'adornment'
+        'order'
     )
-    
-    def __init__(self, number, order=None, adornment=None):
-        self.number = number
-        if order is None:
-            self.order = helpers.order.find(number)
-        else:
-            self.order = order
-        if adornment is None:
-            self.adornment = helpers.adornment.find(number)
-        else:
-            self.adornment = adornment
-    
-    def __str__(self):
-        if self.is_known:
-            return f'{self.number:04d}'
-        return 'Unknown Bus'
-    
-    def __hash__(self):
-        return hash(self.number)
-    
-    def __eq__(self, other):
-        return self.number == other.number
-    
-    def __lt__(self, other):
-        return self.number < other.number
     
     @property
     def is_known(self):
@@ -56,3 +30,31 @@ class Bus:
         if order is None:
             return None
         return order.model
+    
+    @classmethod
+    def find(cls, agency, number):
+        order = helpers.order.find(agency, number)
+        return cls(number, order)
+    
+    def __init__(self, number, order):
+        self.number = number
+        self.order = order
+    
+    def __str__(self):
+        if self.is_known:
+            return f'{self.number:04d}'
+        return 'Unknown Bus'
+    
+    def __hash__(self):
+        return hash(self.number)
+    
+    def __eq__(self, other):
+        return self.number == other.number
+    
+    def __lt__(self, other):
+        return self.number < other.number
+    
+    def find_adornment(self):
+        if self.order is None:
+            return None
+        return helpers.adornment.find(self.order.agency, self)

--- a/models/bus.py
+++ b/models/bus.py
@@ -42,7 +42,9 @@ class Bus:
     
     def __str__(self):
         if self.is_known:
-            return f'{self.number:04d}'
+            if self.order is None or self.order.agency.vehicle_name_length is None:
+                return str(self.number)
+            return f'{self.number:0{self.order.agency.vehicle_name_length}d}'
         return 'Unknown Bus'
     
     def __hash__(self):

--- a/models/order.py
+++ b/models/order.py
@@ -5,6 +5,7 @@ class Order:
     '''A range of buses of a specific model ordered in a specific year'''
     
     __slots__ = (
+        'agency',
         'model',
         'low',
         'high',
@@ -18,14 +19,15 @@ class Order:
     @property
     def first_bus(self):
         '''The first bus in the order'''
-        return Bus(self.low, order=self)
+        return Bus(self.low, self)
     
     @property
     def last_bus(self):
         '''The last bus in the order'''
-        return Bus(self.high, order=self)
+        return Bus(self.high, self)
     
-    def __init__(self, model, number=None, low=None, high=None, year=None, visible=True, demo=False, exceptions=None):
+    def __init__(self, agency, model, number=None, low=None, high=None, year=None, visible=True, demo=False, exceptions=None):
+        self.agency = agency
         self.model = model
         if number is None:
             self.low = low
@@ -51,18 +53,20 @@ class Order:
         return f'{year} {model}'
     
     def __hash__(self):
-        return hash((self.low, self.high))
+        return hash((self.agency, self.low, self.high))
     
     def __eq__(self, other):
-        return self.low == other.low and self.high == other.high
+        return self.agency == other.agency and self.low == other.low and self.high == other.high
     
     def __lt__(self, other):
-        return self.low < other.low
+        if self.agency == other.agency:
+            return self.low < other.low
+        return self.agency < other.agency
     
     def __iter__(self):
         for number in range(self.low, self.high + 1):
             if number not in self.exceptions:
-                yield Bus(number, order=self)
+                yield Bus(number, self)
     
     def __contains__(self, bus_number):
         if bus_number in self.exceptions:
@@ -76,7 +80,7 @@ class Order:
         previous_bus_number = bus_number - 1
         if previous_bus_number in self.exceptions:
             return self.previous_bus(previous_bus_number)
-        return Bus(previous_bus_number, order=self)
+        return Bus(previous_bus_number, self)
     
     def next_bus(self, bus_number):
         '''The next bus following the given bus number'''
@@ -85,4 +89,4 @@ class Order:
         next_bus_number = bus_number + 1
         if next_bus_number in self.exceptions:
             return self.next_bus(next_bus_number)
-        return Bus(next_bus_number, order=self)
+        return Bus(next_bus_number, self)

--- a/models/overview.py
+++ b/models/overview.py
@@ -1,4 +1,5 @@
 
+import helpers.agency
 import helpers.system
 
 from models.bus import Bus
@@ -21,7 +22,8 @@ class Overview:
     @classmethod
     def from_db(cls, row, prefix='overview'):
         '''Returns an overview initialized from the given database row'''
-        bus = Bus(row[f'{prefix}_bus_number'])
+        agency = helpers.agency.find('bc-transit')
+        bus = Bus.find(agency, row[f'{prefix}_bus_number'])
         first_seen_system = helpers.system.find(row[f'{prefix}_first_seen_system_id'])
         first_seen_date = Date.parse_db(row[f'{prefix}_first_seen_date'], first_seen_system.timezone)
         if row[f'{prefix}_first_record_id'] is None:

--- a/models/position.py
+++ b/models/position.py
@@ -1,4 +1,5 @@
 
+import helpers.agency
 import helpers.departure
 import helpers.system
 
@@ -26,8 +27,9 @@ class Position:
     @classmethod
     def from_db(cls, row, prefix='position'):
         '''Returns a position initialized from the given database row'''
+        agency = helpers.agency.find('bc-transit')
         system = helpers.system.find(row[f'{prefix}_system_id'])
-        bus = Bus(row[f'{prefix}_bus_number'])
+        bus = Bus.find(agency, row[f'{prefix}_bus_number'])
         trip_id = row[f'{prefix}_trip_id']
         stop_id = row[f'{prefix}_stop_id']
         block_id = row[f'{prefix}_block_id']
@@ -136,7 +138,7 @@ class Position:
                 data['bus_icon'] = 'ghost'
         if self.lon == 0 and self.lat == 0:
             data['bus_icon'] = 'fish'
-        adornment = self.bus.adornment
+        adornment = self.bus.find_adornment()
         if adornment is not None and adornment.enabled:
             data['adornment'] = str(adornment)
         trip = self.trip

--- a/models/record.py
+++ b/models/record.py
@@ -1,4 +1,5 @@
 
+import helpers.agency
 import helpers.system
 
 from models.bus import Bus
@@ -26,7 +27,8 @@ class Record:
     def from_db(cls, row, prefix='record'):
         '''Returns a record initialized from the given database row'''
         id = row[f'{prefix}_id']
-        bus = Bus(row[f'{prefix}_bus_number'])
+        agency = helpers.agency.find('bc-transit')
+        bus = Bus.find(agency, row[f'{prefix}_bus_number'])
         system = helpers.system.find(row[f'{prefix}_system_id'])
         date = Date.parse_db(row[f'{prefix}_date'], system.timezone)
         block_id = row[f'{prefix}_block_id']

--- a/models/transfer.py
+++ b/models/transfer.py
@@ -1,4 +1,5 @@
 
+import helpers.agency
 import helpers.system
 
 from models.bus import Bus
@@ -19,7 +20,8 @@ class Transfer:
     def from_db(cls, row, prefix='transfer'):
         '''Returns a transfer initialized from the given database row'''
         id = row[f'{prefix}_id']
-        bus = Bus(row[f'{prefix}_bus_number'])
+        agency = helpers.agency.find('bc-transit')
+        bus = Bus.find(agency, row[f'{prefix}_bus_number'])
         old_system = helpers.system.find(row[f'{prefix}_old_system_id'])
         new_system = helpers.system.find(row[f'{prefix}_new_system_id'])
         date = Date.parse_db(row[f'{prefix}_date'], new_system.timezone)

--- a/realtime.py
+++ b/realtime.py
@@ -48,8 +48,9 @@ def update(system):
             vehicle = entity.vehicle
             try:
                 vehicle_id = vehicle.vehicle.id
-                if len(vehicle_id) > 4:
-                    vehicle_id = vehicle_id[-4:]
+                vehicle_name_length = system.agency.vehicle_name_length
+                if vehicle_name_length is not None and len(vehicle_id) > vehicle_name_length:
+                    vehicle_id = vehicle_id[-vehicle_name_length:]
                 bus_number = int(vehicle_id)
             except:
                 bus_number = -(index + 1)

--- a/server.py
+++ b/server.py
@@ -317,7 +317,8 @@ def realtime_speed_page(system):
 
 @endpoint('/fleet')
 def fleet_page(system):
-    orders = helpers.order.find_all()
+    agency = helpers.agency.find('bc-transit')
+    orders = helpers.order.find_all(agency)
     overviews = helpers.overview.find_all()
     return page('fleet', system,
         title='Fleet',
@@ -328,7 +329,8 @@ def fleet_page(system):
 
 @endpoint('/bus/<bus_number:int>')
 def bus_overview_page(system, bus_number):
-    bus = Bus(bus_number)
+    agency = helpers.agency.find('bc-transit')
+    bus = Bus.find(agency, bus_number)
     overview = helpers.overview.find(bus)
     if (bus.order is None and overview is None) or not bus.visible:
         return error_page('invalid_bus', system,
@@ -348,7 +350,8 @@ def bus_overview_page(system, bus_number):
 
 @endpoint('/bus/<bus_number:int>/map')
 def bus_map_page(system, bus_number):
-    bus = Bus(bus_number)
+    agency = helpers.agency.find('bc-transit')
+    bus = Bus.find(agency, bus_number)
     overview = helpers.overview.find(bus)
     if (bus.order is None and overview is None) or not bus.visible:
         return error_page('invalid_bus', system,
@@ -366,7 +369,8 @@ def bus_map_page(system, bus_number):
 
 @endpoint('/bus/<bus_number:int>/history')
 def bus_history_page(system, bus_number):
-    bus = Bus(bus_number)
+    agency = helpers.agency.find('bc-transit')
+    bus = Bus.find(agency, bus_number)
     overview = helpers.overview.find(bus)
     if (bus.order is None and overview is None) or not bus.visible:
         return error_page('invalid_bus', system,
@@ -877,11 +881,12 @@ def api_shape_id(system, shape_id):
 
 @endpoint('/api/search', method='POST')
 def api_search(system):
+    agency = helpers.agency.find('bc-transit')
     query = request.forms.get('query', '')
     matches = []
     if query != '':
         if query.isnumeric() and (system is None or system.realtime_enabled):
-            matches += helpers.order.find_matches(query, helpers.overview.find_bus_numbers(system))
+            matches += helpers.order.find_matches(agency, query, helpers.overview.find_bus_numbers(system))
         if system is not None:
             matches += system.search_blocks(query)
             matches += system.search_routes(query)

--- a/static/adornments.json
+++ b/static/adornments.json
@@ -1,35 +1,37 @@
 {
-    "1032": {
-        "text": "🎅",
-        "description": "Santa Bus",
-        "enabled": false
-    },
-    "1154": {
-        "text": "🎅",
-        "description": "Santa Bus",
-        "enabled": false
-    },
-    "4017": {
-        "text": "🎅",
-        "description": "Santa Bus",
-        "enabled": false
-    },
-    "6018": {
-        "text": "🎅",
-        "description": "Santa Bus",
-        "enabled": false
-    },
-    "9093": {
-        "text": "⚡",
-        "description": "Battery Bus Demo"
-    },
-    "9387": {
-        "text": "🏳️‍🌈",
-        "description": "Pride Bus"
-    },
-    "9434": {
-        "text": "🎄",
-        "description": "Christmas Bus",
-        "enabled": false
+    "bc-transit": {
+        "1032": {
+            "text": "🎅",
+            "description": "Santa Bus",
+            "enabled": false
+        },
+        "1154": {
+            "text": "🎅",
+            "description": "Santa Bus",
+            "enabled": false
+        },
+        "4017": {
+            "text": "🎅",
+            "description": "Santa Bus",
+            "enabled": false
+        },
+        "6018": {
+            "text": "🎅",
+            "description": "Santa Bus",
+            "enabled": false
+        },
+        "9093": {
+            "text": "⚡",
+            "description": "Battery Bus Demo"
+        },
+        "9387": {
+            "text": "🏳️‍🌈",
+            "description": "Pride Bus"
+        },
+        "9434": {
+            "text": "🎄",
+            "description": "Christmas Bus",
+            "enabled": false
+        }
     }
 }

--- a/static/agencies.json
+++ b/static/agencies.json
@@ -3,6 +3,7 @@
         "name": "BC Transit",
         "gtfs_url": "https://bct.tmix.se/Tmix.Cap.TdExport.WebApi/gtfs/?operatorIds=$REMOTE_ID",
         "realtime_url": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=$REMOTE_ID",
-        "prefix_headsigns": true
+        "prefix_headsigns": true,
+        "vehicle_name_length": 4
     }
 }

--- a/static/orders.json
+++ b/static/orders.json
@@ -1,159 +1,161 @@
 {
-    "alexander-dennis-enviro500": [
-        { "year": 2004, "low": 9041, "high": 9049 },
-        { "year": 2008, "low": 9501, "high": 9526 },
-        { "year": 2007, "number": 9528 },
-        { "year": 2008, "low": 9529, "high": 9531 },
-        { "year": 2020, "low": 9532, "high": 9542 },
-        { "year": 2022, "low": 9543, "high": 9550 }
-    ],
-    "alexander-dennis-enviro500h": [
-        { "year": 2008, "number":9527 }
-    ],
-    "byd-k9": [
-        { "year": 2016, "number": 9092, "demo": true }
-    ],
-    "chevrolet-arboc-4500-sof-27": [
-        { "year": 2020, "low": 2723, "high": 2756 },
-        { "year": 2022, "low": 2802, "high": 2860 },
-        { "year": 2023, "low": 2861, "high": 2895 }
-    ],
-    "chevrolet-arboc-4500-som-28": [
-        { "year": 2017, "low": 2641, "high": 2662 },
-        { "year": 2018, "low": 2663, "high": 2687 }
-    ],
-    "chevrolet-arboc-4500-som23d": [
-        { "year": 2010, "low": 2301, "high": 2310 }
-    ],
-    "chevrolet-arboc-4500-som28d": [
-        { "year": 2010, "low": 2311, "high": 2315 },
-        { "year": 2012, "low": 2316, "high": 2339 },
-        { "year": 2012, "low": 2342, "high": 2344 },
-        { "year": 2012, "low": 2347, "high": 2367 },
-        { "year": 2012, "low": 2369, "high": 2377 },
-        { "year": 2013, "low": 2378, "high": 2449 },
-        { "year": 2014, "low": 2451, "high": 2557 },
-        { "year": 2015, "low": 2558, "high": 2618 },
-        { "year": 2016, "low": 2625, "high": 2636 }
-    ],
-    "chevrolet-arboc-4500-som28g": [
-        { "year": 2015, "low": 2619, "high": 2624 },
-        { "year": 2016, "low": 2637, "high": 2640 }
-    ],
-    "chevrolet-girardin-4500-g5": [
-        { "year": 2020, "low": 2688, "high": 2722 },
-        { "year": 2021, "low": 2757, "high": 2784 }
-    ],
-    "dennis-dart-slf-30": [
-        { "year": 1999, "low": 9901, "high": 9951 }
-    ],
-    "dennis-dart-slf-35": [
-        { "year": 2000, "low": 1, "high": 18 },
-        { "year": 2001, "low": 101, "high": 116 },
-        { "year": 2002, "low": 221, "high": 237 },
-        { "year": 2000, "low": 9051, "high": 9078 },
-        { "year": 2001, "low": 9081, "high": 9085 }
-    ],
-    "dennis-trident": [
-        { "year": 2000, "low": 9001, "high": 9010 }
-    ],
-    "ford-cbb-e450-polar-v": [
-        { "year": 2009, "low": 2173, "high": 2240 }
-    ],
-    "ford-girardin-t350-mbii": [
-        { "year": 2021, "low": 2785, "high": 2801 }
-    ],
-    "grande-west-vicinity-27": [
-        { "year": 2013, "low": 3001, "high": 3015 }
-    ],
-    "grande-west-vicinity-30": [
-        { "year": 2017, "low": 4007, "high": 4070 },
-        { "year": 2018, "low": 4071, "high": 4073 }
-    ],
-    "grande-west-vicinity-35": [
-        { "year": 2017, "low": 4400, "high": 4432 },
-        { "year": 2018, "low": 4433, "high": 4474 }
-    ],
-    "grande-west-vicinity-cng-30": [
-        { "year": 2020, "low": 4200, "high": 4233 }
-    ],
-    "international-eldorado-3200-advantage": [
-        { "year": 2022, "low": 3029, "high": 3034 }
-    ],
-    "international-eldorado-3200-aero-elite": [
-        { "year": 2015, "low": 3016, "high": 3023, "exceptions": [ 3020, 3022 ] },
-        { "year": 2018, "low": 3024, "high": 3028 }
-    ],
-    "mercedes-benz-sprinter-minibus": [
-        { "year": 2012, "low": 2340, "high": 2341 },
-        { "year": 2012, "low": 2345, "high": 2346 },
-        { "year": 2012, "number": 2368 },
-        { "year": 2011, "number": 2450 }
-    ],
-    "new-flyer-d40lf": [
-        { "year": 1991, "low": 8001, "high": 8009 },
-        { "year": 1992, "low": 8010, "high": 8033 },
-        { "year": 1994, "low": 8034, "high": 8048 },
-        { "year": 1995, "low": 8049, "high": 8094 },
-        { "year": 1996, "low": 8095, "high": 8117 },
-        { "year": 1996, "low": 9701, "high": 9749 },
-        { "year": 1995, "low": 9750, "high": 9760 },
-        { "year": 1998, "low": 9815, "high": 9828 },
-        { "year": 1998, "low": 9831, "high": 9856 },
-        { "year": 1998, "low": 9861, "high": 9878 },
-        { "year": 1998, "low": 9881, "high": 9891 }
-    ],
-    "new-flyer-de40lf": [
-        { "year": 2005, "low": 9101, "high": 9106 }
-    ],
-    "new-flyer-h40lfr": [
-        { "year": 2009, "low": 1000, "high": 1019 }
-    ],
-    "new-flyer-xn40": [
-        { "year": 2013, "low": 1020, "high": 1044 },
-        { "year": 2015, "low": 1045, "high": 1069 },
-        { "year": 2016, "low": 1070, "high": 1114 },
-        { "year": 2017, "low": 1115, "high": 1139 },
-        { "year": 2018, "low": 1140, "high": 1148 },
-        { "year": 2019, "low": 1149, "high": 1185 },
-        { "year": 2020, "low": 1186, "high": 1212 },
-        { "year": 2021, "low": 1213, "high": 1232 },
-        { "year": 2022, "low": 1233, "high": 1253 }
-    ],
-    "nova-bus-lfs": [
-        { "year": 2017, "low": 6000, "high": 6029 },
-        { "year": 2006, "low": 9201, "high": 9231 },
-        { "year": 2007, "low": 9232, "high": 9267 },
-        { "year": 2008, "low": 9268, "high": 9289 },
-        { "year": 2008, "low": 9301, "high": 9318 },
-        { "year": 2009, "low": 9319, "high": 9433 },
-        { "year": 2012, "number": 9434 },
-        { "year": 2013, "low": 9435, "high": 9446 },
-        { "year": 2015, "low": 9447, "high": 9486 }
-    ],
-    "nova-bus-lfs-suburban": [
-        { "year": 2008, "low": 9290, "high": 9300 }
-    ],
-    "proterra-zx5": [
-        { "year": 2022, "number": 9093, "demo": true }
-    ],
-    "transbus-trident": [
-        { "year": 2002, "low": 9021, "high": 9039 }
-    ],
-    "unknown": [
-        { "number": 0, "visible": false },
-        { "number": 46, "visible": false },
-        { "number": 49, "visible": false },
-        { "number": 53, "visible": false },
-        { "number": 65, "visible": false },
-        { "low": 92, "high": 94, "visible": false },
-        { "low": 990, "high": 999, "visible": false },
-        { "number": 1717, "visible": false },
-        { "number": 7404, "visible": false },
-        { "number": 7812, "visible": false },
-        { "low": 9980, "high": 9999, "visible": false }
-    ],
-    "vmc-classic-vi30-cng": [
-        { "year": 2022, "low": 4234, "high": 4248 }
-    ]
+    "bc-transit": {
+        "alexander-dennis-enviro500": [
+            { "year": 2004, "low": 9041, "high": 9049 },
+            { "year": 2008, "low": 9501, "high": 9526 },
+            { "year": 2007, "number": 9528 },
+            { "year": 2008, "low": 9529, "high": 9531 },
+            { "year": 2020, "low": 9532, "high": 9542 },
+            { "year": 2022, "low": 9543, "high": 9550 }
+        ],
+        "alexander-dennis-enviro500h": [
+            { "year": 2008, "number": 9527 }
+        ],
+        "byd-k9": [
+            { "year": 2016, "number": 9092, "demo": true }
+        ],
+        "chevrolet-arboc-4500-sof-27": [
+            { "year": 2020, "low": 2723, "high": 2756 },
+            { "year": 2022, "low": 2802, "high": 2860 },
+            { "year": 2023, "low": 2861, "high": 2895 }
+        ],
+        "chevrolet-arboc-4500-som-28": [
+            { "year": 2017, "low": 2641, "high": 2662 },
+            { "year": 2018, "low": 2663, "high": 2687 }
+        ],
+        "chevrolet-arboc-4500-som23d": [
+            { "year": 2010, "low": 2301, "high": 2310 }
+        ],
+        "chevrolet-arboc-4500-som28d": [
+            { "year": 2010, "low": 2311, "high": 2315 },
+            { "year": 2012, "low": 2316, "high": 2339 },
+            { "year": 2012, "low": 2342, "high": 2344 },
+            { "year": 2012, "low": 2347, "high": 2367 },
+            { "year": 2012, "low": 2369, "high": 2377 },
+            { "year": 2013, "low": 2378, "high": 2449 },
+            { "year": 2014, "low": 2451, "high": 2557 },
+            { "year": 2015, "low": 2558, "high": 2618 },
+            { "year": 2016, "low": 2625, "high": 2636 }
+        ],
+        "chevrolet-arboc-4500-som28g": [
+            { "year": 2015, "low": 2619, "high": 2624 },
+            { "year": 2016, "low": 2637, "high": 2640 }
+        ],
+        "chevrolet-girardin-4500-g5": [
+            { "year": 2020, "low": 2688, "high": 2722 },
+            { "year": 2021, "low": 2757, "high": 2784 }
+        ],
+        "dennis-dart-slf-30": [
+            { "year": 1999, "low": 9901, "high": 9951 }
+        ],
+        "dennis-dart-slf-35": [
+            { "year": 2000, "low": 1, "high": 18 },
+            { "year": 2001, "low": 101, "high": 116 },
+            { "year": 2002, "low": 221, "high": 237 },
+            { "year": 2000, "low": 9051, "high": 9078 },
+            { "year": 2001, "low": 9081, "high": 9085 }
+        ],
+        "dennis-trident": [
+            { "year": 2000, "low": 9001, "high": 9010 }
+        ],
+        "ford-cbb-e450-polar-v": [
+            { "year": 2009, "low": 2173, "high": 2240 }
+        ],
+        "ford-girardin-t350-mbii": [
+            { "year": 2021, "low": 2785, "high": 2801 }
+        ],
+        "grande-west-vicinity-27": [
+            { "year": 2013, "low": 3001, "high": 3015 }
+        ],
+        "grande-west-vicinity-30": [
+            { "year": 2017, "low": 4007, "high": 4070 },
+            { "year": 2018, "low": 4071, "high": 4073 }
+        ],
+        "grande-west-vicinity-35": [
+            { "year": 2017, "low": 4400, "high": 4432 },
+            { "year": 2018, "low": 4433, "high": 4474 }
+        ],
+        "grande-west-vicinity-cng-30": [
+            { "year": 2020, "low": 4200, "high": 4233 }
+        ],
+        "international-eldorado-3200-advantage": [
+            { "year": 2022, "low": 3029, "high": 3034 }
+        ],
+        "international-eldorado-3200-aero-elite": [
+            { "year": 2015, "low": 3016, "high": 3023, "exceptions": [ 3020, 3022 ] },
+            { "year": 2018, "low": 3024, "high": 3028 }
+        ],
+        "mercedes-benz-sprinter-minibus": [
+            { "year": 2012, "low": 2340, "high": 2341 },
+            { "year": 2012, "low": 2345, "high": 2346 },
+            { "year": 2012, "number": 2368 },
+            { "year": 2011, "number": 2450 }
+        ],
+        "new-flyer-d40lf": [
+            { "year": 1991, "low": 8001, "high": 8009 },
+            { "year": 1992, "low": 8010, "high": 8033 },
+            { "year": 1994, "low": 8034, "high": 8048 },
+            { "year": 1995, "low": 8049, "high": 8094 },
+            { "year": 1996, "low": 8095, "high": 8117 },
+            { "year": 1996, "low": 9701, "high": 9749 },
+            { "year": 1995, "low": 9750, "high": 9760 },
+            { "year": 1998, "low": 9815, "high": 9828 },
+            { "year": 1998, "low": 9831, "high": 9856 },
+            { "year": 1998, "low": 9861, "high": 9878 },
+            { "year": 1998, "low": 9881, "high": 9891 }
+        ],
+        "new-flyer-de40lf": [
+            { "year": 2005, "low": 9101, "high": 9106 }
+        ],
+        "new-flyer-h40lfr": [
+            { "year": 2009, "low": 1000, "high": 1019 }
+        ],
+        "new-flyer-xn40": [
+            { "year": 2013, "low": 1020, "high": 1044 },
+            { "year": 2015, "low": 1045, "high": 1069 },
+            { "year": 2016, "low": 1070, "high": 1114 },
+            { "year": 2017, "low": 1115, "high": 1139 },
+            { "year": 2018, "low": 1140, "high": 1148 },
+            { "year": 2019, "low": 1149, "high": 1185 },
+            { "year": 2020, "low": 1186, "high": 1212 },
+            { "year": 2021, "low": 1213, "high": 1232 },
+            { "year": 2022, "low": 1233, "high": 1253 }
+        ],
+        "nova-bus-lfs": [
+            { "year": 2017, "low": 6000, "high": 6029 },
+            { "year": 2006, "low": 9201, "high": 9231 },
+            { "year": 2007, "low": 9232, "high": 9267 },
+            { "year": 2008, "low": 9268, "high": 9289 },
+            { "year": 2008, "low": 9301, "high": 9318 },
+            { "year": 2009, "low": 9319, "high": 9433 },
+            { "year": 2012, "number": 9434 },
+            { "year": 2013, "low": 9435, "high": 9446 },
+            { "year": 2015, "low": 9447, "high": 9486 }
+        ],
+        "nova-bus-lfs-suburban": [
+            { "year": 2008, "low": 9290, "high": 9300 }
+        ],
+        "proterra-zx5": [
+            { "year": 2022, "number": 9093, "demo": true }
+        ],
+        "transbus-trident": [
+            { "year": 2002, "low": 9021, "high": 9039 }
+        ],
+        "unknown": [
+            { "number": 0, "visible": false },
+            { "number": 46, "visible": false },
+            { "number": 49, "visible": false },
+            { "number": 53, "visible": false },
+            { "number": 65, "visible": false },
+            { "low": 92, "high": 94, "visible": false },
+            { "low": 990, "high": 999, "visible": false },
+            { "number": 1717, "visible": false },
+            { "number": 7404, "visible": false },
+            { "number": 7812, "visible": false },
+            { "low": 9980, "high": 9999, "visible": false }
+        ],
+        "vmc-classic-vi30-cng": [
+            { "year": 2022, "low": 4234, "high": 4248 }
+        ]
+    }
 }

--- a/views/components/bus.tpl
+++ b/views/components/bus.tpl
@@ -4,7 +4,7 @@
     % else:
         <div>{{ bus }}</div>
     % end
-    % adornment = bus.adornment
+    % adornment = bus.find_adornment()
     % if adornment is not None and adornment.enabled:
         <div class="adornment tooltip-anchor">
             {{ adornment }}


### PR DESCRIPTION
- Orders (and adornments) are now grouped by agency
- An agency is now required to get a valid order/adornment for each bus
  - In some cases this is acquired via a system we are dealing with, which has an agency association already
  - In other cases, we're just grabbing the `bc-transit` agency directly, since this is the existing default behaviour
  - Down the road, we'll need to update that second scenario to get the agency in other ways
    - When loading models from the DB, we can add a new column to those tables for the agency ID
    - When loading web pages, we'll need to add new pathing to specify the agency ID
- Agencies can now specify a `vehicle_name_length`
  - Default value is `None`, BCT value is set to `4`
  - Has two purposes - will trim vehicle names longer than that length (eliminating the v2 NR prefixes), and will pad extra 0s to shorter bus numbers (eg `1` -> `0001`)
- Adornments are no longer stored as a direct property of the bus model, now fetched when needed