### PR TITLE
Update checkbox UI

### DIFF
--- a/img/check.svg
+++ b/img/check.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" /></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9,20.42L2.79,14.21L5.62,11.38L9,14.77L18.88,4.88L21.71,7.71L9,20.42Z" /></svg>

--- a/style/devices/desktop.css
+++ b/style/devices/desktop.css
@@ -191,6 +191,10 @@ table th {
     display: none !important;
 }
 
+.selection-container:hover {
+    background-color: var(--hover-background);
+}
+
 .side-bar-open .side-bar-closed-only {
     display: none !important;
 }

--- a/style/devices/desktop.css
+++ b/style/devices/desktop.css
@@ -191,7 +191,7 @@ table th {
     display: none !important;
 }
 
-.selection-container:hover {
+.option:hover {
     background-color: var(--hover-background);
 }
 

--- a/style/devices/mobile.css
+++ b/style/devices/mobile.css
@@ -243,17 +243,17 @@ table {
     display: none !important;
 }
 
-.page-container {
-    flex-direction: column;
-    gap: 20px;
-}
-
 .options-container {
     row-gap: 0px;
 }
 
 .option {
     padding: 5px 0px;
+}
+
+.page-container {
+    flex-direction: column;
+    gap: 20px;
 }
 
 .side-bar-closed-only {

--- a/style/devices/mobile.css
+++ b/style/devices/mobile.css
@@ -248,7 +248,11 @@ table {
     gap: 20px;
 }
 
-.selection-container {
+.options-container {
+    row-gap: 0px;
+}
+
+.option {
     padding: 5px 0px;
 }
 

--- a/style/devices/mobile.css
+++ b/style/devices/mobile.css
@@ -248,6 +248,10 @@ table {
     gap: 20px;
 }
 
+.selection-container {
+    padding: 5px 0px;
+}
+
 .side-bar-closed-only {
     display: none;
 }

--- a/style/devices/tablet.css
+++ b/style/devices/tablet.css
@@ -239,7 +239,11 @@ table {
     gap: 20px;
 }
 
-.selection-container {
+.options-container {
+    row-gap: 0px;
+}
+
+.option {
     padding: 5px 0px;
 }
 

--- a/style/devices/tablet.css
+++ b/style/devices/tablet.css
@@ -234,17 +234,17 @@ table {
     display: none !important;
 }
 
-.page-container {
-    flex-direction: column;
-    gap: 20px;
-}
-
 .options-container {
     row-gap: 0px;
 }
 
 .option {
     padding: 5px 0px;
+}
+
+.page-container {
+    flex-direction: column;
+    gap: 20px;
 }
 
 .smaller-font {

--- a/style/devices/tablet.css
+++ b/style/devices/tablet.css
@@ -239,6 +239,10 @@ table {
     gap: 20px;
 }
 
+.selection-container {
+    padding: 5px 0px;
+}
+
 .smaller-font {
     font-size: 11pt;
 }

--- a/style/main.css
+++ b/style/main.css
@@ -674,12 +674,6 @@ table tr.header td {
     gap: 40px !important;
 }
 
-.grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 5px;
-}
-
 .headsign {
     display: flex;
     flex-direction: row;
@@ -1032,7 +1026,19 @@ table tr.header td {
     justify-content: space-between;
 }
 
-.selection-container {
+.options-container {
+    display: flex;
+    flex-direction: column;
+    row-gap: 2px;
+}
+
+.options-container.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    column-gap: 10px;
+}
+
+.option {
     display: flex;
     flex-direction: row;
     gap: 10px;
@@ -1044,7 +1050,7 @@ table tr.header td {
     border-radius: 10px;
 }
 
-.selection-container .checkbox {
+.option .checkbox {
     border: 2px solid var(--checkbox-color);
     border-radius: 5px;
     width: 18px;
@@ -1053,15 +1059,15 @@ table tr.header td {
     --image-color: var(--checkbox-color);
 }
 
-.selection-container .checkbox svg {
+.option .checkbox svg {
     display: none;
 }
 
-.selection-container .checkbox.selected svg {
+.option .checkbox.selected svg {
     display: initial;
 }
 
-.selection-container .radio-button {
+.option .radio-button {
     width: 12px;
     height: 12px;
     border: 2px solid var(--radio-button-color);
@@ -1070,7 +1076,7 @@ table tr.header td {
     flex-shrink: 0;
 }
 
-.selection-container .radio-button.selected::before {
+.option .radio-button.selected::before {
     content: '';
     display: block;
     width: 100%;

--- a/style/main.css
+++ b/style/main.css
@@ -942,6 +942,65 @@ table tr.header td {
     white-space: nowrap;
 }
 
+.options-container {
+    display: flex;
+    flex-direction: column;
+    row-gap: 2px;
+}
+
+.options-container.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    column-gap: 10px;
+}
+
+.option {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+    align-self: flex-start;
+    align-items: center;
+    cursor: pointer;
+    user-select: none;
+    padding: 5px 10px 5px 10px;
+    border-radius: 10px;
+}
+
+.option .checkbox {
+    border: 2px solid var(--checkbox-color);
+    border-radius: 5px;
+    width: 18px;
+    height: 18px;
+    --image-size: 18px;
+    --image-color: var(--checkbox-color);
+}
+
+.option .checkbox svg {
+    display: none;
+}
+
+.option .checkbox.selected svg {
+    display: initial;
+}
+
+.option .radio-button {
+    width: 12px;
+    height: 12px;
+    border: 2px solid var(--radio-button-color);
+    border-radius: 50%;
+    padding: 3px;
+    flex-shrink: 0;
+}
+
+.option .radio-button.selected::before {
+    content: '';
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background-color: var(--radio-button-color);
+}
+
 .order-details .content {
     display: flex;
     flex-direction: row;
@@ -1024,65 +1083,6 @@ table tr.header td {
 
 .row.space-between {
     justify-content: space-between;
-}
-
-.options-container {
-    display: flex;
-    flex-direction: column;
-    row-gap: 2px;
-}
-
-.options-container.grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    column-gap: 10px;
-}
-
-.option {
-    display: flex;
-    flex-direction: row;
-    gap: 10px;
-    align-self: flex-start;
-    align-items: center;
-    cursor: pointer;
-    user-select: none;
-    padding: 5px 10px 5px 10px;
-    border-radius: 10px;
-}
-
-.option .checkbox {
-    border: 2px solid var(--checkbox-color);
-    border-radius: 5px;
-    width: 18px;
-    height: 18px;
-    --image-size: 18px;
-    --image-color: var(--checkbox-color);
-}
-
-.option .checkbox svg {
-    display: none;
-}
-
-.option .checkbox.selected svg {
-    display: initial;
-}
-
-.option .radio-button {
-    width: 12px;
-    height: 12px;
-    border: 2px solid var(--radio-button-color);
-    border-radius: 50%;
-    padding: 3px;
-    flex-shrink: 0;
-}
-
-.option .radio-button.selected::before {
-    content: '';
-    display: block;
-    width: 100%;
-    height: 100%;
-    border-radius: 50%;
-    background-color: var(--radio-button-color);
 }
 
 .sheet {

--- a/style/main.css
+++ b/style/main.css
@@ -552,32 +552,6 @@ table tr.header td {
     text-align: center;
 }
 
-.checkbox-container {
-    display: flex;
-    gap: 5px;
-    align-items: center;
-    cursor: pointer;
-    align-self: flex-start;
-    user-select: none;
-}
-
-.checkbox-container .checkbox {
-    border-width: 1px;
-    border-style: solid;
-    border-radius: 5px;
-    width: 24px;
-    height: 24px;
-    --image-size: 24px;
-}
-
-.checkbox-container .checkbox svg {
-    display: none;
-}
-
-.checkbox-container .checkbox.selected svg {
-    display: initial;
-}
-
 .code-block {
     border-width: 1px;
     border-style: solid;
@@ -1003,38 +977,6 @@ table tr.header td {
     font-weight: bold;
 }
 
-.radio-button-container {
-    display: flex;
-    flex-direction: row;
-    gap: 10px;
-    cursor: pointer;
-    align-items: center;
-    padding: 5px 10px 5px 10px;
-    border-radius: 10px;
-}
-
-.radio-button-container .label {
-    user-select: none;
-}
-
-.radio-button-container .radio-button {
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    border-width: 2px;
-    border-style: solid;
-    padding: 3px;
-    flex-shrink: 0;
-}
-
-.radio-button-container .radio-button.selected::before {
-    content: '';
-    display: block;
-    width: 100%;
-    height: 100%;
-    border-radius: 50%;
-}
-
 .route {
     display: inline-block;
     padding: 1px 6px;
@@ -1088,6 +1030,53 @@ table tr.header td {
 
 .row.space-between {
     justify-content: space-between;
+}
+
+.selection-container {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+    align-self: flex-start;
+    align-items: center;
+    cursor: pointer;
+    user-select: none;
+    padding: 5px 10px 5px 10px;
+    border-radius: 10px;
+}
+
+.selection-container .checkbox {
+    border: 2px solid var(--checkbox-color);
+    border-radius: 5px;
+    width: 18px;
+    height: 18px;
+    --image-size: 18px;
+    --image-color: var(--checkbox-color);
+}
+
+.selection-container .checkbox svg {
+    display: none;
+}
+
+.selection-container .checkbox.selected svg {
+    display: initial;
+}
+
+.selection-container .radio-button {
+    width: 12px;
+    height: 12px;
+    border: 2px solid var(--radio-button-color);
+    border-radius: 50%;
+    padding: 3px;
+    flex-shrink: 0;
+}
+
+.selection-container .radio-button.selected::before {
+    content: '';
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background-color: var(--radio-button-color);
 }
 
 .sheet {

--- a/style/themes/bchydro.css
+++ b/style/themes/bchydro.css
@@ -418,6 +418,18 @@ table tr:nth-child(2n-1) {
     --adherence-background: #3C5ABE;
 }
 
+.option {
+    --hover-background: #D8D8D8;
+}
+
+.option .checkbox {
+    background-color: #FFFFFF;
+}
+
+.option .radio-button {
+    background-color: #FFFFFF;
+}
+
 .order-details .content .separator {
     color: #666666;
 }
@@ -430,18 +442,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
-}
-
-.option {
-    --hover-background: #D8D8D8;
-}
-
-.option .checkbox {
-    background-color: #FFFFFF;
-}
-
-.option .radio-button {
-    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/bchydro.css
+++ b/style/themes/bchydro.css
@@ -43,7 +43,7 @@ body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .selection-container {
+body.full-map #page-header .option {
     --hover-background: #FFFFFF;
 }
 
@@ -358,7 +358,7 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #CBCBCB;
 }
 
-.info-box .selection-container {
+.info-box .option {
     --hover-background: #CBCBCB;
 }
 
@@ -432,15 +432,15 @@ table tr:nth-child(2n-1) {
     background-color: #989898;
 }
 
-.selection-container {
+.option {
     --hover-background: #D8D8D8;
 }
 
-.selection-container .checkbox {
+.option .checkbox {
     background-color: #FFFFFF;
 }
 
-.selection-container .radio-button {
+.option .radio-button {
     background-color: #FFFFFF;
 }
 

--- a/style/themes/bchydro.css
+++ b/style/themes/bchydro.css
@@ -25,6 +25,9 @@
     
     --adherence-background: #989898;
     --adherence-text: #FFFFFF;
+    
+    --checkbox-color: #61C315;
+    --radio-button-color: #61C315;
 }
 
 a {
@@ -38,6 +41,10 @@ body {
 
 body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
+}
+
+body.full-map #page-header .selection-container {
+    --hover-background: #FFFFFF;
 }
 
 input[type="text"] {
@@ -333,12 +340,6 @@ table tr:nth-child(2n-1) {
     background-color: #AD6000;
 }
 
-.checkbox-container .checkbox {
-    border-color: #000000;
-    background-color: #FFFFFF;
-    --image-color: #000000;
-}
-
 .code-block {
     background-color: #D8D8D8;
     border-color: #666666;
@@ -357,8 +358,8 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #CBCBCB;
 }
 
-.info-box .radio-button-container:hover {
-    background-color: #CBCBCB;
+.info-box .selection-container {
+    --hover-background: #CBCBCB;
 }
 
 .lighter-text {
@@ -425,23 +426,22 @@ table tr:nth-child(2n-1) {
     color: #1A671A;
 }
 
-.radio-button-container:hover {
-    background-color: #D8D8D8;
-}
-
-.radio-button-container .radio-button {
-    background-color: #FFFBEF;
-    border-color: #61C315;
-}
-
-.radio-button-container .radio-button.selected::before {
-    background-color: #61C315;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
+}
+
+.selection-container {
+    --hover-background: #D8D8D8;
+}
+
+.selection-container .checkbox {
+    background-color: #FFFFFF;
+}
+
+.selection-container .radio-button {
+    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -414,6 +414,18 @@ table tr:nth-child(2n-1) {
     --adherence-background: #3C5ABE;
 }
 
+.option {
+    --hover-background: #E6E6E6;
+}
+
+.option .checkbox {
+    background-color: #FFFFFF;
+}
+
+.option .radio-button {
+    background-color: #FFFFFF;
+}
+
 .order-details .content .separator {
     color: #666666;
 }
@@ -426,18 +438,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
-}
-
-.option {
-    --hover-background: #E6E6E6;
-}
-
-.option .checkbox {
-    background-color: #FFFFFF;
-}
-
-.option .radio-button {
-    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -43,7 +43,7 @@ body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .selection-container {
+body.full-map #page-header .option {
     --hover-background: #FFFFFF;
 }
 
@@ -354,7 +354,7 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #CBCBCB;
 }
 
-.info-box .selection-container {
+.info-box .option {
     --hover-background: #CBCBCB;
 }
 
@@ -428,15 +428,15 @@ table tr:nth-child(2n-1) {
     background-color: #989898;
 }
 
-.selection-container {
+.option {
     --hover-background: #E6E6E6;
 }
 
-.selection-container .checkbox {
+.option .checkbox {
     background-color: #FFFFFF;
 }
 
-.selection-container .radio-button {
+.option .radio-button {
     background-color: #FFFFFF;
 }
 

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -19,8 +19,15 @@
 :root {
     --tooltip-background: #666666;
     --tooltip-text: #FFFFFF;
+    
+    --loading-background: #FFFFFF;
+    --loading-foreground: #165ABE;
+    
     --adherence-background: #989898;
     --adherence-text: #FFFFFF;
+    
+    --checkbox-color: #165ABE;
+    --radio-button-color: #165ABE;
 }
 
 a {
@@ -34,6 +41,10 @@ body {
 
 body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
+}
+
+body.full-map #page-header .selection-container {
+    --hover-background: #FFFFFF;
 }
 
 input[type="text"] {
@@ -325,12 +336,6 @@ table tr:nth-child(2n-1) {
     background-color: #AD6000;
 }
 
-.checkbox-container .checkbox {
-    border-color: #000000;
-    background-color: #FFFFFF;
-    --image-color: #000000;
-}
-
 .code-block {
     background-color: #E6E6E6;
     border-color: #000000;
@@ -347,6 +352,10 @@ table tr:nth-child(2n-1) {
 
 .info-box .section {
     border-bottom-color: #CBCBCB;
+}
+
+.info-box .selection-container {
+    --hover-background: #CBCBCB;
 }
 
 .lighter-text {
@@ -413,22 +422,22 @@ table tr:nth-child(2n-1) {
     color: #1A671A;
 }
 
-.radio-button-container:hover {
-    background-color: #E6E6E6;
-}
-
-.radio-button-container .radio-button {
-    border-color: #E39B35;
-}
-
-.radio-button-container .radio-button.selected::before {
-    background-color: #E39B35;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
+}
+
+.selection-container {
+    --hover-background: #E6E6E6;
+}
+
+.selection-container .checkbox {
+    background-color: #FFFFFF;
+}
+
+.selection-container .radio-button {
+    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -43,7 +43,7 @@ body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .selection-container {
+body.full-map #page-header .option {
     --hover-background: #FFFFFF;
 }
 
@@ -358,7 +358,7 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #C3E9C1;
 }
 
-.info-box .selection-container {
+.info-box .option {
     --hover-background: #C3E9C1;
 }
 
@@ -432,15 +432,15 @@ table tr:nth-child(2n-1) {
     background-color: #989898;
 }
 
-.selection-container {
+.option {
     --hover-background: #E4F6E3;
 }
 
-.selection-container .checkbox {
+.option .checkbox {
     background-color: #FFFFFF;
 }
 
-.selection-container .radio-button {
+.option .radio-button {
     background-color: #FFFFFF;
 }
 

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -418,6 +418,18 @@ table tr:nth-child(2n-1) {
     --adherence-background: #3C5ABE;
 }
 
+.option {
+    --hover-background: #E4F6E3;
+}
+
+.option .checkbox {
+    background-color: #FFFFFF;
+}
+
+.option .radio-button {
+    background-color: #FFFFFF;
+}
+
 .order-details .content .separator {
     color: #69BB65;
 }
@@ -430,18 +442,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
-}
-
-.option {
-    --hover-background: #E4F6E3;
-}
-
-.option .checkbox {
-    background-color: #FFFFFF;
-}
-
-.option .radio-button {
-    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -25,6 +25,9 @@
     
     --adherence-background: #989898;
     --adherence-text: #FFFFFF;
+    
+    --checkbox-color: #D70000;
+    --radio-button-color: #D70000;
 }
 
 a {
@@ -38,6 +41,10 @@ body {
 
 body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
+}
+
+body.full-map #page-header .selection-container {
+    --hover-background: #FFFFFF;
 }
 
 input[type="text"] {
@@ -333,12 +340,6 @@ table tr:nth-child(2n-1) {
     background-color: #AD6000;
 }
 
-.checkbox-container .checkbox {
-    border-color: #000000;
-    background-color: #FFFFFF;
-    --image-color: #000000;
-}
-
 .code-block {
     background-color: #E4F6E3;
     border-color: #69BB65;
@@ -357,8 +358,8 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #C3E9C1;
 }
 
-.info-box .radio-button-container:hover {
-    background-color: #C3E9C1;
+.info-box .selection-container {
+    --hover-background: #C3E9C1;
 }
 
 .lighter-text {
@@ -425,23 +426,22 @@ table tr:nth-child(2n-1) {
     color: #AB0000;
 }
 
-.radio-button-container:hover {
-    background-color: #E4F6E3;
-}
-
-.radio-button-container .radio-button {
-    background-color: #FFFFFF;
-    border-color: #D70000;
-}
-
-.radio-button-container .radio-button.selected::before {
-    background-color: #D70000;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
+}
+
+.selection-container {
+    --hover-background: #E4F6E3;
+}
+
+.selection-container .checkbox {
+    background-color: #FFFFFF;
+}
+
+.selection-container .radio-button {
+    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/classic.css
+++ b/style/themes/classic.css
@@ -25,6 +25,9 @@
     
     --adherence-background: #989898;
     --adherence-text: #FFFFFF;
+    
+    --checkbox-color: #E20000;
+    --radio-button-color: #E20000;
 }
 
 a {
@@ -38,6 +41,10 @@ body {
 
 body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
+}
+
+body.full-map #page-header .selection-container {
+    --hover-background: #FFFFFF;
 }
 
 input[type="text"] {
@@ -333,12 +340,6 @@ table tr:nth-child(2n-1) {
     background-color: #AD6000;
 }
 
-.checkbox-container .checkbox {
-    border-color: #000000;
-    background-color: #FFFFFF;
-    --image-color: #000000;
-}
-
 .code-block {
     background-color: #E6E6E6;
     border-color: #666666;
@@ -357,8 +358,8 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #CBCBCB;
 }
 
-.info-box .radio-button-container:hover {
-    background-color: #CBCBCB;
+.info-box .selection-container {
+    --hover-background: #CBCBCB;
 }
 
 .lighter-text {
@@ -425,23 +426,22 @@ table tr:nth-child(2n-1) {
     color: #1A671A;
 }
 
-.radio-button-container:hover {
-    background-color: #E6E6E6;
-}
-
-.radio-button-container .radio-button {
-    background-color: #FFFFFF;
-    border-color: #E20000;
-}
-
-.radio-button-container .radio-button.selected::before {
-    background-color: #E20000;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
+}
+
+.selection-container {
+    --hover-background: #E6E6E6;
+}
+
+.selection-container .checkbox {
+    background-color: #FFFFFF;
+}
+
+.selection-container .radio-button {
+    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/classic.css
+++ b/style/themes/classic.css
@@ -43,7 +43,7 @@ body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .selection-container {
+body.full-map #page-header .option {
     --hover-background: #FFFFFF;
 }
 
@@ -358,7 +358,7 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #CBCBCB;
 }
 
-.info-box .selection-container {
+.info-box .option {
     --hover-background: #CBCBCB;
 }
 
@@ -432,15 +432,15 @@ table tr:nth-child(2n-1) {
     background-color: #989898;
 }
 
-.selection-container {
+.option {
     --hover-background: #E6E6E6;
 }
 
-.selection-container .checkbox {
+.option .checkbox {
     background-color: #FFFFFF;
 }
 
-.selection-container .radio-button {
+.option .radio-button {
     background-color: #FFFFFF;
 }
 

--- a/style/themes/classic.css
+++ b/style/themes/classic.css
@@ -418,6 +418,18 @@ table tr:nth-child(2n-1) {
     --adherence-background: #3C5ABE;
 }
 
+.option {
+    --hover-background: #E6E6E6;
+}
+
+.option .checkbox {
+    background-color: #FFFFFF;
+}
+
+.option .radio-button {
+    background-color: #FFFFFF;
+}
+
 .order-details .content .separator {
     color: #666666;
 }
@@ -430,18 +442,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
-}
-
-.option {
-    --hover-background: #E6E6E6;
-}
-
-.option .checkbox {
-    background-color: #FFFFFF;
-}
-
-.option .radio-button {
-    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/contrast.css
+++ b/style/themes/contrast.css
@@ -25,6 +25,9 @@
     
     --adherence-background: #989898;
     --adherence-text: #FFFFFF;
+    
+    --checkbox-color: #365CCB;
+    --radio-button-color: #365CCB;
 }
 
 a {
@@ -38,6 +41,10 @@ body {
 
 body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
+}
+
+body.full-map #page-header .selection-container {
+    --hover-background: #FFFFFF;
 }
 
 input[type="text"] {
@@ -333,12 +340,6 @@ table tr:nth-child(2n-1) {
     background-color: #AD6000;
 }
 
-.checkbox-container .checkbox {
-    border-color: #000000;
-    background-color: #FFFFFF;
-    --image-color: #000000;
-}
-
 .code-block {
     background-color: #E6E6E6;
     border-color: #666666;
@@ -357,8 +358,8 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #CBCBCB;
 }
 
-.info-box .radio-button-container:hover {
-    background-color: #CBCBCB;
+.info-box .selection-container {
+    --hover-background: #CBCBCB;
 }
 
 .lighter-text {
@@ -425,23 +426,22 @@ table tr:nth-child(2n-1) {
     color: #1A671A;
 }
 
-.radio-button-container:hover {
-    background-color: #E6E6E6;
-}
-
-.radio-button-container .radio-button {
-    background-color: #FFFFFF;
-    border-color: #365CCB;
-}
-
-.radio-button-container .radio-button.selected::before {
-    background-color: #365CCB;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
+}
+
+.selection-container {
+    --hover-background: #E6E6E6;
+}
+
+.selection-container .checkbox {
+    background-color: #FFFFFF;
+}
+
+.selection-container .radio-button {
+    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/contrast.css
+++ b/style/themes/contrast.css
@@ -43,7 +43,7 @@ body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .selection-container {
+body.full-map #page-header .option {
     --hover-background: #FFFFFF;
 }
 
@@ -358,7 +358,7 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #CBCBCB;
 }
 
-.info-box .selection-container {
+.info-box .option {
     --hover-background: #CBCBCB;
 }
 
@@ -432,15 +432,15 @@ table tr:nth-child(2n-1) {
     background-color: #989898;
 }
 
-.selection-container {
+.option {
     --hover-background: #E6E6E6;
 }
 
-.selection-container .checkbox {
+.option .checkbox {
     background-color: #FFFFFF;
 }
 
-.selection-container .radio-button {
+.option .radio-button {
     background-color: #FFFFFF;
 }
 

--- a/style/themes/contrast.css
+++ b/style/themes/contrast.css
@@ -418,6 +418,18 @@ table tr:nth-child(2n-1) {
     --adherence-background: #3C5ABE;
 }
 
+.option {
+    --hover-background: #E6E6E6;
+}
+
+.option .checkbox {
+    background-color: #FFFFFF;
+}
+
+.option .radio-button {
+    background-color: #FFFFFF;
+}
+
 .order-details .content .separator {
     color: #666666;
 }
@@ -430,18 +442,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
-}
-
-.option {
-    --hover-background: #E6E6E6;
-}
-
-.option .checkbox {
-    background-color: #FFFFFF;
-}
-
-.option .radio-button {
-    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/dark.css
+++ b/style/themes/dark.css
@@ -26,6 +26,9 @@
     
     --adherence-background: #989898;
     --adherence-text: #FFFFFF;
+    
+    --checkbox-color: #5CC3FF;
+    --radio-button-color: #5CC3FF;
 }
 
 a {
@@ -39,6 +42,10 @@ body {
 
 body.full-map #page-header {
     background-color: rgba(30, 30, 30, 0.7);
+}
+
+body.full-map #page-header .selection-container {
+    --hover-background: #2F2F2F;
 }
 
 input[type="text"] {
@@ -341,12 +348,6 @@ table tr:nth-child(2n-1) {
     background-color: #653800;
 }
 
-.checkbox-container .checkbox {
-    border-color: #FFFFFF;
-    background-color: #565656;
-    --image-color: #FFFFFF;
-}
-
 .code-block {
     background-color: #393939;
     border-color: #565656;
@@ -365,8 +366,8 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #565656;
 }
 
-.info-box .radio-button-container:hover {
-    background-color: #565656;
+.info-box .selection-container {
+    --hover-background: #565656;
 }
 
 .lighter-text {
@@ -437,23 +438,22 @@ table tr:nth-child(2n-1) {
     color: #428342;
 }
 
-.radio-button-container:hover {
-    background-color: #393939;
-}
-
-.radio-button-container .radio-button {
-    background-color: #2F2F2F;
-    border-color: #2247B7;
-}
-
-.radio-button-container .radio-button.selected::before {
-    background-color: #2247B7;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #393939;
     background-color: #989898;
+}
+
+.selection-container {
+    --hover-background: #393939;
+}
+
+.selection-container .checkbox {
+    background-color: #2F2F2F;
+}
+
+.selection-container .radio-button {
+    background-color: #2F2F2F;
 }
 
 .sheet {

--- a/style/themes/dark.css
+++ b/style/themes/dark.css
@@ -44,7 +44,7 @@ body.full-map #page-header {
     background-color: rgba(30, 30, 30, 0.7);
 }
 
-body.full-map #page-header .selection-container {
+body.full-map #page-header .option {
     --hover-background: #2F2F2F;
 }
 
@@ -366,7 +366,7 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #565656;
 }
 
-.info-box .selection-container {
+.info-box .option {
     --hover-background: #565656;
 }
 
@@ -444,15 +444,15 @@ table tr:nth-child(2n-1) {
     background-color: #989898;
 }
 
-.selection-container {
+.option {
     --hover-background: #393939;
 }
 
-.selection-container .checkbox {
+.option .checkbox {
     background-color: #2F2F2F;
 }
 
-.selection-container .radio-button {
+.option .radio-button {
     background-color: #2F2F2F;
 }
 

--- a/style/themes/dark.css
+++ b/style/themes/dark.css
@@ -430,6 +430,18 @@ table tr:nth-child(2n-1) {
     --adherence-background: #0093A8;
 }
 
+.option {
+    --hover-background: #393939;
+}
+
+.option .checkbox {
+    background-color: #2F2F2F;
+}
+
+.option .radio-button {
+    background-color: #2F2F2F;
+}
+
 .order-details .content .separator {
     color: #565656;
 }
@@ -442,18 +454,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
     border-color: #393939;
     background-color: #989898;
-}
-
-.option {
-    --hover-background: #393939;
-}
-
-.option .checkbox {
-    background-color: #2F2F2F;
-}
-
-.option .radio-button {
-    background-color: #2F2F2F;
 }
 
 .sheet {

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -43,7 +43,7 @@ body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .selection-container {
+body.full-map #page-header .option {
     --hover-background: #FFFFFF;
 }
 
@@ -349,7 +349,7 @@ table tr {
     border-bottom-color: #DDDDDD;
 }
 
-.info-box .selection-container {
+.info-box .option {
     --hover-background: #DDDDDD;
 }
 
@@ -423,15 +423,15 @@ table tr {
     background-color: #989898;
 }
 
-.selection-container {
+.option {
     --hover-background: #EEEEEE;
 }
 
-.selection-container .checkbox {
+.option .checkbox {
     background-color: #FFFFFF;
 }
 
-.selection-container .radio-button {
+.option .radio-button {
     background-color: #FFFFFF;
 }
 

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -409,6 +409,18 @@ table tr {
     --adherence-background: #3C5ABE;
 }
 
+.option {
+    --hover-background: #EEEEEE;
+}
+
+.option .checkbox {
+    background-color: #FFFFFF;
+}
+
+.option .radio-button {
+    background-color: #FFFFFF;
+}
+
 .order-details .content .separator {
     color: #888888;
 }
@@ -421,18 +433,6 @@ table tr {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
-}
-
-.option {
-    --hover-background: #EEEEEE;
-}
-
-.option .checkbox {
-    background-color: #FFFFFF;
-}
-
-.option .radio-button {
-    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -25,6 +25,9 @@
     
     --adherence-background: #989898;
     --adherence-text: #FFFFFF;
+    
+    --checkbox-color: #000000;
+    --radio-button-color: #000000;
 }
 
 a {
@@ -38,6 +41,10 @@ body {
 
 body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
+}
+
+body.full-map #page-header .selection-container {
+    --hover-background: #FFFFFF;
 }
 
 input[type="text"] {
@@ -324,12 +331,6 @@ table tr {
     background-color: #AD6000;
 }
 
-.checkbox-container .checkbox {
-    border-color: #000000;
-    background-color: #FFFFFF;
-    --image-color: #000000;
-}
-
 .code-block {
     background-color: #EEEEEE;
     border-color: #DDDDDD;
@@ -348,8 +349,8 @@ table tr {
     border-bottom-color: #DDDDDD;
 }
 
-.info-box .radio-button-container:hover {
-    background-color: #DDDDDD;
+.info-box .selection-container {
+    --hover-background: #DDDDDD;
 }
 
 .lighter-text {
@@ -416,23 +417,22 @@ table tr {
     color: #1A671A;
 }
 
-.radio-button-container:hover {
-    background-color: #EEEEEE;
-}
-
-.radio-button-container .radio-button {
-    background-color: #FFFFFF;
-    border-color: #AAAAAA;
-}
-
-.radio-button-container .radio-button.selected::before {
-    background-color: #AAAAAA;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
+}
+
+.selection-container {
+    --hover-background: #EEEEEE;
+}
+
+.selection-container .checkbox {
+    background-color: #FFFFFF;
+}
+
+.selection-container .radio-button {
+    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -44,7 +44,7 @@ body.full-map #page-header {
     background-color: rgba(30, 30, 30, 0.7);
 }
 
-body.full-map #page-header .selection-container {
+body.full-map #page-header .option {
     --hover-background: #2F2F2F;
 }
 
@@ -366,7 +366,7 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #565656;
 }
 
-.info-box .selection-container {
+.info-box .option {
     --hover-background: #565656;
 }
 
@@ -444,15 +444,15 @@ table tr:nth-child(2n-1) {
     background-color: #989898;
 }
 
-.selection-container {
+.option {
     --hover-background: #393939;
 }
 
-.selection-container .checkbox {
+.option .checkbox {
     background-color: #2F2F2F;
 }
 
-.selection-container .radio-button {
+.option .radio-button {
     background-color: #2F2F2F;
 }
 

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -430,6 +430,18 @@ table tr:nth-child(2n-1) {
     --adherence-background: #0093A8;
 }
 
+.option {
+    --hover-background: #393939;
+}
+
+.option .checkbox {
+    background-color: #2F2F2F;
+}
+
+.option .radio-button {
+    background-color: #2F2F2F;
+}
+
 .order-details .content .separator {
     color: #565656;
 }
@@ -442,18 +454,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
     border-color: #393939;
     background-color: #989898;
-}
-
-.option {
-    --hover-background: #393939;
-}
-
-.option .checkbox {
-    background-color: #2F2F2F;
-}
-
-.option .radio-button {
-    background-color: #2F2F2F;
 }
 
 .sheet {

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -26,6 +26,9 @@
     
     --adherence-background: #989898;
     --adherence-text: #FFFFFF;
+    
+    --checkbox-color: #FF6C00;
+    --radio-button-color: #FF6C00;
 }
 
 a {
@@ -39,6 +42,10 @@ body {
 
 body.full-map #page-header {
     background-color: rgba(30, 30, 30, 0.7);
+}
+
+body.full-map #page-header .selection-container {
+    --hover-background: #2F2F2F;
 }
 
 input[type="text"] {
@@ -341,12 +348,6 @@ table tr:nth-child(2n-1) {
     background-color: #653800;
 }
 
-.checkbox-container .checkbox {
-    border-color: #FFFFFF;
-    background-color: #565656;
-    --image-color: #FFFFFF;
-}
-
 .code-block {
     background-color: #393939;
     border-color: #565656;
@@ -365,8 +366,8 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #565656;
 }
 
-.info-box .radio-button-container:hover {
-    background-color: #565656;
+.info-box .selection-container {
+    --hover-background: #565656;
 }
 
 .lighter-text {
@@ -437,23 +438,22 @@ table tr:nth-child(2n-1) {
     color: #428342;
 }
 
-.radio-button-container:hover {
-    background-color: #393939;
-}
-
-.radio-button-container .radio-button {
-    background-color: #2F2F2F;
-    border-color: #FF6C00;
-}
-
-.radio-button-container .radio-button.selected::before {
-    background-color: #FF6C00;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #393939;
     background-color: #989898;
+}
+
+.selection-container {
+    --hover-background: #393939;
+}
+
+.selection-container .checkbox {
+    background-color: #2F2F2F;
+}
+
+.selection-container .radio-button {
+    background-color: #2F2F2F;
 }
 
 .sheet {

--- a/style/themes/light.css
+++ b/style/themes/light.css
@@ -25,6 +25,9 @@
     
     --adherence-background: #989898;
     --adherence-text: #FFFFFF;
+    
+    --checkbox-color: #365CCB;
+    --radio-button-color: #365CCB;
 }
 
 a {
@@ -38,6 +41,10 @@ body {
 
 body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
+}
+
+body.full-map #page-header .selection-container {
+    --hover-background: #FFFFFF;
 }
 
 input[type="text"] {
@@ -333,12 +340,6 @@ table tr:nth-child(2n-1) {
     background-color: #AD6000;
 }
 
-.checkbox-container .checkbox {
-    border-color: #000000;
-    background-color: #FFFFFF;
-    --image-color: #000000;
-}
-
 .code-block {
     background-color: #E6E6E6;
     border-color: #666666;
@@ -357,8 +358,8 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #CBCBCB;
 }
 
-.info-box .radio-button-container:hover {
-    background-color: #CBCBCB;
+.info-box .selection-container {
+    --hover-background: #CBCBCB;
 }
 
 .lighter-text {
@@ -425,23 +426,22 @@ table tr:nth-child(2n-1) {
     color: #1A671A;
 }
 
-.radio-button-container:hover {
-    background-color: #E6E6E6;
-}
-
-.radio-button-container .radio-button {
-    background-color: #FFFFFF;
-    border-color: #365CCB;
-}
-
-.radio-button-container .radio-button.selected::before {
-    background-color: #365CCB;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
+}
+
+.selection-container {
+    --hover-background: #E6E6E6;
+}
+
+.selection-container .checkbox {
+    background-color: #FFFFFF;
+}
+
+.selection-container .radio-button {
+    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/light.css
+++ b/style/themes/light.css
@@ -43,7 +43,7 @@ body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .selection-container {
+body.full-map #page-header .option {
     --hover-background: #FFFFFF;
 }
 
@@ -358,7 +358,7 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #CBCBCB;
 }
 
-.info-box .selection-container {
+.info-box .option {
     --hover-background: #CBCBCB;
 }
 
@@ -432,15 +432,15 @@ table tr:nth-child(2n-1) {
     background-color: #989898;
 }
 
-.selection-container {
+.option {
     --hover-background: #E6E6E6;
 }
 
-.selection-container .checkbox {
+.option .checkbox {
     background-color: #FFFFFF;
 }
 
-.selection-container .radio-button {
+.option .radio-button {
     background-color: #FFFFFF;
 }
 

--- a/style/themes/light.css
+++ b/style/themes/light.css
@@ -418,6 +418,18 @@ table tr:nth-child(2n-1) {
     --adherence-background: #3C5ABE;
 }
 
+.option {
+    --hover-background: #E6E6E6;
+}
+
+.option .checkbox {
+    background-color: #FFFFFF;
+}
+
+.option .radio-button {
+    background-color: #FFFFFF;
+}
+
 .order-details .content .separator {
     color: #666666;
 }
@@ -430,18 +442,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
-}
-
-.option {
-    --hover-background: #E6E6E6;
-}
-
-.option .checkbox {
-    background-color: #FFFFFF;
-}
-
-.option .radio-button {
-    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -12,6 +12,9 @@
     
     --adherence-background: #989898;
     --adherence-text: #FFFFFF;
+    
+    --checkbox-color: #5E87B0;
+    --radio-button-color: #5E87B0;
 }
 
 a {
@@ -27,6 +30,10 @@ body {
 
 body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
+}
+
+body.full-map #page-header .selection-container {
+    --hover-background: #FFFFFF;
 }
 
 input[type="text"] {
@@ -411,12 +418,6 @@ table tr {
     background-color: #AD6000;
 }
 
-.checkbox-container .checkbox {
-    border-color: #000000;
-    background-color: #FFFFFF;
-    --image-color: #000000;
-}
-
 .code-block {
     background-color: #EEEEEE;
     color: #222222;
@@ -443,8 +444,8 @@ table tr {
     border-bottom-color: #CBCBCB;
 }
 
-.info-box .radio-button-container:hover {
-    background-color: #CBCBCB;
+.info-box .selection-container {
+    --hover-background: #CBCBCB;
 }
 
 .lighter-text {
@@ -517,25 +518,24 @@ table tr {
     color: #1A671A;
 }
 
-.radio-button-container:hover {
-    background-color: #EEEEEE;
-}
-
-.radio-button-container .radio-button {
-    background-color: #FFFFFF;
-    border-color: #222222;
-}
-
-.radio-button-container .radio-button.selected::before {
-    background-color: #222222;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
     text-shadow: none;
     text-decoration: none;
+}
+
+.selection-container {
+    --hover-background: #EEEEEE;
+}
+
+.selection-container .checkbox {
+    background-color: #FFFFFF;
+}
+
+.selection-container .radio-button {
+    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -514,18 +514,6 @@ table tr {
     --adherence-background: #4EBF40;
 }
 
-.positive {
-    color: #1A671A;
-}
-
-.route {
-    color: #FFFFFF;
-    border-color: #FFFFFF;
-    background-color: #989898;
-    text-shadow: none;
-    text-decoration: none;
-}
-
 .option {
     --hover-background: #EEEEEE;
 }
@@ -536,6 +524,18 @@ table tr {
 
 .option .radio-button {
     background-color: #FFFFFF;
+}
+
+.positive {
+    color: #1A671A;
+}
+
+.route {
+    color: #FFFFFF;
+    border-color: #FFFFFF;
+    background-color: #989898;
+    text-shadow: none;
+    text-decoration: none;
 }
 
 .sheet {

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -32,7 +32,7 @@ body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .selection-container {
+body.full-map #page-header .option {
     --hover-background: #FFFFFF;
 }
 
@@ -444,7 +444,7 @@ table tr {
     border-bottom-color: #CBCBCB;
 }
 
-.info-box .selection-container {
+.info-box .option {
     --hover-background: #CBCBCB;
 }
 
@@ -526,15 +526,15 @@ table tr {
     text-decoration: none;
 }
 
-.selection-container {
+.option {
     --hover-background: #EEEEEE;
 }
 
-.selection-container .checkbox {
+.option .checkbox {
     background-color: #FFFFFF;
 }
 
-.selection-container .radio-button {
+.option .radio-button {
     background-color: #FFFFFF;
 }
 

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -43,7 +43,7 @@ body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .selection-container {
+body.full-map #page-header .option {
     --hover-background: #FFFFFF;
 }
 
@@ -358,7 +358,7 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #CBCBCB;
 }
 
-.info-box .selection-container {
+.info-box .option {
     --hover-background: #CBCBCB;
 }
 
@@ -432,15 +432,15 @@ table tr:nth-child(2n-1) {
     background-color: #989898;
 }
 
-.selection-container {
+.option {
     --hover-background: #E6E6E6;
 }
 
-.selection-container .checkbox {
+.option .checkbox {
     background-color: #FFFFFF;
 }
 
-.selection-container .radio-button {
+.option .radio-button {
     background-color: #FFFFFF;
 }
 

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -25,6 +25,9 @@
     
     --adherence-background: #989898;
     --adherence-text: #FFFFFF;
+    
+    --checkbox-color: #C7743B;
+    --radio-button-color: #C7743B;
 }
 
 a {
@@ -38,6 +41,10 @@ body {
 
 body.full-map #page-header {
     background-color: rgba(255, 255, 255, 0.7);
+}
+
+body.full-map #page-header .selection-container {
+    --hover-background: #FFFFFF;
 }
 
 input[type="text"] {
@@ -333,12 +340,6 @@ table tr:nth-child(2n-1) {
     background-color: #AD6000;
 }
 
-.checkbox-container .checkbox {
-    border-color: #000000;
-    background-color: #FFFFFF;
-    --image-color: #000000;
-}
-
 .code-block {
     background-color: #E6E6E6;
     border-color: #666666;
@@ -357,8 +358,8 @@ table tr:nth-child(2n-1) {
     border-bottom-color: #CBCBCB;
 }
 
-.info-box .radio-button-container:hover {
-    background-color: #CBCBCB;
+.info-box .selection-container {
+    --hover-background: #CBCBCB;
 }
 
 .lighter-text {
@@ -425,23 +426,22 @@ table tr:nth-child(2n-1) {
     color: #1A671A;
 }
 
-.radio-button-container:hover {
-    background-color: #E6E6E6;
-}
-
-.radio-button-container .radio-button {
-    background-color: #FFFBEF;
-    border-color: #C7743B;
-}
-
-.radio-button-container .radio-button.selected::before {
-    background-color: #C7743B;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
+}
+
+.selection-container {
+    --hover-background: #E6E6E6;
+}
+
+.selection-container .checkbox {
+    background-color: #FFFFFF;
+}
+
+.selection-container .radio-button {
+    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -418,6 +418,18 @@ table tr:nth-child(2n-1) {
     --adherence-background: #3C5ABE;
 }
 
+.option {
+    --hover-background: #E6E6E6;
+}
+
+.option .checkbox {
+    background-color: #FFFFFF;
+}
+
+.option .radio-button {
+    background-color: #FFFFFF;
+}
+
 .order-details .content .separator {
     color: #666666;
 }
@@ -430,18 +442,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
     border-color: #FFFFFF;
     background-color: #989898;
-}
-
-.option {
-    --hover-background: #E6E6E6;
-}
-
-.option .checkbox {
-    background-color: #FFFFFF;
-}
-
-.option .radio-button {
-    background-color: #FFFFFF;
 }
 
 .sheet {

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -19,29 +19,29 @@
             <div class="content">
                 <div class="info-box">
                     <div class="grid section">
-                        <div class="radio-button-container" onclick="setDays(1)">
+                        <div class="selection-container" onclick="setDays(1)">
                             <div class="radio-button {{ 'selected' if days == 1 else '' }}"></div>
-                            <div class="label">Today</div>
+                            <div>Today</div>
                         </div>
-                        <div class="radio-button-container" onclick="setDays(7)">
+                        <div class="selection-container" onclick="setDays(7)">
                             <div class="radio-button {{ 'selected' if days == 7 else '' }}"></div>
-                            <div class="label">Last Week</div>
+                            <div>Last Week</div>
                         </div>
-                        <div class="radio-button-container" onclick="setDays(31)">
+                        <div class="selection-container" onclick="setDays(31)">
                             <div class="radio-button {{ 'selected' if days == 31 else '' }}"></div>
-                            <div class="label">Last Month</div>
+                            <div>Last Month</div>
                         </div>
-                        <div class="radio-button-container" onclick="setDays(90)">
+                        <div class="selection-container" onclick="setDays(90)">
                             <div class="radio-button {{ 'selected' if days == 90 else '' }}"></div>
-                            <div class="label">Last 3 Months</div>
+                            <div>Last 3 Months</div>
                         </div>
-                        <div class="radio-button-container" onclick="setDays(365)">
+                        <div class="selection-container" onclick="setDays(365)">
                             <div class="radio-button {{ 'selected' if days == 365 else '' }}"></div>
-                            <div class="label">Last Year</div>
+                            <div>Last Year</div>
                         </div>
-                        <div class="radio-button-container" onclick="setDays(null)">
+                        <div class="selection-container" onclick="setDays(null)">
                             <div class="radio-button {{ 'selected' if days is None else '' }}"></div>
-                            <div class="label">All Time</div>
+                            <div>All Time</div>
                         </div>
                     </div>
                 </div>

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -18,30 +18,32 @@
             </div>
             <div class="content">
                 <div class="info-box">
-                    <div class="grid section">
-                        <div class="selection-container" onclick="setDays(1)">
-                            <div class="radio-button {{ 'selected' if days == 1 else '' }}"></div>
-                            <div>Today</div>
-                        </div>
-                        <div class="selection-container" onclick="setDays(7)">
-                            <div class="radio-button {{ 'selected' if days == 7 else '' }}"></div>
-                            <div>Last Week</div>
-                        </div>
-                        <div class="selection-container" onclick="setDays(31)">
-                            <div class="radio-button {{ 'selected' if days == 31 else '' }}"></div>
-                            <div>Last Month</div>
-                        </div>
-                        <div class="selection-container" onclick="setDays(90)">
-                            <div class="radio-button {{ 'selected' if days == 90 else '' }}"></div>
-                            <div>Last 3 Months</div>
-                        </div>
-                        <div class="selection-container" onclick="setDays(365)">
-                            <div class="radio-button {{ 'selected' if days == 365 else '' }}"></div>
-                            <div>Last Year</div>
-                        </div>
-                        <div class="selection-container" onclick="setDays(null)">
-                            <div class="radio-button {{ 'selected' if days is None else '' }}"></div>
-                            <div>All Time</div>
+                    <div class="section">
+                        <div class="options-container grid">
+                            <div class="option" onclick="setDays(1)">
+                                <div class="radio-button {{ 'selected' if days == 1 else '' }}"></div>
+                                <div>Today</div>
+                            </div>
+                            <div class="option" onclick="setDays(7)">
+                                <div class="radio-button {{ 'selected' if days == 7 else '' }}"></div>
+                                <div>Last Week</div>
+                            </div>
+                            <div class="option" onclick="setDays(31)">
+                                <div class="radio-button {{ 'selected' if days == 31 else '' }}"></div>
+                                <div>Last Month</div>
+                            </div>
+                            <div class="option" onclick="setDays(90)">
+                                <div class="radio-button {{ 'selected' if days == 90 else '' }}"></div>
+                                <div>Last 3 Months</div>
+                            </div>
+                            <div class="option" onclick="setDays(365)">
+                                <div class="radio-button {{ 'selected' if days == 365 else '' }}"></div>
+                                <div>Last Year</div>
+                            </div>
+                            <div class="option" onclick="setDays(null)">
+                                <div class="radio-button {{ 'selected' if days is None else '' }}"></div>
+                                <div>All Time</div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -6,23 +6,25 @@
 <div id="page-header">
     <h1>Map</h1>
     % if len(visible_positions) > 0:
-        <div class="selection-container" onclick="toggleAutomaticRefresh()">
-            <div id="auto-refresh-checkbox" class="checkbox {{ 'selected' if auto_refresh else '' }}">
-                % include('components/svg', name='check')
+        <div class="options-container">
+            <div class="option" onclick="toggleAutomaticRefresh()">
+                <div id="auto-refresh-checkbox" class="checkbox {{ 'selected' if auto_refresh else '' }}">
+                    % include('components/svg', name='check')
+                </div>
+                <span>Automatically Refresh</span>
             </div>
-            <span>Automatically Refresh</span>
-        </div>
-        <div class="selection-container" onclick="toggleRouteLines()">
-            <div id="show-route-lines-checkbox" class="checkbox {{ 'selected' if show_route_lines else '' }}">
-                % include('components/svg', name='check')
+            <div class="option" onclick="toggleRouteLines()">
+                <div id="show-route-lines-checkbox" class="checkbox {{ 'selected' if show_route_lines else '' }}">
+                    % include('components/svg', name='check')
+                </div>
+                <span>Show Route Lines</span>
             </div>
-            <span>Show Route Lines</span>
-        </div>
-        <div class="selection-container" onclick="toggleNISBuses()">
-            <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
-                % include('components/svg', name='check')
+            <div class="option" onclick="toggleNISBuses()">
+                <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
+                    % include('components/svg', name='check')
+                </div>
+                <span>Show NIS Buses</span>
             </div>
-            <span>Show NIS Buses</span>
         </div>
     % end
 </div>
@@ -30,11 +32,13 @@
 % if len(visible_positions) == 0:
     <div class="container">
         <div class="section">
-            <div class="selection-container" onclick="toggleNISBusesEmpty()">
-                <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
-                    % include('components/svg', name='check')
+            <div class="options-container">
+                <div class="option" onclick="toggleNISBusesEmpty()">
+                    <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
+                        % include('components/svg', name='check')
+                    </div>
+                    <div>Show NIS Buses</div>
                 </div>
-                <div>Show NIS Buses</div>
             </div>
             <script>
                 function toggleNISBusesEmpty() {

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -6,19 +6,19 @@
 <div id="page-header">
     <h1>Map</h1>
     % if len(visible_positions) > 0:
-        <div class="checkbox-container" onclick="toggleAutomaticRefresh()">
+        <div class="selection-container" onclick="toggleAutomaticRefresh()">
             <div id="auto-refresh-checkbox" class="checkbox {{ 'selected' if auto_refresh else '' }}">
                 % include('components/svg', name='check')
             </div>
             <span>Automatically Refresh</span>
         </div>
-        <div class="checkbox-container" onclick="toggleRouteLines()">
+        <div class="selection-container" onclick="toggleRouteLines()">
             <div id="show-route-lines-checkbox" class="checkbox {{ 'selected' if show_route_lines else '' }}">
                 % include('components/svg', name='check')
             </div>
             <span>Show Route Lines</span>
         </div>
-        <div class="checkbox-container" onclick="toggleNISBuses()">
+        <div class="selection-container" onclick="toggleNISBuses()">
             <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
                 % include('components/svg', name='check')
             </div>
@@ -30,7 +30,7 @@
 % if len(visible_positions) == 0:
     <div class="container">
         <div class="section">
-            <div class="checkbox-container" onclick="toggleNISBusesEmpty()">
+            <div class="selection-container" onclick="toggleNISBusesEmpty()">
                 <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
                     % include('components/svg', name='check')
                 </div>

--- a/views/pages/personalize.tpl
+++ b/views/pages/personalize.tpl
@@ -25,22 +25,22 @@
                 % hidden_themes = [t for t in themes if not t.visible]
                 
                 <div class="column">
-                    <div class="radio-button-container" onclick="setTheme('automatic')">
+                    <div class="selection-container" onclick="setTheme('automatic')">
                         <div class="radio-button {{ 'selected' if theme is None else '' }}"></div>
-                        <div class="label">BC Transit (Auto)</div>
+                        <div>BC Transit (Auto)</div>
                     </div>
                     
                     % for visible_theme in visible_themes:
-                        <div class="radio-button-container" onclick="setTheme('{{ visible_theme.id }}')">
+                        <div class="selection-container" onclick="setTheme('{{ visible_theme.id }}')">
                             <div class="radio-button {{ 'selected' if theme is not None and visible_theme == theme else '' }}"></div>
-                            <div class="label">{{ visible_theme }}</div>
+                            <div>{{ visible_theme }}</div>
                         </div>
                     % end
                     
                     % if theme is not None and not theme.visible:
-                        <div class="radio-button-container" onclick="setTheme('{{ theme.id }}')">
+                        <div class="selection-container" onclick="setTheme('{{ theme.id }}')">
                             <div class="radio-button selected"></div>
-                            <div class="label">{{ theme }}</div>
+                            <div>{{ theme }}</div>
                         </div>
                     % end
                 </div>
@@ -67,16 +67,16 @@
                 <p>You can choose whether times are displayed as 12hr or 30hr.</p>
                 <p>Since buses running between midnight and early morning are considered part of the previous day's schedule, both formats modify how those times are shown.</p>
                 <div class="column">
-                    <div class="radio-button-container" onclick="setTimeFormat('12hr')">
+                    <div class="selection-container" onclick="setTimeFormat('12hr')">
                         <div class="radio-button {{ 'selected' if time_format == '12hr' else '' }}"></div>
-                        <div class="label column">
+                        <div class="column">
                             <p>12hr</p>
                             <p class="smaller-font lighter-text">Uses xm instead of am, so 1am is shown as 1xm</p>
                         </div>
                     </div>
-                    <div class="radio-button-container" onclick="setTimeFormat('30hr')">
+                    <div class="selection-container" onclick="setTimeFormat('30hr')">
                         <div class="radio-button {{ 'selected' if time_format is None or time_format == '24hr' or time_format == '30hr' else '' }}"></div>
-                        <div class="label column">
+                        <div class="column">
                             <p>30hr</p>
                             <p class="smaller-font lighter-text">Continues increasing the hour beyond a normal 24 hour clock, so 1am is shown as 25:00</p>
                         </div>
@@ -93,21 +93,21 @@
             <div class="content">
                 <p>Choose a style for bus icons shown on the map screen.</p>
                 <div class="column">
-                    <div class="radio-button-container" onclick="setBusMarkerStyle('default')">
+                    <div class="selection-container" onclick="setBusMarkerStyle('default')">
                         <div class="radio-button {{ 'selected' if bus_marker_style is None or bus_marker_style == 'default' else '' }}"></div>
-                        <div class="label">Default</div>
+                        <div>Default</div>
                     </div>
-                    <div class="radio-button-container" onclick="setBusMarkerStyle('mini')">
+                    <div class="selection-container" onclick="setBusMarkerStyle('mini')">
                         <div class="radio-button {{ 'selected' if bus_marker_style == 'mini' else '' }}"></div>
-                        <div class="label">Mini</div>
+                        <div>Mini</div>
                     </div>
-                    <div class="radio-button-container" onclick="setBusMarkerStyle('adherence')">
+                    <div class="selection-container" onclick="setBusMarkerStyle('adherence')">
                         <div class="radio-button {{ 'selected' if bus_marker_style == 'adherence' else '' }}"></div>
-                        <div class="label">Schedule Adherence</div>
+                        <div>Schedule Adherence</div>
                     </div>
-                    <div class="radio-button-container" onclick="setBusMarkerStyle('route')">
+                    <div class="selection-container" onclick="setBusMarkerStyle('route')">
                         <div class="radio-button {{ 'selected' if bus_marker_style == 'route' else '' }}"></div>
-                        <div class="label">Route Number</div>
+                        <div>Route Number</div>
                     </div>
                 </div>
             </div>

--- a/views/pages/personalize.tpl
+++ b/views/pages/personalize.tpl
@@ -24,21 +24,21 @@
                 % visible_themes = [t for t in themes if t.visible]
                 % hidden_themes = [t for t in themes if not t.visible]
                 
-                <div class="column">
-                    <div class="selection-container" onclick="setTheme('automatic')">
+                <div class="options-container">
+                    <div class="option" onclick="setTheme('automatic')">
                         <div class="radio-button {{ 'selected' if theme is None else '' }}"></div>
                         <div>BC Transit (Auto)</div>
                     </div>
                     
                     % for visible_theme in visible_themes:
-                        <div class="selection-container" onclick="setTheme('{{ visible_theme.id }}')">
+                        <div class="option" onclick="setTheme('{{ visible_theme.id }}')">
                             <div class="radio-button {{ 'selected' if theme is not None and visible_theme == theme else '' }}"></div>
                             <div>{{ visible_theme }}</div>
                         </div>
                     % end
                     
                     % if theme is not None and not theme.visible:
-                        <div class="selection-container" onclick="setTheme('{{ theme.id }}')">
+                        <div class="option" onclick="setTheme('{{ theme.id }}')">
                             <div class="radio-button selected"></div>
                             <div>{{ theme }}</div>
                         </div>
@@ -66,15 +66,15 @@
             <div class="content">
                 <p>You can choose whether times are displayed as 12hr or 30hr.</p>
                 <p>Since buses running between midnight and early morning are considered part of the previous day's schedule, both formats modify how those times are shown.</p>
-                <div class="column">
-                    <div class="selection-container" onclick="setTimeFormat('12hr')">
+                <div class="options-container">
+                    <div class="option" onclick="setTimeFormat('12hr')">
                         <div class="radio-button {{ 'selected' if time_format == '12hr' else '' }}"></div>
                         <div class="column">
                             <p>12hr</p>
                             <p class="smaller-font lighter-text">Uses xm instead of am, so 1am is shown as 1xm</p>
                         </div>
                     </div>
-                    <div class="selection-container" onclick="setTimeFormat('30hr')">
+                    <div class="option" onclick="setTimeFormat('30hr')">
                         <div class="radio-button {{ 'selected' if time_format is None or time_format == '24hr' or time_format == '30hr' else '' }}"></div>
                         <div class="column">
                             <p>30hr</p>
@@ -92,20 +92,20 @@
             </div>
             <div class="content">
                 <p>Choose a style for bus icons shown on the map screen.</p>
-                <div class="column">
-                    <div class="selection-container" onclick="setBusMarkerStyle('default')">
+                <div class="options-container">
+                    <div class="option" onclick="setBusMarkerStyle('default')">
                         <div class="radio-button {{ 'selected' if bus_marker_style is None or bus_marker_style == 'default' else '' }}"></div>
                         <div>Default</div>
                     </div>
-                    <div class="selection-container" onclick="setBusMarkerStyle('mini')">
+                    <div class="option" onclick="setBusMarkerStyle('mini')">
                         <div class="radio-button {{ 'selected' if bus_marker_style == 'mini' else '' }}"></div>
                         <div>Mini</div>
                     </div>
-                    <div class="selection-container" onclick="setBusMarkerStyle('adherence')">
+                    <div class="option" onclick="setBusMarkerStyle('adherence')">
                         <div class="radio-button {{ 'selected' if bus_marker_style == 'adherence' else '' }}"></div>
                         <div>Schedule Adherence</div>
                     </div>
-                    <div class="selection-container" onclick="setBusMarkerStyle('route')">
+                    <div class="option" onclick="setBusMarkerStyle('route')">
                         <div class="radio-button {{ 'selected' if bus_marker_style == 'route' else '' }}"></div>
                         <div>Route Number</div>
                     </div>

--- a/views/pages/realtime/all.tpl
+++ b/views/pages/realtime/all.tpl
@@ -18,7 +18,7 @@
     </div>
 </div>
 
-<div class="checkbox-container" onclick="toggleNISBuses()">
+<div class="selection-container" onclick="toggleNISBuses()">
     <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
         % include('components/svg', name='check')
     </div>

--- a/views/pages/realtime/all.tpl
+++ b/views/pages/realtime/all.tpl
@@ -18,11 +18,13 @@
     </div>
 </div>
 
-<div class="selection-container" onclick="toggleNISBuses()">
-    <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
-        % include('components/svg', name='check')
+<div class="options-container">
+    <div class="option" onclick="toggleNISBuses()">
+        <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
+            % include('components/svg', name='check')
+        </div>
+        <div>Show NIS Buses</div>
     </div>
-    <div>Show NIS Buses</div>
 </div>
 
 % if len(positions) == 0:

--- a/views/pages/realtime/models.tpl
+++ b/views/pages/realtime/models.tpl
@@ -18,7 +18,7 @@
     </div>
 </div>
 
-<div class="checkbox-container" onclick="toggleNISBuses()">
+<div class="selection-container" onclick="toggleNISBuses()">
     <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
         % include('components/svg', name='check')
     </div>

--- a/views/pages/realtime/models.tpl
+++ b/views/pages/realtime/models.tpl
@@ -18,11 +18,13 @@
     </div>
 </div>
 
-<div class="selection-container" onclick="toggleNISBuses()">
-    <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
-        % include('components/svg', name='check')
+<div class="options-container">
+    <div class="option" onclick="toggleNISBuses()">
+        <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
+            % include('components/svg', name='check')
+        </div>
+        <div>Show NIS Buses</div>
     </div>
-    <div>Show NIS Buses</div>
 </div>
 
 % if len(positions) == 0:

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -16,11 +16,13 @@
     </div>
 </div>
 
-<div class="selection-container" onclick="toggleNISBuses()">
-    <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
-        % include('components/svg', name='check')
+<div class="options-container">
+    <div class="option" onclick="toggleNISBuses()">
+        <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
+            % include('components/svg', name='check')
+        </div>
+        <div>Show NIS Buses</div>
     </div>
-    <div>Show NIS Buses</div>
 </div>
 
 % if len(positions) == 0:

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -16,7 +16,7 @@
     </div>
 </div>
 
-<div class="checkbox-container" onclick="toggleNISBuses()">
+<div class="selection-container" onclick="toggleNISBuses()">
     <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
         % include('components/svg', name='check')
     </div>

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -14,11 +14,13 @@
     </div>
 </div>
 
-<div class="selection-container" onclick="toggleNISBuses()">
-    <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
-        % include('components/svg', name='check')
+<div class="options-container">
+    <div class="option" onclick="toggleNISBuses()">
+        <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
+            % include('components/svg', name='check')
+        </div>
+        <div>Show NIS Buses</div>
     </div>
-    <div>Show NIS Buses</div>
 </div>
 
 % if len(positions) == 0:

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -14,7 +14,7 @@
     </div>
 </div>
 
-<div class="checkbox-container" onclick="toggleNISBuses()">
+<div class="selection-container" onclick="toggleNISBuses()">
     <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
         % include('components/svg', name='check')
     </div>

--- a/views/pages/routes/map.tpl
+++ b/views/pages/routes/map.tpl
@@ -11,7 +11,7 @@
             <span class="tab-button current">Map</span>
         </div>
         % if routes:
-            <div class="checkbox-container" onclick="toggleRouteNumbers()">
+            <div class="selection-container" onclick="toggleRouteNumbers()">
                 <div id="route-numbers-checkbox" class="checkbox {{ 'selected' if show_route_numbers else '' }}">
                     % include('components/svg', name='check')
                 </div>

--- a/views/pages/routes/map.tpl
+++ b/views/pages/routes/map.tpl
@@ -11,11 +11,13 @@
             <span class="tab-button current">Map</span>
         </div>
         % if routes:
-            <div class="selection-container" onclick="toggleRouteNumbers()">
-                <div id="route-numbers-checkbox" class="checkbox {{ 'selected' if show_route_numbers else '' }}">
-                    % include('components/svg', name='check')
+            <div class="options-container">
+                <div class="option" onclick="toggleRouteNumbers()">
+                    <div id="route-numbers-checkbox" class="checkbox {{ 'selected' if show_route_numbers else '' }}">
+                        % include('components/svg', name='check')
+                    </div>
+                    <span>Show Route Numbers</span>
                 </div>
-                <span>Show Route Numbers</span>
             </div>
         % end
     </div>


### PR DESCRIPTION
Checkboxes are updated to match the UI for radio buttons, giving the site a more consistent look and feel:
![Screenshot from 2024-04-05 20-39-08](https://github.com/bumblesquashs/bctracker/assets/7077422/6cf91683-733b-4361-b523-f1128cb423cd)

In practice the UI now looks like this:
![Screenshot from 2024-04-05 22-07-51](https://github.com/bumblesquashs/bctracker/assets/7077422/26c66c34-447b-4fde-9c25-e34be46f63ca)
![Screenshot from 2024-04-05 22-07-40](https://github.com/bumblesquashs/bctracker/assets/7077422/923cfc9f-38f8-40f9-a7c4-77c9f03f0e80)

Like radio buttons, the background of the overall container changes colour when hovered over:
![Screenshot from 2024-04-05 22-21-46](https://github.com/bumblesquashs/bctracker/assets/7077422/531f82aa-5075-4ee5-a8e0-f53dcd3604e3)

On transparent-white backgrounds (like maps) the hover colour is white. On light grey backgrounds, the hover colour is darker grey.

More technical overview of the changes:
- Updated checkbox UI
  - Overall size is slightly reduced to match radio button dimensions
  - Border width is increased
  - Checkbox image line width is increased
  - Border and image are now coloured rather than black/white
- `checkbox-container` and `radio-button-container` are combined into a single `option` class
  - Ensures consistency between the two types of selections
  - Space between checkbox and text is now 10px instead of 5px
  - Radio buttons now self-align to flex-start
  - Radio buttons are no longer indented on mobile
- Added `options-container` class
  - Dedicated layout control for multiple options
  - Adjusts spacing based on device
  - Has dedicated grid option
- Checkbox, radio button, and hover background colours are now set CSS variables
- Other minor updates:
  - Tcomm theme radio buttons are now blue instead of black
  - Ghost theme radio buttons are now black instead of light grey
  - Dark theme radio buttons are now a lighter shade of blue
  - Added some missing CSS in Broome County theme