### PR TITLE
Tooltip improvements

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -1155,11 +1155,12 @@ table tr.header td {
 }
 
 .tooltip-anchor .tooltip {
+    background-color: var(--tooltip-background);
+    color: var(--tooltip-text);
     display: none;
     padding: 5px 10px;
     position: absolute;
     z-index: 10;
-    left: calc(100% + 10px);
     box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
     top: 50%;
     transform: translate(0px, -50%);
@@ -1172,12 +1173,32 @@ table tr.header td {
     font-weight: normal;
 }
 
-.tooltip-anchor .tooltip::after {
+.tooltip-anchor .tooltip.left {
+    right: calc(100% + 10px);
+}
+
+.tooltip-anchor .tooltip.left::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 100%;
+    margin-top: -5px;
+    border-color: transparent transparent transparent var(--tooltip-background);
+    border-width: 5px 0px 5px 5px;
+    border-style: solid;
+}
+
+.tooltip-anchor .tooltip.right {
+    left: calc(100% + 10px);
+}
+
+.tooltip-anchor .tooltip.right::after {
     content: "";
     position: absolute;
     top: 50%;
     right: 100%;
     margin-top: -5px;
+    border-color: transparent var(--tooltip-background) transparent transparent;
     border-width: 5px 5px 5px 0px;
     border-style: solid;
 }

--- a/style/themes/bchydro.css
+++ b/style/themes/bchydro.css
@@ -16,6 +16,11 @@
  * Other colors may also be used for specific purposes
 */
 
+:root {
+    --tooltip-background: #666666;
+    --tooltip-text: #FFFFFF;
+}
+
 a {
     color: #026E6E;
 }
@@ -88,6 +93,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar {
     background-color: #61C315;
+    --tooltip-background: #347800;
 }
 
 #navigation-bar .navigation-icon {
@@ -104,14 +110,6 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar .navigation-icon img.black {
     display: none;
-}
-
-#navigation-bar .navigation-icon .tooltip {
-    background-color: #347800;
-}
-
-#navigation-bar .navigation-icon .tooltip::after {
-    border-color: transparent #347800 transparent transparent;
 }
 
 #navigation-bar .navigation-item {
@@ -194,6 +192,7 @@ table tr:nth-child(2n-1) {
     background-color: #249B9B;
     color: #FFFFFF;
     border-color: #666666;
+    --tooltip-background: #347800;
 }
 
 #search-input {
@@ -546,15 +545,6 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #666666;
-}
-
-.tooltip-anchor .tooltip {
-    background-color: #666666;
-    color: #FFFFFF;
-}
-
-.tooltip-anchor .tooltip::after {
-    border-color: transparent #666666 transparent transparent;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -16,6 +16,11 @@
  * Other colors may also be used for specific purposes
 */
 
+:root {
+    --tooltip-background: #69BB65;
+    --tooltip-text: #FFFFFF;
+}
+
 a {
     color: #D70000;
 }
@@ -88,6 +93,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar {
     background-color: #AB0000;
+    --tooltip-background: #7A0000;
 }
 
 #navigation-bar .navigation-icon {
@@ -104,14 +110,6 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar .navigation-icon img.black {
     display: none;
-}
-
-#navigation-bar .navigation-icon .tooltip {
-    background-color: #7A0000;
-}
-
-#navigation-bar .navigation-icon .tooltip::after {
-    border-color: transparent #7A0000 transparent transparent;
 }
 
 #navigation-bar .navigation-item {
@@ -178,6 +176,7 @@ table tr:nth-child(2n-1) {
     background-color: #D70000;
     color: #FFFFFF;
     border-color: #69BB65;
+    --tooltip-background: #7A0000;
 }
 
 #search-input {
@@ -530,15 +529,6 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #69BB65;
-}
-
-.tooltip-anchor .tooltip {
-    background-color: #69BB65;
-    color: #FFFFFF;
-}
-
-.tooltip-anchor .tooltip::after {
-    border-color: transparent #69BB65 transparent transparent;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/classic.css
+++ b/style/themes/classic.css
@@ -16,6 +16,11 @@
  * Other colors may also be used for specific purposes
 */
 
+:root {
+    --tooltip-background: #666666;
+    --tooltip-text: #FFFFFF;
+}
+
 a {
     color: #023496;
 }
@@ -88,6 +93,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar {
     background-color: #E20000;
+    --tooltip-background: #840000;
 }
 
 #navigation-bar .navigation-icon {
@@ -104,14 +110,6 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar .navigation-icon img.black {
     display: none;
-}
-
-#navigation-bar .navigation-icon .tooltip {
-    background-color: #840000;
-}
-
-#navigation-bar .navigation-icon .tooltip::after {
-    border-color: transparent #840000 transparent transparent;
 }
 
 #navigation-bar .navigation-item {
