### PR TITLE
Cache improvements

### DIFF
--- a/models/route.py
+++ b/models/route.py
@@ -21,12 +21,7 @@ class Route:
         'key',
         'name',
         'colour',
-        'text_colour',
-        'is_setup',
-        '_trips',
-        '_schedule',
-        '_sheets',
-        '_indicator_points'
+        'text_colour'
     )
     
     @classmethod
@@ -45,24 +40,25 @@ class Route:
         return self.name.replace('/', '/<wbr />')
     
     @property
+    def cache(self):
+        '''Returns the cache for this route'''
+        return self.system.get_route_cache(self)
+    
+    @property
     def trips(self):
-        self.setup()
-        return self._trips
+        return self.cache.trips
     
     @property
     def schedule(self):
-        self.setup()
-        return self._schedule
+        return self.cache.schedule
     
     @property
     def sheets(self):
-        self.setup()
-        return self._sheets
+        return self.cache.sheets
     
     @property
     def indicator_points(self):
-        self.setup()
-        return self._indicator_points
+        return self.cache.indicator_points
     
     def __init__(self, system, id, number, name, colour, text_colour):
         self.system = system
@@ -73,12 +69,6 @@ class Route:
         self.text_colour = text_colour
         
         self.key = tuple([int(s) if s.isnumeric() else s for s in re.split('([0-9]+)', number)])
-        
-        self.is_setup = False
-        self._trips = []
-        self._schedule = None
-        self._sheets = []
-        self._indicator_points = []
     
     def __str__(self):
         return f'{self.number} {self.name}'
@@ -94,29 +84,6 @@ class Route:
     
     def __gt__(self, other):
         return self.key > other.key
