### PR TITLE
Stale trip record removal

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -2,6 +2,7 @@ import os
 import signal
 from crontab import CronTab
 
+import helpers.record
 import helpers.system
 
 from models.date import Date
@@ -51,6 +52,7 @@ def handle_gtfs(sig, frame):
                 gtfs.load(system, True)
                 gtfs.update_cache_in_background(system)
     if running:
+        helpers.record.delete_stale_trip_records()
         database.archive()
         date = Date.today()
         backup.run(date.previous(), include_db=date.weekday == Weekday.MON)


### PR DESCRIPTION
Adds a SQL query that removes unused trip records from the database, which should help to improve query times. A trip record is "unused" if
- The trip ID is not present in the `trip` table
- The record date is 90+ days old

The query runs once per day, after updating GTFS when needed, and before creating the daily backup.

The first time the query runs will likely hit the hardest, as there will be a very large number of trip records to be removed. Going forward, it will have much less work to do as it will typically only be removing one sheet at a time, rather than multiple years worth. Overall, on the first removal, the table should be reduced from over 5 million records to under 1 million.

With this change alone, there will not be a directly noticeable change to the DB size, despite the record deletions. This is because the deleting of records does not immediately free up space, it is simply marked as available and then overwritten as needed. So while the DB won't shrink, it also likely won't grow for quite some time while that unused space is reclaimed. If we really want to shrink the DB immediately we can try find a way to run the `VACUUM;` SQL command which fully deletes all unused data. For now I think that's not a step that we need to take.

Future work may be done to improve query times more by adding indexes and other temp data tables.