@@ -194,6 +192,7 @@ table tr:nth-child(2n-1) {
     background-color: #023496;
     color: #FFFFFF;
     border-color: #666666;
+    --tooltip-background: #840000;
 }
 
 #search-input {
@@ -546,15 +545,6 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #666666;
-}
-
-.tooltip-anchor .tooltip {
-    background-color: #666666;
-    color: #FFFFFF;
-}
-
-.tooltip-anchor .tooltip::after {
-    border-color: transparent #666666 transparent transparent;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/contrast.css
+++ b/style/themes/contrast.css
@@ -16,6 +16,11 @@
  * Other colors may also be used for specific purposes
 */
 
+:root {
+    --tooltip-background: #666666;
+    --tooltip-text: #FFFFFF;
+}
+
 a {
     color: #0040FF;
 }
@@ -88,6 +93,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar {
     background-color: #1A671A;
+    --tooltip-background: #094409;
 }
 
 #navigation-bar .navigation-icon {
@@ -104,14 +110,6 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar .navigation-icon img.black {
     display: none;
-}
-
-#navigation-bar .navigation-icon .tooltip {
-    background-color: #094409;
-}
-
-#navigation-bar .navigation-icon .tooltip::after {
-    border-color: transparent #094409 transparent transparent;
 }
 
 #navigation-bar .navigation-item {
@@ -194,6 +192,7 @@ table tr:nth-child(2n-1) {
     background-color: #48A348;
     color: #FFFFFF;
     border-color: #666666;
+    --tooltip-background: #094409;
 }
 
 #search-input {
@@ -546,15 +545,6 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #666666;
-}
-
-.tooltip-anchor .tooltip {
-    background-color: #666666;
-    color: #FFFFFF;
-}
-
-.tooltip-anchor .tooltip::after {
-    border-color: transparent #666666 transparent transparent;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/dark.css
+++ b/style/themes/dark.css
@@ -18,6 +18,8 @@
 
 :root {
     color-scheme: dark;
+    --tooltip-background: #2F2F2F;
+    --tooltip-text: #FFFFFF;
 }
 
 a {
@@ -100,6 +102,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar {
     background-color: #154E15;
+    --tooltip-background: #053305;
 }
 
 #navigation-bar .navigation-icon {
@@ -116,14 +119,6 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar .navigation-icon img.black {
     display: none;
-}
-
-#navigation-bar .navigation-icon .tooltip {
-    background-color: #053305;
-}
-
-#navigation-bar .navigation-icon .tooltip::after {
-    border-color: transparent #053305 transparent transparent;
 }
 
 #navigation-bar .navigation-item {
@@ -205,6 +200,7 @@ table tr:nth-child(2n-1) {
 #search-header {
     background-color: #276227;
     border-color: #565656;
+    --tooltip-background: #053305;
 }
 
 #search-input {