-    
-    def setup(self, trips=None):
-        if self.is_setup:
-            return
-        self.is_setup = True
-        if trips is None:
-            trips = [t for t in self.system.get_trips() if t.route_id == self.id]
-        self._trips = trips
-        services = {t.service for t in trips}
-        self._schedule = Schedule.combine(services)
-        self._sheets = self.system.copy_sheets(services)
-        if len(trips) > 0:
-            sorted_trips = sorted(trips, key=lambda t: t.departure_count, reverse=True)
-            points = sorted_trips[0].find_points()
-            first_point = points[0]
-            last_point = points[-1]
-            distance = sqrt(((first_point.lat - last_point.lat) ** 2) + ((first_point.lon - last_point.lon) ** 2))
-            if distance <= 0.05:
-                count = min((len(points) // 500) + 1, 3)
-            else:
-                count = min(int(distance * 8) + 1, 4)
-            size = len(points) // count
-            self._indicator_points = [points[(i * size) + (size // 2)] for i in range(count)]
     
     def get_json(self):
         '''Returns a representation of this route in JSON-compatible format'''
@@ -191,3 +158,32 @@ def generate_colour(system, number):
     g = int(rgb[1] * 255)
     b = int(rgb[2] * 255)
     return f'{r:02x}{g:02x}{b:02x}'
+
+class RouteCache:
+    
+    __slots__ = (
+        'trips',
+        'schedule',
+        'sheets',
+        'indicator_points'
+    )
+    
+    def __init__(self, system, trips):
+        self.trips = trips
+        services = {t.service for t in trips}
+        self.schedule = Schedule.combine(services)
+        self.sheets = system.copy_sheets(services)
+        try:
+            sorted_trips = sorted(trips, key=lambda t: t.departure_count, reverse=True)
+            points = sorted_trips[0].find_points()
+            first_point = points[0]
+            last_point = points[-1]
+            distance = sqrt(((first_point.lat - last_point.lat) ** 2) + ((first_point.lon - last_point.lon) ** 2))
+            if distance <= 0.05:
+                count = min((len(points) // 500) + 1, 3)
+            else:
+                count = min(int(distance * 8) + 1, 4)
+            size = len(points) // count
+            self.indicator_points = [points[(i * size) + (size // 2)] for i in range(count)]
+        except IndexError:
+            self.indicator_points = []

--- a/models/route.py
+++ b/models/route.py
@@ -46,18 +46,22 @@ class Route:
     
     @property
     def trips(self):
+        '''Returns the trips for this route'''
         return self.cache.trips
     
     @property
     def schedule(self):
+        '''Returns the schedule for this route'''
         return self.cache.schedule
     
     @property
     def sheets(self):
+        '''Returns the sheets for this route'''
         return self.cache.sheets
     
     @property
     def indicator_points(self):
+        '''Returns the indicator points for this route'''
         return self.cache.indicator_points
     
     def __init__(self, system, id, number, name, colour, text_colour):
@@ -160,6 +164,7 @@ def generate_colour(system, number):
     return f'{r:02x}{g:02x}{b:02x}'
 
 class RouteCache:
+    '''A collection of calculated values for a single route'''
     
     __slots__ = (
         'trips',

--- a/models/stop.py
+++ b/models/stop.py
@@ -18,11 +18,7 @@ class Stop:
         'number',
         'name',
         'lat',
-        'lon',
-        'is_setup',
-        '_schedule',
-        '_sheets',
-        '_routes'
+        'lon'
     )
     
     @classmethod
@@ -42,19 +38,20 @@ class Stop:
         return sorted({s for s in stops if s.is_near(self.lat, self.lon) and self != s})
     
     @property
+    def cache(self):
+        return self.system.get_stop_cache(self)
+    
+    @property
     def schedule(self):
-        self.setup()
-        return self._schedule
+        return self.cache.schedule
     
     @property
     def sheets(self):
-        self.setup()
-        return self._sheets
+        return self.cache.sheets
     
     @property
     def routes(self):
-        self.setup()
-        return self._routes
+        return self.cache.routes
     
     def __init__(self, system, id, number, name, lat, lon):
         self.system = system
@@ -63,11 +60,6 @@ class Stop:
         self.name = name
         self.lat = lat
         self.lon = lon
-        
-        self.is_setup = False
-        self._schedule = None
-        self._sheets = []
-        self._routes = []
     
     def __str__(self):
         return self.name
@@ -82,17 +74,6 @@ class Stop:
         if self.name == other.name:
             return self.number < other.number
         return self.name < other.name
-    
-    def setup(self, departures=None):
-        if self.is_setup:
-            return
-        self.is_setup = True
-        if departures is None:
-            departures = helpers.departure.find_all(self.system, stop=self)
-        services = {d.trip.service for d in departures if d.trip is not None}
-        self._schedule = Schedule.combine(services)
-        self._sheets = self.system.copy_sheets(services)
-        self._routes = sorted({d.trip.route for d in departures if d.trip is not None and d.trip.route is not None})
     
     def get_json(self):
         '''Returns a representation of this stop in JSON-compatible format'''
@@ -141,3 +122,17 @@ class Stop:
     def find_adjacent_departures(self):
         '''Returns all departures on trips that serve this stop'''
         return helpers.departure.find_adjacent(self.system, self)
+
+class StopCache:
+    
+    __slots__ = (
+        'schedule',
+        'sheets',
+        'routes'
+    )
+    
+    def __init__(self, system, departures):
+        services = {d.trip.service for d in departures if d.trip is not None}
+        self.schedule = Schedule.combine(services)
+        self.sheets = system.copy_sheets(services)
+        self.routes = sorted({d.trip.route for d in departures if d.trip is not None and d.trip.route is not None})

--- a/models/stop.py
+++ b/models/stop.py
@@ -39,18 +39,22 @@ class Stop:
     
     @property
     def cache(self):
+        '''Returns the cache for this stop'''
         return self.system.get_stop_cache(self)
     
     @property
     def schedule(self):
+        '''Returns the schedule for this stop'''
         return self.cache.schedule
     
     @property
     def sheets(self):
+        '''Returns the sheets for this stop'''
         return self.cache.sheets
     
     @property
     def routes(self):
+        '''Returns the routes for this stop'''
         return self.cache.routes
     
     def __init__(self, system, id, number, name, lat, lon):
@@ -124,6 +128,7 @@ class Stop:
         return helpers.departure.find_adjacent(self.system, self)
 
 class StopCache:
+    '''A collection of calculated values for a single stop'''
     
     __slots__ = (
         'schedule',

--- a/models/system.py
+++ b/models/system.py
@@ -217,6 +217,9 @@ class System:
             return
         print(f'Updating cached data for {self}')
         try:
+            self.route_caches = {}
+            self.stop_caches = {}
+            self.trip_caches = {}
             departures = helpers.departure.find_all(self)
             trip_departures = {}
             stop_departures = {}

--- a/models/trip.py
+++ b/models/trip.py
@@ -110,22 +110,27 @@ class Trip:
     
     @property
     def cache(self):
+        '''Returns the cache for this trip'''
         return self.system.get_trip_cache(self)
     
     @property
     def first_departure(self):
+        '''Returns the first departure for this trip'''
         return self.cache.first_departure
     
     @property
     def last_departure(self):
+        '''Returns the last departure for this trip'''
         return self.cache.last_departure
     
     @property
     def departure_count(self):
+        '''Returns the departure count for this trip'''
         return self.cache.departure_count
     
     @property
     def direction(self):
+        '''Returns the direction for this trip'''
         return self.cache.direction
     
     def __init__(self, system, trip_id, route_id, service_id, block_id, direction_id, shape_id, headsign):
@@ -207,6 +212,7 @@ class Trip:
         return True
 
 class TripCache:
+    '''A collection of calculated values for a single trip'''
     
     __slots__ = (
         'first_departure',


### PR DESCRIPTION
- Cached values are no longer stored as properties of `Route`, `Stop`, and `Trip` models
- Added `RouteCache`, `StopCache`, and `TripCache` models
- Added `route_caches`, `stop_caches`, and `trip_caches` properties for systems
- Calling `system.update_cache()` now creates cache objects and stores them as part of the system
- Cached properties are now accessed through the system's cache

The main benefit here is that the caches are not associated with a single instance of a model. That means we can do stuff like load a list of routes from the database and access the cached values without having to recalculate them, since the data would previously only be available in the routes already in memory, not ones newly loaded.