### PR TITLE
Agency/system loading improvements

### DIFF
--- a/gtfs.py
+++ b/gtfs.py
@@ -68,6 +68,8 @@ def load(system, force_download=False, update_db=False):
         system.routes_by_number = {r.number: r for r in routes}
         
         system.blocks = {id: Block(system, id, trips) for id, trips in block_trips.items()}
+        
+        system.gtfs_loaded = True
     except Exception as e:
         print(f'Failed to load GTFS for {system}: {e}')
 

--- a/helpers/departure.py
+++ b/helpers/departure.py
@@ -6,24 +6,21 @@ import database
 def create(system, row):
     '''Inserts a new departure into the database'''
     system_id = getattr(system, 'id', system)
-    if 'pickup_type' in row:
+    try:
         pickup_type = PickupType(row['pickup_type'])
-    else:
+    except:
         pickup_type = PickupType.NORMAL
-    if 'drop_off_type' in row:
+    try:
         dropoff_type = DropoffType(row['drop_off_type'])
-    else:
+    except:
         dropoff_type = DropoffType.NORMAL
-    if 'timepoint' in row:
+    try:
         timepoint = row['timepoint'] == '1'
-    else:
+    except:
         timepoint = False
-    if 'shape_dist_traveled' in row:
-        try:
-            distance = int(row['shape_dist_traveled'])
-        except:
-            distance = None
-    else:
+    try:
+        distance = int(row['shape_dist_traveled'])
+    except:
         distance = None
     database.insert('departure', {
         'system_id': system_id,

--- a/helpers/departure.py
+++ b/helpers/departure.py
@@ -8,19 +8,19 @@ def create(system, row):
     system_id = getattr(system, 'id', system)
     try:
         pickup_type = PickupType(row['pickup_type'])
-    except:
+    except (KeyError, ValueError):
         pickup_type = PickupType.NORMAL
     try:
         dropoff_type = DropoffType(row['drop_off_type'])
-    except:
+    except (KeyError, ValueError):
         dropoff_type = DropoffType.NORMAL
     try:
         timepoint = row['timepoint'] == '1'
-    except:
+    except KeyError:
         timepoint = False
     try:
         distance = int(row['shape_dist_traveled'])
-    except:
+    except (KeyError, ValueError):
         distance = None
     database.insert('departure', {
         'system_id': system_id,

--- a/helpers/route.py
+++ b/helpers/route.py
@@ -6,13 +6,19 @@ import database
 def create(system, row):
     '''Inserts a new route into the database'''
     system_id = getattr(system, 'id', system)
-    if 'route_color' in row and row['route_color'] != '' and (not system.colour_routes or row['route_color'] != '000000'):
+    try:
         colour = row['route_color']
-    else:
+        if colour == '':
+            raise ValueError('Colour must not be empty')
+        if colour == system.colour_routes:
+            raise ValueError('Colour must be auto-generated')
+    except (KeyError, ValueError):
         colour = None
-    if 'route_text_color' in row and row['route_text_color'] != '':
+    try:
         text_colour = row['route_text_color']
-    else:
+        if text_colour == '':
+            raise ValueError('Text colour must not be empty')
+    except (KeyError, ValueError):
         text_colour = None
     database.insert('route', {
         'system_id': system_id,

--- a/models/adornment.py
+++ b/models/adornment.py
@@ -10,12 +10,12 @@ class Adornment:
         'enabled'
     )
     
-    def __init__(self, agency_id, bus_number, text, description=None, enabled=True):
+    def __init__(self, agency_id, bus_number, text, **kwargs):
         self.agency_id = agency_id
         self.bus_number = bus_number
         self.text = text
-        self.description = description
-        self.enabled = enabled
+        self.description = kwargs.get('description')
+        self.enabled = kwargs.get('enabled', True)
     
     def __str__(self):
         return self.text

--- a/models/agency.py
+++ b/models/agency.py
@@ -24,16 +24,16 @@ class Agency:
         '''Checks if realtime is enabled for this agency'''
         return self.enabled and self.realtime_url
     
-    def __init__(self, id, name, gtfs_url=None, realtime_url=None, enabled=True, prefix_headsigns=False, accurate_seconds=True, vehicle_name_length=None, distance_scale=1):
+    def __init__(self, id, name, **kwargs):
         self.id = id
         self.name = name
-        self.gtfs_url = gtfs_url
-        self.realtime_url = realtime_url
-        self.enabled = enabled
-        self.prefix_headsigns = prefix_headsigns
-        self.accurate_seconds = accurate_seconds
-        self.vehicle_name_length = vehicle_name_length
-        self.distance_scale = distance_scale
+        self.gtfs_url = kwargs.get('gtfs_url')
+        self.realtime_url = kwargs.get('realtime_url')
+        self.enabled = kwargs.get('enabled', True)
+        self.prefix_headsigns = kwargs.get('prefix_headsigns', False)
+        self.accurate_seconds = kwargs.get('accurate_seconds', True)
+        self.vehicle_name_length = kwargs.get('vehicle_name_length')
+        self.distance_scale = kwargs.get('distance_scale', 1)
     
     def __str__(self):
         return self.name

--- a/models/agency.py
+++ b/models/agency.py
@@ -8,7 +8,8 @@ class Agency:
         'gtfs_url',
         'realtime_url',
         'enabled',
-        'prefix_headsigns'
+        'prefix_headsigns',
+        'distance_scale'
     )
     
     @property
@@ -21,13 +22,14 @@ class Agency:
         '''Checks if realtime is enabled for this agency'''
         return self.enabled and self.realtime_url
     
-    def __init__(self, id, name, gtfs_url=None, realtime_url=None, enabled=True, prefix_headsigns=False):
+    def __init__(self, id, name, gtfs_url=None, realtime_url=None, enabled=True, prefix_headsigns=False, distance_scale=1):
         self.id = id
         self.name = name
         self.gtfs_url = gtfs_url
         self.realtime_url = realtime_url
         self.enabled = enabled
         self.prefix_headsigns = prefix_headsigns
+        self.distance_scale = distance_scale
     
     def __str__(self):
         return self.name

--- a/models/model.py
+++ b/models/model.py
@@ -28,8 +28,8 @@ class Model:
     __slots__ = (
         'id',
         'type',
-        'manufacturer',
         'name',
+        'manufacturer',
         'length',
         'fuel'
     )
@@ -37,6 +37,8 @@ class Model:
     @property
     def display_manufacturer(self):
         '''Formats the manufacturer for web display'''
+        if self.manufacturer is None:
+            return None
         return self.manufacturer.replace('/', '/<wbr />')
     
     @property
@@ -44,15 +46,17 @@ class Model:
         '''Formats the model name for web display'''
         return self.name.replace('/', '/<wbr />')
     
-    def __init__(self, id, type, manufacturer, name, length, fuel):
+    def __init__(self, id, type, name, **kwargs):
         self.id = id
         self.type = type
-        self.manufacturer = manufacturer
         self.name = name
-        self.length = length
-        self.fuel = fuel
+        self.manufacturer = kwargs.get('manufacturer')
+        self.length = kwargs.get('length')
+        self.fuel = kwargs.get('fuel')
     
     def __str__(self):
+        if self.manufacturer is None:
+            return self.display_name
         return f'{self.display_manufacturer} {self.display_name}'
     
     def __hash__(self):

--- a/models/order.py
+++ b/models/order.py
@@ -26,20 +26,20 @@ class Order:
         '''The last bus in the order'''
         return Bus(self.high, self)
     
-    def __init__(self, agency, model, number=None, low=None, high=None, year=None, visible=True, demo=False, exceptions=None):
+    def __init__(self, agency, model, **kwargs):
         self.agency = agency
         self.model = model
-        if number is None:
-            self.low = low
-            self.high = high
+        if 'number' in kwargs:
+            self.low = kwargs['number']
+            self.high = kwargs['number']
         else:
-            self.low = number
-            self.high = number
-        self.year = year
-        self.visible = visible
-        self.demo = demo
-        if exceptions:
-            self.exceptions = set(exceptions)
+            self.low = kwargs['low']
+            self.high = kwargs['high']
+        self.year = kwargs.get('year')
+        self.visible = kwargs.get('visible', True)
+        self.demo = kwargs.get('demo', False)
+        if 'exceptions' in kwargs:
+            self.exceptions = set(kwargs['exceptions'])
         else:
             self.exceptions = set()
         

--- a/models/region.py
+++ b/models/region.py
@@ -7,7 +7,7 @@ class Region:
         'name'
     )
     
-    def __init__(self, id, name):
+    def __init__(self, id, name, **kwargs):
         self.id = id
         self.name = name
     

--- a/models/system.py
+++ b/models/system.py
@@ -15,6 +15,7 @@ class System:
         'name',
         'remote_id',
         'colour_routes',
+        'gtfs_loaded',
         'validation_errors',
         'last_updated_date',
         'last_updated_time',
@@ -30,7 +31,7 @@ class System:
     )
     
     @property
-    def is_loaded(self):
+    def realtime_loaded(self):
         '''Checks if realtime data has been loaded'''
         return self.last_updated_date is not None and self.last_updated_time is not None
     
@@ -77,6 +78,7 @@ class System:
         self.remote_id = remote_id
         self.colour_routes = colour_routes
         
+        self.gtfs_loaded = False
         self.validation_errors = 0
         self.last_updated_date = None
         self.last_updated_time = None

--- a/models/system.py
+++ b/models/system.py
@@ -79,7 +79,7 @@ class System:
         self.name = name
         self.remote_id = kwargs.get('remote_id')
         self.timezone = pytz.timezone(kwargs.get('timezone', 'America/Vancouver'))
-        self.colour_routes = kwargs.get('colour_routes', False)
+        self.colour_routes = kwargs.get('colour_routes')
         
         self.gtfs_loaded = False
         self.validation_errors = 0

--- a/models/system.py
+++ b/models/system.py
@@ -72,14 +72,14 @@ class System:
         '''The overall service schedule for this system'''
         return Schedule.combine(self.get_services())
     
-    def __init__(self, id, agency, region, name, remote_id=None, timezone='America/Vancouver', colour_routes=False):
+    def __init__(self, id, agency, region, name, **kwargs):
         self.id = id
         self.agency = agency
         self.region = region
         self.name = name
-        self.remote_id = remote_id
-        self.timezone = pytz.timezone(timezone)
-        self.colour_routes = colour_routes
+        self.remote_id = kwargs.get('remote_id')
+        self.timezone = pytz.timezone(kwargs.get('timezone', 'America/Vancouver'))
+        self.colour_routes = kwargs.get('colour_routes', False)
         
         self.gtfs_loaded = False
         self.validation_errors = 0

--- a/models/theme.py
+++ b/models/theme.py
@@ -8,10 +8,10 @@ class Theme:
         'visible'
     )
     
-    def __init__(self, id, name, visible=True):
+    def __init__(self, id, name, **kwargs):
         self.id = id
         self.name = name
-        self.visible = visible
+        self.visible = kwargs.get('visible', True)
     
     def __str__(self):
         return self.name

--- a/static/agencies.json
+++ b/static/agencies.json
@@ -3,6 +3,7 @@
         "name": "BC Transit",
         "gtfs_url": "https://bct.tmix.se/Tmix.Cap.TdExport.WebApi/gtfs/?operatorIds=$REMOTE_ID",
         "realtime_url": "https://bct.tmix.se/gtfs-realtime/vehicleupdates.pb?operatorIds=$REMOTE_ID",
-        "prefix_headsigns": true
+        "prefix_headsigns": true,
+        "distance_scale": 1000
     }
 }