@@ -560,15 +556,6 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #565656;
-}
-
-.tooltip-anchor .tooltip {
-    background-color: #2F2F2F;
-    color: #FFFFFF;
-}
-
-.tooltip-anchor .tooltip::after {
-    border-color: transparent #2F2F2F transparent transparent;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -16,6 +16,11 @@
  * Other colors may also be used for specific purposes
 */
 
+:root {
+    --tooltip-background: #888888;
+    --tooltip-text: #FFFFFF;
+}
+
 a {
     color: #0040FF;
 }
@@ -531,15 +536,6 @@ table tr {
 
 .timeline .section:hover {
     border-color: #888888;
-}
-
-.tooltip-anchor .tooltip {
-    background-color: #888888;
-    color: #FFFFFF;
-}
-
-.tooltip-anchor .tooltip::after {
-    border-color: transparent #888888 transparent transparent;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -18,6 +18,8 @@
 
 :root {
     color-scheme: dark;
+    --tooltip-background: #2F2F2F;
+    --tooltip-text: #FFFFFF;
 }
 
 a {
@@ -100,6 +102,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar {
     background-color: #E56100;
+    --tooltip-background: #B24C00;
 }
 
 #navigation-bar .navigation-icon {
@@ -116,14 +119,6 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar .navigation-icon img.black {
     display: none;
-}
-
-#navigation-bar .navigation-icon .tooltip {
-    background-color: #B24C00;
-}
-
-#navigation-bar .navigation-icon .tooltip::after {
-    border-color: transparent #B24C00 transparent transparent;
 }
 
 #navigation-bar .navigation-item {
@@ -205,6 +200,7 @@ table tr:nth-child(2n-1) {
 #search-header {
     background-color: #FF6C00;
     border-color: #565656;
+    --tooltip-background: #B24C00;
 }
 
 #search-input {
@@ -560,15 +556,6 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #565656;
-}
-
-.tooltip-anchor .tooltip {
-    background-color: #2F2F2F;
-    color: #FFFFFF;
-}
-
-.tooltip-anchor .tooltip::after {
-    border-color: transparent #2F2F2F transparent transparent;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/light.css
+++ b/style/themes/light.css
@@ -16,6 +16,11 @@
  * Other colors may also be used for specific purposes
 */
 
+:root {
+    --tooltip-background: #666666;
+    --tooltip-text: #FFFFFF;
+}
+
 a {
     color: #0040FF;
 }
@@ -88,6 +93,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar {
     background-color: #1A671A;
+    --tooltip-background: #094409;
 }
 
 #navigation-bar .navigation-icon {
@@ -104,14 +110,6 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar .navigation-icon img.black {
     display: none;
-}
-
-#navigation-bar .navigation-icon .tooltip {
-    background-color: #094409;
-}
-
-#navigation-bar .navigation-icon .tooltip::after {
-    border-color: transparent #094409 transparent transparent;
 }
 
 #navigation-bar .navigation-item {
@@ -194,6 +192,7 @@ table tr:nth-child(2n-1) {
     background-color: #48A348;
     color: #FFFFFF;
     border-color: #666666;
+    --tooltip-background: #094409;
 }
 
 #search-input {
@@ -546,15 +545,6 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #666666;
-}
-
-.tooltip-anchor .tooltip {
-    background-color: #666666;
-    color: #FFFFFF;
-}
-
-.tooltip-anchor .tooltip::after {
-    border-color: transparent #666666 transparent transparent;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -3,6 +3,11 @@
  * Based on tcomm.bustrainferry.com
 */
 
+:root {
+    --tooltip-background: #000000;
+    --tooltip-text: #FFFFFF;
+}
+
 a {
     color: #2489CE;
     text-shadow: 0 1px 0 #FFFFFF;
@@ -91,6 +96,7 @@ table tr {
     background-color: #111111;
     background-image: linear-gradient(#3C3C3C, #111111);
     text-shadow: 0 -1px 1px #000000;
+    --tooltip-background: #444444;
 }
 
 #navigation-bar .navigation-icon {
@@ -109,14 +115,6 @@ table tr {
 
 #navigation-bar .navigation-icon img.black {
     display: none;
-}
-
-#navigation-bar .navigation-icon .tooltip {
-    background-color: #444444;
-}
-
-#navigation-bar .navigation-icon .tooltip::after {
-    border-color: transparent #444444 transparent transparent;
 }
 
 #navigation-bar .navigation-item {
@@ -215,6 +213,7 @@ table tr {
     color: #FFFFFF;
     text-shadow: none;
     border-color: #000000;
+    --tooltip-background: #444444;
 }
 
 #search-input {
@@ -667,13 +666,7 @@ table tr {
 }
 
 .tooltip-anchor .tooltip {
-    background-color: #000000;
-    color: #FFFFFF;
     text-shadow: none;
-}
-
-.tooltip-anchor .tooltip::after {
-    border-color: transparent #000000 transparent transparent;
 }
 
 .weekdays .weekday {

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -16,6 +16,11 @@
  * Other colors may also be used for specific purposes
 */
 
+:root {
+    --tooltip-background: #666666;
+    --tooltip-text: #FFFFFF;
+}
+
 a {
     color: #7E3704;
 }
@@ -88,6 +93,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar {
     background-color: #C7743B;
+    --tooltip-background: #7E3704;
 }
 
 #navigation-bar .navigation-icon {
@@ -104,14 +110,6 @@ table tr:nth-child(2n-1) {
 
 #navigation-bar .navigation-icon img.black {
     display: none;
-}
-
-#navigation-bar .navigation-icon .tooltip {
-    background-color: #7E3704;
-}
-
-#navigation-bar .navigation-icon .tooltip::after {
-    border-color: transparent #7E3704 transparent transparent;
 }
 
 #navigation-bar .navigation-item {
