### PR TITLE
Fix and simplify adherence styles

### DIFF
--- a/server.py
+++ b/server.py
@@ -29,7 +29,7 @@ import gtfs
 import realtime
 
 # Increase the version to force CSS reload
-VERSION = 30
+VERSION = 31
 
 app = Bottle()
 running = False

--- a/style/main.css
+++ b/style/main.css
@@ -384,7 +384,7 @@ table tr.header td {
     display: none;
 }
 
-.adherence {
+.adherence-indicator {
     padding: 2px 4px;
     border-radius: 4px;
     min-width: 14px;
@@ -395,9 +395,11 @@ table tr.header td {
     font-size: 9pt;
     line-height: 9pt;
     flex-shrink: 0;
+    background-color: var(--adherence-background);
+    color: var(--adherence-text);
 }
 
-.adherence.large {
+.adherence-indicator.large {
     font-size: 12pt;
     line-height: 12pt;
     padding: 3px 6px;
@@ -433,6 +435,10 @@ table tr.header td {
 .banner .title {
     font-weight: bold;
     font-size: 16pt;
+}
+
+.bearing.adherence {
+    border-bottom-color: var(--adherence-background);
 }
 
 .block-timeline {
@@ -742,7 +748,7 @@ table tr.header td {
     gap: 1px;
 }
 
-.marker .details .content .adherence {
+.marker .details .content .adherence-indicator {
     font-size: 8pt;
     line-height: 8pt;
     border-radius: 3px;
@@ -825,6 +831,8 @@ table tr.header td {
     font-size: 11pt;
     vertical-align: middle;
     text-decoration: none;
+    background-color: var(--adherence-background);
+    color: var(--adherence-text);
 }
 
 .marker .icon.route {

--- a/style/themes/bchydro.css
+++ b/style/themes/bchydro.css
@@ -19,6 +19,9 @@
 :root {
     --tooltip-background: #666666;
     --tooltip-text: #FFFFFF;
+    
+    --adherence-background: #989898;
+    --adherence-text: #FFFFFF;
 }
 
 a {
@@ -291,29 +294,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.adherence {
-    color: #FFFFFF;
-    background-color: #989898 !important;
-}
-
-.adherence.ahead {
-    background-color: #FF9A3A !important;
-}
-
-.adherence.behind {
-    background-color: #FF9A3A !important;
-}
-
-.adherence.on-time {
-    background-color: #3C5ABE !important;
-}
-
-.adherence.very-ahead {
-    background-color: #FD393E !important;
-}
-
-.adherence.very-behind {
-    background-color: #FD393E !important;
+.ahead {
+    --adherence-background: #FF9A3A;
 }
 
 .banner {
@@ -329,29 +311,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.bearing.adherence {
-    background-color: transparent !important;
-    border-bottom-color: #989898;
-}
-
-.bearing.adherence.ahead {
-    border-bottom-color: #FF9A3A;
-}
-
-.bearing.adherence.behind {
-    border-bottom-color: #FF9A3A;
-}
-
-.bearing.adherence.on-time {
-    border-bottom-color: #3C5ABE;
-}
-
-.bearing.adherence.very-ahead {
-    border-bottom-color: #FD393E;
-}
-
-.bearing.adherence.very-behind {
-    border-bottom-color: #FD393E;
+.behind {
+    --adherence-background: #FF9A3A;
 }
 
 .button {
@@ -469,6 +430,10 @@ table tr:nth-child(2n-1) {
     color: #000000;
 }
 
+.on-time {
+    --adherence-background: #3C5ABE;
+}
+
 .order-details .content .separator {
     color: #666666;
 }
@@ -545,6 +510,14 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #666666;
+}
+
+.very-ahead {
+    --adherence-background: #FD393E;
+}
+
+.very-behind {
+    --adherence-background: #FD393E;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -19,6 +19,8 @@
 :root {
     --tooltip-background: #69BB65;
     --tooltip-text: #FFFFFF;
+    --adherence-background: #989898;
+    --adherence-text: #FFFFFF;
 }
 
 a {
@@ -275,29 +277,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.adherence {
-    color: #FFFFFF;
-    background-color: #989898 !important;
-}
-
-.adherence.ahead {
-    background-color: #FF9A3A !important;
-}
-
-.adherence.behind {
-    background-color: #FF9A3A !important;
-}
-
-.adherence.on-time {
-    background-color: #3C5ABE !important;
-}
-
-.adherence.very-ahead {
-    background-color: #FD393E !important;
-}
-
-.adherence.very-behind {
-    background-color: #FD393E !important;
+.ahead {
+    --adherence-background: #FF9A3A;
 }
 
 .banner {
@@ -313,29 +294,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.bearing.adherence {
-    background-color: transparent !important;
-    border-bottom-color: #989898;
-}
-
-.bearing.adherence.ahead {
-    border-bottom-color: #FF9A3A;
-}
-
-.bearing.adherence.behind {
-    border-bottom-color: #FF9A3A;
-}
-
-.bearing.adherence.on-time {
-    border-bottom-color: #3C5ABE;
-}
-
-.bearing.adherence.very-ahead {
-    border-bottom-color: #FD393E;
-}
-
-.bearing.adherence.very-behind {
-    border-bottom-color: #FD393E;
+.behind {
+    --adherence-background: #FF9A3A;
 }
 
 .button {
@@ -453,6 +413,10 @@ table tr:nth-child(2n-1) {
     color: #000000;
 }
 
+.on-time {
+    --adherence-background: #3C5ABE;
+}
+
 .order-details .content .separator {
     color: #69BB65;
 }
@@ -529,6 +493,14 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #69BB65;
+}
+
+.very-ahead {
+    --adherence-background: #FD393E;
+}
+
+.very-behind {
+    --adherence-background: #FD393E;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/classic.css
+++ b/style/themes/classic.css
@@ -19,6 +19,8 @@
 :root {
     --tooltip-background: #666666;
     --tooltip-text: #FFFFFF;
+    --adherence-background: #989898;
+    --adherence-text: #FFFFFF;
 }
 
 a {
@@ -291,29 +293,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.adherence {
-    color: #FFFFFF;
-    background-color: #989898 !important;
-}
-
-.adherence.ahead {
-    background-color: #FF9A3A !important;
-}
-
-.adherence.behind {
-    background-color: #FF9A3A !important;
-}
-
-.adherence.on-time {
-    background-color: #3C5ABE !important;
-}
-
-.adherence.very-ahead {
-    background-color: #FD393E !important;
-}
-
-.adherence.very-behind {
-    background-color: #FD393E !important;
+.ahead {
+    --adherence-background: #FF9A3A;
 }
 
 .banner {
@@ -329,29 +310,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.bearing.adherence {
-    background-color: transparent !important;
-    border-bottom-color: #989898;
-}
-
-.bearing.adherence.ahead {
-    border-bottom-color: #FF9A3A;
-}
-
-.bearing.adherence.behind {
-    border-bottom-color: #FF9A3A;
-}
-
-.bearing.adherence.on-time {
-    border-bottom-color: #3C5ABE;
-}
-
-.bearing.adherence.very-ahead {
-    border-bottom-color: #FD393E;
-}
-
-.bearing.adherence.very-behind {
-    border-bottom-color: #FD393E;
+.behind {
+    --adherence-background: #FF9A3A;
 }
 
 .button {
@@ -469,6 +429,10 @@ table tr:nth-child(2n-1) {
     color: #000000;
 }
 
+.on-time {
+    --adherence-background: #3C5ABE;
+}
+
 .order-details .content .separator {
     color: #666666;
 }
@@ -545,6 +509,14 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #666666;
+}
+
+.very-ahead {
+    --adherence-background: #FD393E;
+}
+
+.very-behind {
+    --adherence-background: #FD393E;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/contrast.css
+++ b/style/themes/contrast.css
@@ -19,6 +19,8 @@
 :root {
     --tooltip-background: #666666;
     --tooltip-text: #FFFFFF;
+    --adherence-background: #989898;
+    --adherence-text: #FFFFFF;
 }
 
 a {
@@ -291,29 +293,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.adherence {
-    color: #FFFFFF;
-    background-color: #989898 !important;
-}
-
-.adherence.ahead {
-    background-color: #FFB000 !important;
-}
-
-.adherence.behind {
-    background-color: #FFB000 !important;
-}
-
-.adherence.on-time {
-    background-color: #648FFF !important;
-}
-
-.adherence.very-ahead {
-    background-color: #DC267F !important;
-}
-
-.adherence.very-behind {
-    background-color: #DC267F !important;
+.ahead {
+    --adherence-background: #FF9A3A;
 }
 
 .banner {
@@ -329,29 +310,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.bearing.adherence {
-    background-color: transparent !important;
-    border-bottom-color: #989898;
-}
-
-.bearing.adherence.ahead {
-    border-bottom-color: #FFB000;
-}
-
-.bearing.adherence.behind {
-    border-bottom-color: #FFB000;
-}
-
-.bearing.adherence.on-time {
-    border-bottom-color: #648FFF;
-}
-
-.bearing.adherence.very-ahead {
-    border-bottom-color: #DC267F;
-}
-
-.bearing.adherence.very-behind {
-    border-bottom-color: #DC267F;
+.behind {
+    --adherence-background: #FF9A3A;
 }
 
 .button {
@@ -469,6 +429,10 @@ table tr:nth-child(2n-1) {
     color: #000000;
 }
 
+.on-time {
+    --adherence-background: #3C5ABE;
+}
+
 .order-details .content .separator {
     color: #666666;
 }
@@ -545,6 +509,14 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #666666;
+}
+
+.very-ahead {
+    --adherence-background: #FD393E;
+}
+
+.very-behind {
+    --adherence-background: #FD393E;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/dark.css
+++ b/style/themes/dark.css
@@ -20,6 +20,8 @@
     color-scheme: dark;
     --tooltip-background: #2F2F2F;
     --tooltip-text: #FFFFFF;
+    --adherence-background: #989898;
+    --adherence-text: #FFFFFF;
 }
 
 a {
@@ -299,29 +301,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.adherence {
-    color: #FFFFFF;
-    background-color: #989898 !important;
-}
-
-.adherence.ahead {
-    background-color: #FF6A00 !important;
-}
-
-.adherence.behind {
-    background-color: #FF6A00 !important;
-}
-
-.adherence.on-time {
-    background-color: #0093A8 !important;
-}
-
-.adherence.very-ahead {
-    background-color: #FF0007 !important;
-}
-
-.adherence.very-behind {
-    background-color: #FF0007 !important;
+.ahead {
+    --adherence-background: #FF6A00;
 }
 
 .banner {
@@ -337,29 +318,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.bearing.adherence {
-    background-color: transparent !important;
-    border-bottom-color: #989898;
-}
-
-.bearing.adherence.ahead {
-    border-bottom-color: #FF6A00;
-}
-
-.bearing.adherence.behind {
-    border-bottom-color: #FF6A00;
-}
-
-.bearing.adherence.on-time {
-    border-bottom-color: #0093A8;
-}
-
-.bearing.adherence.very-ahead {
-    border-bottom-color: #FF0007;
-}
-
-.bearing.adherence.very-behind {
-    border-bottom-color: #FF0007;
+.behind {
+    --adherence-background: #FF6A00;
 }
 
 .button {
@@ -481,6 +441,10 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
 }
 
+.on-time {
+    --adherence-background: #0093A8;
+}
+
 .order-details .content .separator {
     color: #565656;
 }
@@ -556,6 +520,14 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #565656;
+}
+
+.very-ahead {
+    --adherence-background: #FF0007;
+}
+
+.very-behind {
+    --adherence-background: #FF0007;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -19,6 +19,8 @@
 :root {
     --tooltip-background: #888888;
     --tooltip-text: #FFFFFF;
+    --adherence-background: #989898;
+    --adherence-text: #FFFFFF;
 }
 
 a {
@@ -282,29 +284,8 @@ table tr {
     display: none;
 }
 
-.adherence {
-    color: #FFFFFF;
-    background-color: #989898 !important;
-}
-
-.adherence.ahead {
-    background-color: #FF9A3A !important;
-}
-
-.adherence.behind {
-    background-color: #FF9A3A !important;
-}
-
-.adherence.on-time {
-    background-color: #3C5ABE !important;
-}
-
-.adherence.very-ahead {
-    background-color: #FD393E !important;
-}
-
-.adherence.very-behind {
-    background-color: #FD393E !important;
+.ahead {
+    --adherence-background: #FF9A3A;
 }
 
 .banner {
@@ -320,29 +301,8 @@ table tr {
     display: none;
 }
 
-.bearing.adherence {
-    background-color: transparent !important;
-    border-bottom-color: #989898;
-}
-
-.bearing.adherence.ahead {
-    border-bottom-color: #FF9A3A;
-}
-
-.bearing.adherence.behind {
-    border-bottom-color: #FF9A3A;
-}
-
-.bearing.adherence.on-time {
-    border-bottom-color: #3C5ABE;
-}
-
-.bearing.adherence.very-ahead {
-    border-bottom-color: #FD393E;
-}
-
-.bearing.adherence.very-behind {
-    border-bottom-color: #FD393E;
+.behind {
+    --adherence-background: #FF9A3A;
 }
 
 .button {
@@ -460,6 +420,10 @@ table tr {
     color: #000000;
 }
 
+.on-time {
+    --adherence-background: #3C5ABE;
+}
+
 .order-details .content .separator {
     color: #888888;
 }
@@ -536,6 +500,14 @@ table tr {
 
 .timeline .section:hover {
     border-color: #888888;
+}
+
+.very-ahead {
+    --adherence-background: #FD393E;
+}
+
+.very-behind {
+    --adherence-background: #FD393E;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -20,6 +20,8 @@
     color-scheme: dark;
     --tooltip-background: #2F2F2F;
     --tooltip-text: #FFFFFF;
+    --adherence-background: #989898;
+    --adherence-text: #FFFFFF;
 }
 
 a {
@@ -299,29 +301,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.adherence {
-    color: #FFFFFF;
-    background-color: #989898 !important;
-}
-
-.adherence.ahead {
-    background-color: #FF6A00 !important;
-}
-
-.adherence.behind {
-    background-color: #FF6A00 !important;
-}
-
-.adherence.on-time {
-    background-color: #0093A8 !important;
-}
-
-.adherence.very-ahead {
-    background-color: #FF0007 !important;
-}
-
-.adherence.very-behind {
-    background-color: #FF0007 !important;
+.ahead {
+    --adherence-background: #FF6A00;
 }
 
 .banner {
@@ -337,29 +318,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.bearing.adherence {
-    background-color: transparent !important;
-    border-bottom-color: #989898;
-}
-
-.bearing.adherence.ahead {
-    border-bottom-color: #FF6A00;
-}
-
-.bearing.adherence.behind {
-    border-bottom-color: #FF6A00;
-}
-
-.bearing.adherence.on-time {
-    border-bottom-color: #0093A8;
-}
-
-.bearing.adherence.very-ahead {
-    border-bottom-color: #FF0007;
-}
-
-.bearing.adherence.very-behind {
-    border-bottom-color: #FF0007;
+.behind {
+    --adherence-background: #FF6A00;
 }
 
 .button {
@@ -481,6 +441,10 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
 }
 
+.on-time {
+    --adherence-background: #0093A8;
+}
+
 .order-details .content .separator {
     color: #565656;
 }
@@ -556,6 +520,14 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #565656;
+}
+
+.very-ahead {
+    --adherence-background: #FF0007;
+}
+
+.very-behind {
+    --adherence-background: #FF0007;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/light.css
+++ b/style/themes/light.css
@@ -19,6 +19,8 @@
 :root {
     --tooltip-background: #666666;
     --tooltip-text: #FFFFFF;
+    --adherence-background: #989898;
+    --adherence-text: #FFFFFF;
 }
 
 a {
@@ -291,29 +293,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.adherence {
-    color: #FFFFFF;
-    background-color: #989898 !important;
-}
-
-.adherence.ahead {
-    background-color: #FF9A3A !important;
-}
-
-.adherence.behind {
-    background-color: #FF9A3A !important;
-}
-
-.adherence.on-time {
-    background-color: #3C5ABE !important;
-}
-
-.adherence.very-ahead {
-    background-color: #FD393E !important;
-}
-
-.adherence.very-behind {
-    background-color: #FD393E !important;
+.ahead {
+    --adherence-background: #FF9A3A;
 }
 
 .banner {
@@ -329,29 +310,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.bearing.adherence {
-    background-color: transparent !important;
-    border-bottom-color: #989898;
-}
-
-.bearing.adherence.ahead {
-    border-bottom-color: #FF9A3A;
-}
-
-.bearing.adherence.behind {
-    border-bottom-color: #FF9A3A;
-}
-
-.bearing.adherence.on-time {
-    border-bottom-color: #3C5ABE;
-}
-
-.bearing.adherence.very-ahead {
-    border-bottom-color: #FD393E;
-}
-
-.bearing.adherence.very-behind {
-    border-bottom-color: #FD393E;
+.behind {
+    --adherence-background: #FF9A3A;
 }
 
 .button {
@@ -469,6 +429,10 @@ table tr:nth-child(2n-1) {
     color: #000000;
 }
 
+.on-time {
+    --adherence-background: #3C5ABE;
+}
+
 .order-details .content .separator {
     color: #666666;
 }
@@ -545,6 +509,14 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #666666;
+}
+
+.very-ahead {
+    --adherence-background: #FD393E;
+}
+
+.very-behind {
+    --adherence-background: #FD393E;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -6,6 +6,8 @@
 :root {
     --tooltip-background: #000000;
     --tooltip-text: #FFFFFF;
+    --adherence-background: #989898;
+    --adherence-text: #FFFFFF;
 }
 
 a {
@@ -368,30 +370,12 @@ table tr {
     color: #FFFFFF;
 }
 
-.adherence {
-    background-color: #DFDFDF;
-    background-image: linear-gradient(#F6F6F6, #E0E0E0);
+.adherence-indicator {
     text-shadow: none;
 }
 
-.adherence.ahead {
-    background-color: #F00E0E !important;
-}
-
-.adherence.behind {
-    background-color: #CC8800 !important;
-}
-
-.adherence.on-time {
-    background-color: #4EBF40 !important;
-}
-
-.adherence.very-ahead {
-    background-color: #F00E0E !important;
-}
-
-.adherence.very-behind {
-    background-color: #115EBC !important;
+.ahead {
+    --adherence-background: #F00E0E;
 }
 
 .banner {
@@ -408,29 +392,8 @@ table tr {
     display: none;
 }
 
-.bearing.adherence {
-    background-color: transparent !important;
-    border-bottom-color: #989898;
-}
-
-.bearing.adherence.ahead {
-    border-bottom-color: #F00E0E;
-}
-
-.bearing.adherence.behind {
-    border-bottom-color: #CC8800;
-}
-
-.bearing.adherence.on-time {
-    border-bottom-color: #4EBF40;
-}
-
-.bearing.adherence.very-ahead {
-    border-bottom-color: #F00E0E;
-}
-
-.bearing.adherence.very-behind {
-    border-bottom-color: #115EBC;
+.behind {
+    --adherence-background: #CC8800;
 }
 
 .button {
@@ -538,6 +501,10 @@ table tr {
     text-shadow: none;
 }
 
+.marker .icon.adherence {
+    text-shadow: none;
+}
+
 .modified-service {
     background-color: #FFA560;
     color: #000000;
@@ -570,6 +537,10 @@ table tr {
 .normal-service {
     background-color: #7DBD88;
     color: #000000;
+}
+
+.on-time {
+    --adherence-background: #4EBF40;
 }
 
 .positive {
@@ -667,6 +638,14 @@ table tr {
 
 .tooltip-anchor .tooltip {
     text-shadow: none;
+}
+
+.very-ahead {
+    --adherence-background: #F00E0E;
+}
+
+.very-behind {
+    --adherence-background: #115EBC;
 }
 
 .weekdays .weekday {

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -19,6 +19,8 @@
 :root {
     --tooltip-background: #666666;
     --tooltip-text: #FFFFFF;
+    --adherence-background: #989898;
+    --adherence-text: #FFFFFF;
 }
 
 a {
@@ -291,29 +293,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.adherence {
-    color: #FFFFFF;
-    background-color: #989898 !important;
-}
-
-.adherence.ahead {
-    background-color: #FF9A3A !important;
-}
-
-.adherence.behind {
-    background-color: #FF9A3A !important;
-}
-
-.adherence.on-time {
-    background-color: #3C5ABE !important;
-}
-
-.adherence.very-ahead {
-    background-color: #FD393E !important;
-}
-
-.adherence.very-behind {
-    background-color: #FD393E !important;
+.ahead {
+    --adherence-background: #FF9A3A;
 }
 
 .banner {
@@ -329,29 +310,8 @@ table tr:nth-child(2n-1) {
     display: none;
 }
 
-.bearing.adherence {
-    background-color: transparent !important;
-    border-bottom-color: #989898;
-}
-
-.bearing.adherence.ahead {
-    border-bottom-color: #FF9A3A;
-}
-
-.bearing.adherence.behind {
-    border-bottom-color: #FF9A3A;
-}
-
-.bearing.adherence.on-time {
-    border-bottom-color: #3C5ABE;
-}
-
-.bearing.adherence.very-ahead {
-    border-bottom-color: #FD393E;
-}
-
-.bearing.adherence.very-behind {
-    border-bottom-color: #FD393E;
+.behind {
+    --adherence-background: #FF9A3A;
 }
 
 .button {
@@ -469,6 +429,10 @@ table tr:nth-child(2n-1) {
     color: #000000;
 }
 
+.on-time {
+    --adherence-background: #3C5ABE;
+}
+
 .order-details .content .separator {
     color: #666666;
 }
@@ -545,6 +509,14 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #666666;
+}
+
+.very-ahead {
+    --adherence-background: #FD393E;
+}
+
+.very-behind {
+    --adherence-background: #FD393E;
 }
 
 .weekdays a.weekday.no-service:hover {

--- a/views/components/adherence.tpl
+++ b/views/components/adherence.tpl
@@ -1,6 +1,6 @@
 
 % if adherence is not None:
-    <div class="tooltip-anchor adherence {{ adherence.status_class }} {{ get('size', '') }}">
+    <div class="tooltip-anchor adherence-indicator {{ adherence.status_class }} {{ get('size', '') }}">
         {{ adherence }}
         <div class="tooltip right">{{ adherence.description }}</div>
     </div>

--- a/views/components/map.tpl
+++ b/views/components/map.tpl
@@ -132,7 +132,7 @@
                 headsign.className = "row center gap-5";
                 const adherence = position.adherence;
                 const adherenceElement = document.createElement("div");
-                adherenceElement.classList.add("adherence", adherence.status_class);
+                adherenceElement.classList.add("adherence-indicator", adherence.status_class);
                 adherenceElement.innerHTML = adherence.value;
                 
                 headsign.innerHTML = adherenceElement.outerHTML + position.headsign;

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -194,7 +194,7 @@
                 } else {
                     headsign.className = "row center gap-5";
                     const adherenceElement = document.createElement("div");
-                    adherenceElement.classList.add("adherence", adherence.status_class);
+                    adherenceElement.classList.add("adherence-indicator", adherence.status_class);
                     adherenceElement.innerHTML = adherence.value;
                     
                     headsign.innerHTML = adherenceElement.outerHTML + position.headsign;


### PR DESCRIPTION
The `adherence` CSS class was being used for multiple difference scenarios, causing unwanted properties to be used in some places. I've renamed one scenario back to `adherence-indicator`. Also introduced CSS variables for adherence, reducing a lot of duplication of styling.