--- a/static/systems.json
+++ b/static/systems.json
@@ -28,7 +28,7 @@
             "salt-spring": {
                 "name": "Salt Spring Island",
                 "remote_id": 39,
-                "colour_routes": true
+                "colour_routes": "000000"
             },
             "victoria": {
                 "name": "Victoria",
@@ -43,12 +43,12 @@
             "pemberton": {
                 "name": "Pemberton",
                 "remote_id": 50,
-                "colour_routes": true
+                "colour_routes": "000000"
             },
             "powell-river": {
                 "name": "Powell River",
                 "remote_id": 29,
-                "colour_routes": true
+                "colour_routes": "000000"
             },
             "squamish": {
                 "name": "Squamish",
@@ -57,7 +57,7 @@
             "sunshine-coast": {
                 "name": "Sunshine Coast",
                 "remote_id": 18,
-                "colour_routes": true
+                "colour_routes": "000000"
             },
             "whistler": {
                 "name": "Whistler",
@@ -68,12 +68,12 @@
             "ashcroft-clinton": {
                 "name": "Ashcroft-Clinton",
                 "remote_id": 38,
-                "colour_routes": true
+                "colour_routes": "000000"
             },
             "clearwater": {
                 "name": "Clearwater",
                 "remote_id": 35,
-                "colour_routes": true
+                "colour_routes": "000000"
             },
             "creston-valley": {
                 "name": "Creston Valley",
@@ -84,7 +84,7 @@
                 "name": "East Kootenay",
                 "remote_id": 21,
                 "timezone": "America/Edmonton",
-                "colour_routes": true
+                "colour_routes": "000000"
             },
             "kamloops": {
                 "name": "Kamloops",
@@ -97,7 +97,7 @@
             "merritt": {
                 "name": "Merritt",
                 "remote_id": 37,
-                "colour_routes": true
+                "colour_routes": "000000"
             },
             "north-okanagan": {
                 "name": "North Okanagan",
@@ -106,7 +106,7 @@
             "revelstoke": {
                 "name": "Revelstoke",
                 "remote_id": 36,
-                "colour_routes": true
+                "colour_routes": "004B8D"
             },
             "south-okanagan": {
                 "name": "South Okanagan",
@@ -121,12 +121,12 @@
             "100-mile-house": {
                 "name": "100 Mile House",
                 "remote_id": 34,
-                "colour_routes": true
+                "colour_routes": "000000"
             },
             "bella-coola": {
                 "name": "Bella Coola",
                 "remote_id": 30,
-                "colour_routes": true
+                "colour_routes": "000000"
             },
             "dawson-creek": {
                 "name": "Dawson Creek",
@@ -141,12 +141,12 @@
             "kitimat": {
                 "name": "Kitimat-Stikine",
                 "remote_id": 26,
-                "colour_routes": true
+                "colour_routes": "000000"
             },
             "prince-george": {
                 "name": "Prince George",
                 "remote_id": 22,
-                "colour_routes": true
+                "colour_routes": "000000"
             },
             "prince-rupert": {
                 "name": "Prince Rupert",
@@ -155,17 +155,17 @@
             "quesnel": {
                 "name": "Quesnel",
                 "remote_id": 32,
-                "colour_routes": true
+                "colour_routes": "000000"
             },
             "smithers": {
                 "name": "Smithers",
                 "remote_id": 31,
-                "colour_routes": true
+                "colour_routes": "000000"
             },
             "williams-lake": {
                 "name": "Williams Lake",
                 "remote_id": 33,
-                "colour_routes": true
+                "colour_routes": "000000"
             }
         }
     }

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -269,7 +269,7 @@
                         % end
                     </div>
                     <div id="last-updated">
-                        % if system is None or (system.is_loaded and system.realtime_enabled):
+                        % if system is None or (system.realtime_enabled and system.realtime_loaded):
                             Updated {{ last_updated }}
                         % end
                     </div>
@@ -290,7 +290,7 @@
                     % region_systems = [s for s in systems if s.region == region]
                     % if len(region_systems) > 0:
                         <div class="header">{{ region }}</div>
-                        % for region_system in region_systems:
+                        % for region_system in sorted(region_systems):
                             % if system is not None and system == region_system:
                                 <span class="system-button current">{{ region_system }}</span>
                             % else:

--- a/views/components/systems.tpl
+++ b/views/components/systems.tpl
@@ -28,7 +28,7 @@
 					</td>
 				</tr>
 				<tr class="display-none"></tr>
-				% for region_system in region_systems:
+				% for region_system in sorted(region_systems):
 					% count = len(region_system.get_routes())
 					<tr>
 						<td>

--- a/views/frames/nearby.tpl
+++ b/views/frames/nearby.tpl
@@ -11,7 +11,7 @@
     <div class="section">
         <div class="placeholder">
             <h3>No stops nearby</h3>
-            % if system.is_loaded:
+            % if system.gtfs_loaded:
                 <p>You're gonna have to walk!</p>
             % else:
                 <p>System data is currently loading and will be available soon.</p>

--- a/views/pages/admin.tpl
+++ b/views/pages/admin.tpl
@@ -40,7 +40,7 @@
                                 </div>
                                 <div class="content">
                                     <div class="container inline">
-                                        % for region_system in region_systems:
+                                        % for region_system in sorted(region_systems):
                                             <div class="section">
                                                 <div class="header">
                                                     <h4>{{ region_system }}</h4>

--- a/views/pages/blocks/date.tpl
+++ b/views/pages/blocks/date.tpl
@@ -51,7 +51,7 @@
                     % blocks = sorted([b for b in system.get_blocks() if date in b.schedule], key=lambda b: (b.get_start_time(date=date), b.get_end_time(date=date)))
                     % if len(blocks) == 0:
                         <div class="placeholder">
-                            % if system.is_loaded:
+                            % if system.gtfs_loaded:
                                 <h3>No blocks found for {{ system }} on {{ date.format_long() }}</h3>
                                 <p>There are a few reasons why that might be the case:</p>
                                 <ol>

--- a/views/pages/blocks/list.tpl
+++ b/views/pages/blocks/list.tpl
@@ -26,14 +26,14 @@
                             </td>
                         </tr>
                         <tr class="display-none"></tr>
-                        % for region_system in region_systems:
+                        % for region_system in sorted(region_systems):
                             % count = len(region_system.get_blocks())
                             <tr>
                                 <td>
                                     <div class="flex-column">
                                         <a href="{{ get_url(region_system, path) }}">{{ region_system }}</a>
                                         <span class="mobile-only smaller-font">
-                                            % if region_system.is_loaded:
+                                            % if region_system.gtfs_loaded:
                                                 % if count == 1:
                                                     1 Block
                                                 % else:
@@ -43,7 +43,7 @@
                                         </span>
                                     </div>
                                 </td>
-                                % if region_system.is_loaded:
+                                % if region_system.gtfs_loaded:
                                     <td class="non-mobile">{{ count }}</td>
                                     <td>
                                         % include('components/weekdays_indicator', schedule=region_system.schedule, compact=True, schedule_path='blocks')
@@ -63,7 +63,7 @@
     % if len(blocks) == 0:
         <div class="placeholder">
             <h3>Block information for {{ system }} is unavailable</h3>
-            % if system.is_loaded:
+            % if system.gtfs_loaded:
                 <p>Please check again later!</p>
             % else:
                 <p>System data is currently loading and will be available soon.</p>

--- a/views/pages/bus/overview.tpl
+++ b/views/pages/bus/overview.tpl
@@ -186,14 +186,18 @@
                             <div class="name">Vehicle Type</div>
                             <div class="value">{{ model.type }}</div>
                         </div>
-                        <div class="section">
-                            <div class="name">Length</div>
-                            <div class="value">{{ model.length }} feet</div>
-                        </div>
-                        <div class="section">
-                            <div class="name">Fuel Type</div>
-                            <div class="value">{{ model.fuel }}</div>
-                        </div>
+                        % if model.length is not None:
+                            <div class="section">
+                                <div class="name">Length</div>
+                                <div class="value">{{ model.length }} feet</div>
+                            </div>
+                        % end
+                        % if model.fuel is not None:
+                            <div class="section">
+                                <div class="name">Fuel Type</div>
+                                <div class="value">{{ model.fuel }}</div>
+                            </div>
+                        % end
                     </div>
                 </div>
             </div>

--- a/views/pages/errors/invalid_block.tpl
+++ b/views/pages/errors/invalid_block.tpl
@@ -7,9 +7,7 @@
 
 <div class="placeholder">
     <h3>The block you are looking for doesn't seem to exist!</h3>
-    % if not system.is_loaded:
-        <p>System data is currently loading and will be available soon.</p>
-    % else:
+    % if system.gtfs_loaded:
         <p>There are a few reasons why that might be the case:</p>
         <ol>
             <li>It may be from an older sheet that is no longer active</li>
@@ -29,5 +27,7 @@
         <p>If you believe this error is incorrect and the block actually should exist, please email <a href="mailto:james@bctracker.ca">james@bctracker.ca</a> to let us know!</p>
 
         <button class="button" onclick="window.history.back()">Back</button>
+    % else:
+     <p>System data is currently loading and will be available soon.</p>
     % end
 </div>

--- a/views/pages/errors/invalid_route.tpl
+++ b/views/pages/errors/invalid_route.tpl
@@ -7,9 +7,7 @@
 
 <div class="placeholder">
     <h3>The route you are looking for doesn't seem to exist!</h3>
-    % if not system.is_loaded:
-        <p>System data is currently loading and will be available soon.</p>
-    % else:
+    % if system.gtfs_loaded:
         <p>There are a few reasons why that might be the case:</p>
         <ol>
             <li>It may be from an older sheet that is no longer active</li>
@@ -31,5 +29,7 @@
         <p>If you believe this error is incorrect and the route actually should exist, please email <a href="mailto:james@bctracker.ca">james@bctracker.ca</a> to let us know!</p>
         
         <button class="button" onclick="window.history.back()">Back</button>
+    % else:
+        <p>System data is currently loading and will be available soon.</p>
     % end
 </div>

--- a/views/pages/errors/invalid_stop.tpl
+++ b/views/pages/errors/invalid_stop.tpl
@@ -7,9 +7,7 @@
 
 <div class="placeholder">
     <h3>The stop you are looking for doesn't seem to exist!</h3>
-    % if not system.is_loaded:
-        <p>System data is currently loading and will be available soon.</p>
-    % else:
+    % if system.gtfs_loaded:
         <p>There are a few reasons why that might be the case:</p>
         <ol>
             <li>It may no longer serve any bus routes and therefore be removed from the system</li>
@@ -30,5 +28,7 @@
         <p>If you believe this error is incorrect and the stop actually should exist, please email <a href="mailto:james@bctracker.ca">james@bctracker.ca</a> to let us know!</p>
         
         <button class="button" onclick="window.history.back()">Back</button>
+    % else:
+        <p>System data is currently loading and will be available soon.</p>
     % end
 </div>

--- a/views/pages/errors/invalid_trip.tpl
+++ b/views/pages/errors/invalid_trip.tpl
@@ -7,9 +7,7 @@
 
 <div class="placeholder">
     <h3>The trip you are looking for doesn't seem to exist!</h3>
-    % if not system.is_loaded:
-        <p>System data is currently loading and will be available soon.</p>
-    % else:
+    % if system.gtfs_loaded:
         <p>There are a few reasons why that might be the case:</p>
         <ol>
             <li>It may be from an older sheet that is no longer active</li>
@@ -29,5 +27,7 @@
         <p>If you believe this error is incorrect and the trip actually should exist, please email <a href="mailto:james@bctracker.ca">james@bctracker.ca</a> to let us know!</p>
         
         <button class="button" onclick="window.history.back()">Back</button>
+    % else:
+        <p>System data is currently loading and will be available soon.</p>
     % end
 </div>

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -76,7 +76,7 @@
                     <div class="non-desktop">
                         % include('components/systems')
                     </div>
-                % elif not system.is_loaded:
+                % elif not system.realtime_loaded:
                     <h3>Realtime information for {{ system }} is unavailable</h3>
                     <p>System data is currently loading and will be available soon.</p>
                 % elif not show_nis:

--- a/views/pages/nearby.tpl
+++ b/views/pages/nearby.tpl
@@ -45,14 +45,14 @@
                                         </td>
                                     </tr>
                                     <tr class="display-none"></tr>
-                                    % for region_system in region_systems:
+                                    % for region_system in sorted(region_systems):
                                         % count = len(region_system.get_stops())
                                         <tr>
                                             <td>
                                                 <div class="flex-column">
                                                     <a href="{{ get_url(region_system, path) }}">{{ region_system }}</a>
                                                     <span class="mobile-only smaller-font">
-                                                        % if region_system.is_loaded:
+                                                        % if region_system.gtfs_loaded:
                                                             % if count == 1:
                                                                 1 Stop
                                                             % else:
@@ -62,7 +62,7 @@
                                                     </span>
                                                 </div>
                                             </td>
-                                            % if region_system.is_loaded:
+                                            % if region_system.gtfs_loaded:
                                                 <td class="non-mobile">{{ count }}</td>
                                                 <td>
                                                     % include('components/weekdays_indicator', schedule=region_system.schedule, compact=True)

--- a/views/pages/realtime/all.tpl
+++ b/views/pages/realtime/all.tpl
@@ -54,7 +54,7 @@
                         <div class="non-desktop">
                             % include('components/systems')
                         </div>
-                    % elif not system.is_loaded:
+                    % elif not system.realtime_loaded:
                         <h3>Realtime information for {{ system }} is unavailable</h3>
                         <p>System data is currently loading and will be available soon.</p>
                     % elif not show_nis:

--- a/views/pages/realtime/models.tpl
+++ b/views/pages/realtime/models.tpl
@@ -54,7 +54,7 @@
                         <div class="non-desktop">
                             % include('components/systems')
                         </div>
-                    % elif not system.is_loaded:
+                    % elif not system.realtime_loaded:
                         <h3>Realtime information for {{ system }} is unavailable</h3>
                         <p>System data is currently loading and will be available soon.</p>
                     % elif not show_nis:

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -50,7 +50,7 @@
                 <div class="non-desktop">
                     % include('components/systems')
                 </div>
-            % elif not system.is_loaded:
+            % elif not system.realtime_loaded:
                 <h3>Realtime information for {{ system }} is unavailable</h3>
                 <p>System data is currently loading and will be available soon.</p>
             % elif not show_nis:

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -50,7 +50,7 @@
                         <div class="non-desktop">
                             % include('components/systems')
                         </div>
-                    % elif not system.is_loaded:
+                    % elif not system.realtime_loaded:
                         <h3>Realtime information for {{ system }} is unavailable</h3>
                         <p>System data is currently loading and will be available soon.</p>
                     % elif not show_nis:

--- a/views/pages/route/date.tpl
+++ b/views/pages/route/date.tpl
@@ -50,7 +50,7 @@
                 % trips = route.get_trips(date=date)
                 % if len(trips) == 0:
                     <div class="placeholder">
-                        % if system.is_loaded:
+                        % if system.gtfs_loaded:
                             <h3>No trips found on {{ date.format_long() }}</h3>
                             <p>There are a few reasons why that might be the case:</p>
                             <ol>

--- a/views/pages/route/map.tpl
+++ b/views/pages/route/map.tpl
@@ -17,7 +17,7 @@
 
 % if len(route.trips) == 0:
     <div class="placeholder">
-        % if system.is_loaded:
+        % if system.gtfs_loaded:
             <h3>There are currently no trips for this route</h3>
             <p>There are a few reasons why that may be the case:</p>
             <ol>

--- a/views/pages/route/overview.tpl
+++ b/views/pages/route/overview.tpl
@@ -125,7 +125,7 @@
             <div class="content">
                 % if len(trips) == 0:
                     <div class="placeholder">
-                        % if system.is_loaded:
+                        % if system.gtfs_loaded:
                             <h3>There are no trips for this route today</h3>
                             <p>You can check the <a href="{{ get_url(system, f'routes/{route.number}/schedule') }}">full schedule</a> for more information about when this route runs.</p>
                         % else:

--- a/views/pages/route/schedule.tpl
+++ b/views/pages/route/schedule.tpl
@@ -17,7 +17,7 @@
 
 % if len(route.trips) == 0:
     <div class="placeholder">
-        % if system.is_loaded:
+        % if system.gtfs_loaded:
             <h3>There are currently no trips for this route</h3>
             <p>There are a few reasons why that may be the case:</p>
             <ol>

--- a/views/pages/routes/list.tpl
+++ b/views/pages/routes/list.tpl
@@ -30,14 +30,14 @@
                             </td>
                         </tr>
                         <tr class="display-none"></tr>
-                        % for region_system in region_systems:
+                        % for region_system in sorted(region_systems):
                             % count = len(region_system.get_routes())
                             <tr>
                                 <td>
                                     <div class="flex-column">
                                         <a href="{{ get_url(region_system, path) }}">{{ region_system }}</a>
                                         <span class="mobile-only smaller-font">
-                                            % if region_system.is_loaded:
+                                            % if region_system.gtfs_loaded:
                                                 % if count == 1:
                                                     1 Route
                                                 % else:
@@ -47,7 +47,7 @@
                                         </span>
                                     </div>
                                 </td>
-                                % if region_system.is_loaded:
+                                % if region_system.gtfs_loaded:
                                     <td class="non-mobile">{{ count }}</td>
                                     <td>
                                         % include('components/weekdays_indicator', schedule=region_system.schedule, compact=True)
@@ -67,7 +67,7 @@
     % if len(routes) == 0:
         <div class="placeholder">
             <h3>Route information for {{ system }} is unavailable</h3>
-            % if system.is_loaded:
+            % if system.gtfs_loaded:
                 <p>Please check again later!</p>
             % else:
                 <p>System data is currently loading and will be available soon.</p>

--- a/views/pages/routes/map.tpl
+++ b/views/pages/routes/map.tpl
@@ -32,14 +32,14 @@
                             </td>
                         </tr>
                         <tr class="display-none"></tr>
-                        % for region_system in region_systems:
+                        % for region_system in sorted(region_systems):
                             % count = len(region_system.get_routes())
                             <tr>
                                 <td>
                                     <div class="flex-column">
                                         <a href="{{ get_url(region_system, path) }}">{{ region_system }}</a>
                                         <span class="mobile-only smaller-font">
-                                            % if region_system.is_loaded:
+                                            % if region_system.gtfs_loaded:
                                                 % if count == 1:
                                                     1 Route
                                                 % else:
@@ -49,7 +49,7 @@
                                         </span>
                                     </div>
                                 </td>
-                                % if region_system.is_loaded:
+                                % if region_system.gtfs_loaded:
                                     <td class="non-mobile">{{ count }}</td>
                                     <td>
                                         % include('components/weekdays_indicator', schedule=region_system.schedule, compact=True)
@@ -68,7 +68,7 @@
     % if len(routes) == 0:
         <div class="placeholder">
             <h3>Route information for {{ system }} is unavailable</h3>
-            % if system.is_loaded:
+            % if system.gtfs_loaded:
                 <p>Please check again later!</p>
             % else:
                 <p>System data is currently loading and will be available soon.</p>

--- a/views/pages/stop/date.tpl
+++ b/views/pages/stop/date.tpl
@@ -46,7 +46,7 @@
                 % departures = stop.find_departures(date=date)
                 % if len(departures) == 0:
                     <div class="placeholder">
-                        % if system.is_loaded:
+                        % if system.gtfs_loaded:
                             <h3>No departures found on {{ date.format_long() }}</h3>
                             <p>There are a few reasons why that might be the case:</p>
                             <ol>

--- a/views/pages/stop/overview.tpl
+++ b/views/pages/stop/overview.tpl
@@ -170,7 +170,7 @@
             <div class="content">
                 % if len(departures) == 0:
                     <div class="placeholder">
-                        % if system.is_loaded:
+                        % if system.gtfs_loaded:
                             <h3>There are no departures from this stop today</h3>
                             <p>You can check the <a href="{{ get_url(system, f'stops/{stop.number}/schedule') }}">full schedule</a> for more information about when this stop has service.</p>
                         % else:

--- a/views/pages/stop/schedule.tpl
+++ b/views/pages/stop/schedule.tpl
@@ -13,7 +13,7 @@
 
 % if len(stop.find_departures()) == 0:
     <div class="placeholder">
-        % if stop.is_loaded:
+        % if stop.gtfs_loaded:
             <h3>There are currently no departures from this stop</h3>
             <p>There are a few reasons why that may be the case:</p>
             <ol>

--- a/views/pages/stops.tpl
+++ b/views/pages/stops.tpl
@@ -36,7 +36,7 @@
                                     <div class="flex-column">
                                         <a href="{{ get_url(region_system, path) }}">{{ region_system }}</a>
                                         <span class="mobile-only smaller-font">
-                                            % if region_system.is_loaded:
+                                            % if region_system.gtfs_loaded:
                                                 % if count == 1:
                                                     1 Stop
                                                 % else:
@@ -46,7 +46,7 @@
                                         </span>
                                     </div>
                                 </td>
-                                % if region_system.is_loaded:
+                                % if region_system.gtfs_loaded:
                                     <td class="non-mobile">{{ count }}</td>
                                     <td>
                                         % include('components/weekdays_indicator', schedule=region_system.schedule, compact=True)
@@ -66,7 +66,7 @@
     % if len(stops) == 0 and search is None:
         <div class="placeholder">
             <h3>Stop information for {{ system }} is unavailable</h3>
-            % if system.is_loaded:
+            % if system.gtfs_loaded:
                 <p>Please check again later!</p>
             % else:
                 <p>System data is currently loading and will be available soon.</p>

--- a/views/pages/stops.tpl
+++ b/views/pages/stops.tpl
@@ -29,7 +29,7 @@
                             </td>
                         </tr>
                         <tr class="display-none"></tr>
-                        % for region_system in region_systems:
+                        % for region_system in sorted(region_systems):
                             % count = len(region_system.get_stops())
                             <tr>
                                 <td>

--- a/views/pages/systems.tpl
+++ b/views/pages/systems.tpl
@@ -28,62 +28,66 @@
             </tr>
             <tr class="display-none"></tr>
             % region_systems = sorted([s for s in systems if s.region == region])
-            % for region_system in region_systems:
+            % for region_system in sorted(region_systems):
                 <tr>
                     <td>
                         <a href="{{ get_url(region_system) }}">{{ region_system }}</a>
                     </td>
-                    % if region_system.is_loaded:
-                        <td class="non-desktop">
-                            <div class="flex-column">
-                                % if region_system.realtime_enabled:
-                                    % positions = region_system.get_positions()
-                                    % overviews = region_system.get_overviews()
-                                    <div class="flex-row flex-gap-5">
-                                        <span class="bold">Online:</span>
-                                        {{ len(positions) }}
-                                    </div>
-                                    <div class="flex-row flex-gap-5">
-                                        <span class="bold">In Service:</span>
-                                        {{ len([p for p in positions if p.trip is not None]) }}
-                                    </div>
-                                    <div class="flex-row flex-gap-5">
-                                        <span class="bold">Seen:</span>
-                                        {{ len(overviews) }}
-                                    </div>
-                                    <div class="flex-row flex-gap-5">
-                                        <span class="bold">Tracked:</span>
-                                        {{ len([o for o in overviews if o.last_record is not None]) }}
-                                    </div>
-                                % end
-                                % if region_system.gtfs_enabled:
-                                    <div class="flex-row flex-gap-5">
-                                        <span class="bold">Routes:</span>
-                                        {{ len(region_system.get_routes()) }}
-                                    </div>
-                                    <div class="flex-row flex-gap-5">
-                                        <span class="bold">Stops:</span>
-                                        {{ len(region_system.get_stops()) }}
-                                    </div>
-                                    <div class="flex-row flex-gap-5">
-                                        <span class="bold">Blocks:</span>
-                                        {{ len(region_system.get_blocks()) }}
-                                    </div>
-                                    <div class="flex-row flex-gap-5">
-                                        <span class="bold">Trips:</span>
-                                        {{ len(region_system.get_trips()) }}
-                                    </div>
-                                % end
-                            </div>
-                        </td>
-                        % if region_system.realtime_enabled:
+                    <td class="non-desktop">
+                        <div class="flex-column">
+                            % if region_system.realtime_enabled and region_system.realtime_loaded:
+                                % positions = region_system.get_positions()
+                                % overviews = region_system.get_overviews()
+                                <div class="flex-row flex-gap-5">
+                                    <span class="bold">Online:</span>
+                                    {{ len(positions) }}
+                                </div>
+                                <div class="flex-row flex-gap-5">
+                                    <span class="bold">In Service:</span>
+                                    {{ len([p for p in positions if p.trip is not None]) }}
+                                </div>
+                                <div class="flex-row flex-gap-5">
+                                    <span class="bold">Seen:</span>
+                                    {{ len(overviews) }}
+                                </div>
+                                <div class="flex-row flex-gap-5">
+                                    <span class="bold">Tracked:</span>
+                                    {{ len([o for o in overviews if o.last_record is not None]) }}
+                                </div>
+                            % end
+                            % if region_system.gtfs_enabled and region_system.gtfs_loaded:
+                                <div class="flex-row flex-gap-5">
+                                    <span class="bold">Routes:</span>
+                                    {{ len(region_system.get_routes()) }}
+                                </div>
+                                <div class="flex-row flex-gap-5">
+                                    <span class="bold">Stops:</span>
+                                    {{ len(region_system.get_stops()) }}
+                                </div>
+                                <div class="flex-row flex-gap-5">
+                                    <span class="bold">Blocks:</span>
+                                    {{ len(region_system.get_blocks()) }}
+                                </div>
+                                <div class="flex-row flex-gap-5">
+                                    <span class="bold">Trips:</span>
+                                    {{ len(region_system.get_trips()) }}
+                                </div>
+                            % end
+                        </div>
+                    </td>
+                    % if region_system.realtime_enabled:
+                        % if region_system.realtime_loaded:
                             <td class="desktop-only">{{ len(positions) }}</td>
                             <td class="desktop-only">{{ len([p for p in positions if p.trip is not None]) }}</td>
                             <td class="desktop-only">{{ len(overviews) }}</td>
                             <td class="desktop-only">{{ len([o for o in overviews if o.last_record is not None]) }}</td>
                         % else:
-                            <td class="lighter-text desktop-only" colspan="4">Unavailable</td>
+                            <td class="lighter-text desktop-only" colspan="4">Data is loading</td>
                         % end
+                    % else:
+                        <td class="lighter-text desktop-only" colspan="4">Unavailable</td>
+                    % end
+                    % if region_system.gtfs_enabled:
                         % if region_system.gtfs_enabled:
                             <td class="desktop-only">{{ len(region_system.get_routes()) }}</td>
                             <td class="desktop-only">{{ len(region_system.get_stops()) }}</td>
@@ -93,10 +97,10 @@
                                 % include('components/weekdays_indicator', schedule=region_system.schedule, compact=True)
                             </td>
                         % else:
-                            <td class="lighter-text non-mobile" colspan="5">Unavailable</td>
+                            <td class="lighter-text non-mobile" colspan="5">Data is loading</td>
                         % end
                     % else:
-                        <td class="lighter-text" colspan="11">Data is loading</td>
+                        <td class="lighter-text non-mobile" colspan="5">Unavailable</td>
                     % end
                 </tr>
             % end

--- a/views/pages/trip/overview.tpl
+++ b/views/pages/trip/overview.tpl
@@ -72,7 +72,7 @@
                     </div>
                     % length = trip.length
                     % if length is not None:
-                        % km = length / 1000
+                        % km = length / trip.system.agency.distance_scale
                         % hours = (float(trip.end_time.get_minutes() - trip.start_time.get_minutes())) / 60
                         <div class="section">
                             <div class="name">Length</div>


### PR DESCRIPTION
- Replaced `system.is_loaded` with `system.gtfs_loaded` and `system.realtime_loaded` to properly support systems that only have gtfs or realtime but not both
- Improved departure GTFS optional property reading
- All static JSON-based model files now init with `**kwargs` rather than listing out all values as parameters
  - Mainly because agencies were becoming a bit too unwieldy with so many parameters
  - Also makes things a bit more flexible for passing in unused parameters in the future
  - Any values that are required or sourced from elsewhere are still taken as explicit parameters
- Some vehicle model properties (manufacturer, length, fuel) are now optional
- Added `distance_scale` property for agencies, used to determine the scale of travel distances for trips
  - Default value is `1` (aka in km)
  - BCT is set to `1000` (aka in m)
- Region systems are now sorted rather than default order (affects nothing right now but will fix ordering when using multiple agencies)
- Auto route colour is now specified as a specific colour to replace, rather than just a boolean
  - Defaults to `None` for systems with no recolouring
  - Most systems that do recolour use `"000000"` which was previously always used
  - Revelstoke uses `"004B8D"` because it seems to be using that for all route colours currently