@@ -194,6 +192,7 @@ table tr:nth-child(2n-1) {
     background-color: #DC9B41;
     color: #FFFFFF;
     border-color: #666666;
+    --tooltip-background: #7E3704;
 }
 
 #search-input {
@@ -546,15 +545,6 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #666666;
-}
-
-.tooltip-anchor .tooltip {
-    background-color: #666666;
-    color: #FFFFFF;
-}
-
-.tooltip-anchor .tooltip::after {
-    border-color: transparent #666666 transparent transparent;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -159,14 +159,20 @@
             
             <div class="flex-1"></div>
             
-            <a class="navigation-icon desktop-only" href="{{ get_url(system, 'nearby') }}">
+            <a class="navigation-icon desktop-only tooltip-anchor" href="{{ get_url(system, 'nearby') }}">
                 <img class="white" src="/img/white/location.png" />
                 <img class="black" src="/img/black/location.png" />
+                <div class="tooltip left">
+                    <div class="title">Nearby Stops</div>
+                </div>
             </a>
             
-            <a class="navigation-icon desktop-only" href="{{ get_url(system, 'personalize') }}">
+            <a class="navigation-icon desktop-only tooltip-anchor" href="{{ get_url(system, 'personalize') }}">
                 <img class="white" src="/img/white/personalize.png" />
                 <img class="black" src="/img/black/personalize.png" />
+                <div class="tooltip left">
+                    <div class="title">Personalize</div>
+                </div>
             </a>
             
             <div class="navigation-icon" onclick="toggleSearch()">
@@ -307,21 +313,25 @@
                 % if system is not None:
                     <div id="search-filters">
                         <div class="flex-1">Filters:</div>
-                        <div id="search-filter-bus" class="button" onclick="toggleSearchBusFilter()">
+                        <div id="search-filter-bus" class="button tooltip-anchor" onclick="toggleSearchBusFilter()">
                             <img class="white" src="/img/white/bus.png" />
                             <img class="black" src="/img/black/bus.png" />
+                            <div class="tooltip left">Include Buses</div>
                         </div>
-                        <div id="search-filter-route" class="button" onclick="toggleSearchRouteFilter()">
+                        <div id="search-filter-route" class="button tooltip-anchor" onclick="toggleSearchRouteFilter()">
                             <img class="white" src="/img/white/route.png" />
                             <img class="black" src="/img/black/route.png" />
+                            <div class="tooltip left">Include Routes</div>
                         </div>
-                        <div id="search-filter-stop" class="button" onclick="toggleSearchStopFilter()">
+                        <div id="search-filter-stop" class="button tooltip-anchor" onclick="toggleSearchStopFilter()">
                             <img class="white" src="/img/white/stop.png" />
                             <img class="black" src="/img/black/stop.png" />
+                            <div class="tooltip left">Include Stops</div>
                         </div>
-                        <div id="search-filter-block" class="button" onclick="toggleSearchBlockFilter()">
+                        <div id="search-filter-block" class="button tooltip-anchor" onclick="toggleSearchBlockFilter()">
                             <img class="white" src="/img/white/block.png" />
                             <img class="black" src="/img/black/block.png" />
+                            <div class="tooltip left">Include Blocks</div>
                         </div>
                     </div>
                 % end

--- a/views/components/adherence.tpl
+++ b/views/components/adherence.tpl
@@ -2,6 +2,6 @@
 % if adherence is not None:
     <div class="tooltip-anchor adherence {{ adherence.status_class }} {{ get('size', '') }}">
         {{ adherence }}
-        <div class="tooltip">{{ adherence.description }}</div>
+        <div class="tooltip right">{{ adherence.description }}</div>
     </div>
 % end

--- a/views/components/block_timeline.tpl
+++ b/views/components/block_timeline.tpl
@@ -20,7 +20,7 @@
             % offset_minutes = trip.start_time.get_minutes() - start_time.get_minutes()
             % offset_percentage = (offset_minutes / total_minutes) * 100
             <a href="{{ get_url(trip.system, f'trips/{trip.id}') }}" class="section tooltip-anchor" style="background-color: #{{ trip.route.colour }}; width: {{ percentage }}%; left: {{ offset_percentage }}%;">
-                <div class="tooltip">
+                <div class="tooltip right">
                     <div class="title">{{ trip }}</div>
                     {{ trip.start_time.format_web(time_format) }} - {{ trip.end_time.format_web(time_format) }}
                 </div>

--- a/views/components/bus.tpl
+++ b/views/components/bus.tpl
@@ -9,7 +9,7 @@
         <div class="adornment tooltip-anchor">
             {{ adornment }}
             % if adornment.description is not None:
-                <div class="tooltip">{{ adornment.description }}</div>
+                <div class="tooltip right">{{ adornment.description }}</div>
             % end
         </div>
     % end

--- a/views/components/events_list.tpl
+++ b/views/components/events_list.tpl
@@ -10,7 +10,7 @@
                     <img class="black" src="/img/black/calendar.png" />
                     <div>{{ date }}</div>
                 </div>
-                <div class="tooltip">{{ date.format_since() }}</div>
+                <div class="tooltip right">{{ date.format_since() }}</div>
             </div>
         </div>
         <div class="content">

--- a/views/components/record_warnings.tpl
+++ b/views/components/record_warnings.tpl
@@ -2,7 +2,7 @@
     <div class="tooltip-anchor record-warnings">
         <img class="white inline" src="/img/white/warning.png" />
         <img class="black inline" src="/img/black/warning.png" />
-        <div class="tooltip">
+        <div class="tooltip right">
             <div class="title">Potential accidental login</div>
             % for warning in record.warnings:
                 <div>{{ warning }}</div>

--- a/views/components/route.tpl
+++ b/views/components/route.tpl
@@ -9,7 +9,7 @@
                 <span class="route" style="background-color: #{{ route.colour }};">{{ route.number }}</span>
             % end
             % if get('include_tooltip', False):
-                <div class="tooltip">{{ route }}</div>
+                <div class="tooltip right">{{ route }}</div>
             % end
         </span>
     % end

--- a/views/components/trip.tpl
+++ b/views/components/trip.tpl
@@ -1,6 +1,6 @@
 <span class="tooltip-anchor">
     <a href="{{ get_url(trip.system, f'trips/{trip.id}') }}">{{ trip.short_id }}</a>
     % if get('include_tooltip', True) and trip.short_id != trip.id:
-        <div class="tooltip">{{ trip.id }}</div>
+        <div class="tooltip right">{{ trip.id }}</div>
     % end
 </span>

--- a/views/pages/route/overview.tpl
+++ b/views/pages/route/overview.tpl
@@ -202,7 +202,7 @@
                                                                             <div class="tooltip-anchor">
                                                                                 <img class="middle-align white" src="/img/white/schedule.png" />
                                                                                 <img class="middle-align black" src="/img/black/schedule.png" />
-                                                                                <div class="tooltip">Bus is scheduled</div>
+                                                                                <div class="tooltip right">Bus is scheduled</div>
                                                                             </div>
                                                                         </div>
                                                                         <span class="non-desktop smaller-font">

--- a/views/rows/departure.tpl
+++ b/views/rows/departure.tpl
@@ -35,7 +35,7 @@
                         <div class="tooltip-anchor">
                             <img class="middle-align white" src="/img/white/schedule.png" />
                             <img class="middle-align black" src="/img/black/schedule.png" />
-                            <div class="tooltip">Bus is scheduled</div>
+                            <div class="tooltip right">Bus is scheduled</div>
                         </div>
                     </div>
                     <span class="non-desktop smaller-font">


### PR DESCRIPTION
- Tooltips now need to specify either `left` or `right` class (all existing tooltips are `right`)
- Added tooltips for search filter buttons with `left` class
- Re-added tooltips for Nearby Stops/Personalize navbar items with `left` class (previously removed when the new search button was added, as the tooltips may have been cut off the side of the screen)
- Introduced our first (and likely not last) CSS variables `--tooltip-background` and `tooltip-text`
  - Make it much easier to specify tooltip colours in theme files, without needing complex selectors
  - Initially set at `:root` level for each theme, and customized in different places as needed