### PR TITLE
Section toggles

### DIFF
--- a/img/dropdown.svg
+++ b/img/dropdown.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" /></svg>

--- a/img/dropdown.svg
+++ b/img/dropdown.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" /></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z" /></svg>

--- a/style/devices/desktop.css
+++ b/style/devices/desktop.css
@@ -183,6 +183,10 @@ table th {
     vertical-align: middle;
 }
 
+.container > .section > .header > .toggle {
+    display: none;
+}
+
 .mobile-only {
     display: none !important;
 }

--- a/style/devices/mobile.css
+++ b/style/devices/mobile.css
@@ -230,6 +230,14 @@ table {
     display: block;
 }
 
+.container > .section > .header > .toggle {
+    --image-size: 28px;
+}
+
+.container > .section.closed > .content {
+    display: none;
+}
+
 .desktop-only {
     display: none !important;
 }

--- a/style/devices/tablet.css
+++ b/style/devices/tablet.css
@@ -217,6 +217,14 @@ table {
     display: block;
 }
 
+.container > .section > .header > .toggle {
+    --image-size: 28px;
+}
+
+.container > .section.closed > .content {
+    display: none;
+}
+
 .desktop-only {
     display: none !important;
 }

--- a/style/main.css
+++ b/style/main.css
@@ -598,14 +598,21 @@ table tr.header td {
 
 .container > .section > .header {
     display: flex;
-    flex-direction: column;
-    gap: 0px;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    gap: 5px;
 }
 
 .container > .section > .content {
     display: flex;
     flex-direction: column;
     gap: 5px;
+}
+
+.container > .section.closed > .header > .toggle {
+    -webkit-transform: scaleY(-1);
+    transform: scaleY(-1);
 }
 
 .display-none {

--- a/style/themes/bchydro.css
+++ b/style/themes/bchydro.css
@@ -345,6 +345,10 @@ table tr:nth-child(2n-1) {
     border-color: #666666;
 }
 
+.container > .section > .header > .toggle {
+    --image-color: #61C315;
+}
+
 .events .date {
     border-right-color: #CBCBCB;
 }

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -341,6 +341,10 @@ table tr:nth-child(2n-1) {
     border-color: #000000;
 }
 
+.container > .section > .header > .toggle {
+    --image-color: #165ABE;
+}
+
 .events .date {
     border-right-color: #CBCBCB;
 }

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -345,6 +345,10 @@ table tr:nth-child(2n-1) {
     border-color: #69BB65;
 }
 
+.container > .section > .header > .toggle {
+    --image-color: #AB0000;
+}
+
 .events .date {
     border-right-color: #C3E9C1;
 }

--- a/style/themes/classic.css
+++ b/style/themes/classic.css
@@ -345,6 +345,10 @@ table tr:nth-child(2n-1) {
     border-color: #666666;
 }
 
+.container > .section > .header > .toggle {
+    --image-color: #E20000;
+}
+
 .events .date {
     border-right-color: #CBCBCB;
 }

--- a/style/themes/contrast.css
+++ b/style/themes/contrast.css
@@ -345,6 +345,10 @@ table tr:nth-child(2n-1) {
     border-color: #666666;
 }
 
+.container > .section > .header > .toggle {
+    --image-color: #365CCB;
+}
+
 .events .date {
     border-right-color: #CBCBCB;
 }

--- a/style/themes/dark.css
+++ b/style/themes/dark.css
@@ -353,12 +353,16 @@ table tr:nth-child(2n-1) {
     border-color: #565656;
 }
 
+.container > .section > .header > .toggle {
+    --image-color: #5CC3FF;
+}
+
 .events .date {
     border-right-color: #565656;
 }
 
 .favourite {
-    --image-color: #2247B7;
+    --image-color: #5CC3FF;
 }
 
 .favourite:hover {

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -336,6 +336,10 @@ table tr {
     border-color: #DDDDDD;
 }
 
+.container > .section > .header > .toggle {
+    --image-color: #AAAAAA;
+}
+
 .events .date {
     border-right-color: #DDDDDD;
 }

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -353,6 +353,10 @@ table tr:nth-child(2n-1) {
     border-color: #565656;
 }
 
+.container > .section > .header > .toggle {
+    --image-color: #E56100;
+}
+
 .events .date {
     border-right-color: #565656;
 }

--- a/style/themes/light.css
+++ b/style/themes/light.css
@@ -307,7 +307,7 @@ table tr:nth-child(2n-1) {
 }
 
 .button {
-    background-color: #365ccb;
+    background-color: #365CCB;
     color: #FFFFFF;
     --image-color: #FFFFFF;
 }
@@ -343,6 +343,10 @@ table tr:nth-child(2n-1) {
 .code-block {
     background-color: #E6E6E6;
     border-color: #666666;
+}
+
+.container > .section > .header > .toggle {
+    --image-color: #365CCB;
 }
 
 .events .date {

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -427,6 +427,10 @@ table tr {
     box-shadow: 0 1px 4px rgb(0 0 0 / 30%);
 }
 
+.container > .section > .header > .toggle {
+    --image-color: #000000;
+}
+
 .events .date {
     border-right-color: #CBCBCB;
 }

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -345,6 +345,10 @@ table tr:nth-child(2n-1) {
     border-color: #666666;
 }
 
+.container > .section > .header > .toggle {
+    --image-color: #C7743B;
+}
+
 .events .date {
     border-right-color: #CBCBCB;
 }

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -147,6 +147,11 @@
                 
                 document.cookie = "survey_banner=hide;expires=" + now.toUTCString() + ";domain={{ '' if config.cookie_domain is None else config.cookie_domain }};path=/";
             }
+            
+            function toggleSection(header) {
+                const section = header.parentElement;
+                section.classList.toggle("closed");
+            }
         </script>
     </head>
     

--- a/views/components/toggle.tpl
+++ b/views/components/toggle.tpl
@@ -1,0 +1,3 @@
+<div class="toggle">
+    % include('components/svg', name='dropdown')
+</div>

--- a/views/frames/nearby.tpl
+++ b/views/frames/nearby.tpl
@@ -30,9 +30,12 @@
         % assignments = helpers.assignment.find_all(stop.system, stop=stop)
         % positions = {p.trip.id: p for p in helpers.position.find_all(stop.system, trip=trips)}
         <div class="section">
-            <div class="header">
-                <h3>Stop {{ stop.number }} - {{ stop }}</h3>
-                <a href="{{ get_url(stop.system, f'stops/{stop.number}') }}">View stop schedule and details</a>
+            <div class="header" onclick="toggleSection(this)">
+                <div class="column">
+                    <h3>Stop {{ stop.number }} - {{ stop }}</h3>
+                    <a href="{{ get_url(stop.system, f'stops/{stop.number}') }}">View stop schedule and details</a>
+                </div>
+                % include('components/toggle')
             </div>
             <div class="content">
                 % if len(upcoming_departures) == 0:

--- a/views/pages/about.tpl
+++ b/views/pages/about.tpl
@@ -16,14 +16,16 @@
             </div>
         </div>
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Frequently Asked Questions</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <div class="container">
                     <div class="section">
-                        <div class="header">
+                        <div class="header" onclick="toggleSection(this)">
                             <h3>Why is there no transit information for Vancouver?</h3>
+                            % include('components/toggle')
                         </div>
                         <div class="content">
                             <p>
@@ -34,8 +36,9 @@
                         </div>
                     </div>
                     <div class="section">
-                        <div class="header">
+                        <div class="header" onclick="toggleSection(this)">
                             <h3>Why are some transit systems not showing in realtime?</h3>
+                            % include('components/toggle')
                         </div>
                         <div class="content">
                             <p>
@@ -46,8 +49,9 @@
                         </div>
                     </div>
                     <div class="section">
-                        <div class="header">
+                        <div class="header" onclick="toggleSection(this)">
                             <h3>How long has BCTracker been recording bus history?</h3>
+                            % include('components/toggle')
                         </div>
                         <div class="content">
                             <p>
@@ -59,8 +63,9 @@
                         </div>
                     </div>
                     <div class="section">
-                        <div class="header">
+                        <div class="header" onclick="toggleSection(this)">
                             <h3>How is BCTracker made?</h3>
+                            % include('components/toggle')
                         </div>
                         <div class="content">
                             <p>
@@ -70,8 +75,9 @@
                         </div>
                     </div>
                     <div class="section">
-                        <div class="header">
+                        <div class="header" onclick="toggleSection(this)">
                             <h3>Will there ever be a BCTracker phone app?</h3>
+                            % include('components/toggle')
                         </div>
                         <div class="content">
                             <p>
@@ -86,8 +92,9 @@
             </div>
         </div>
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>About the Developers</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <p>
@@ -110,8 +117,9 @@
     </div>
     <div class="sidebar container flex-1">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Contact</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <p>

--- a/views/pages/admin.tpl
+++ b/views/pages/admin.tpl
@@ -9,8 +9,9 @@
 <div class="page-container">
     <div class="sidebar container flex-1">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Server Management</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <div class="button-container">
@@ -26,8 +27,9 @@
     </div>
     <div class="container flex-3">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>System Management</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <div class="container">
@@ -35,15 +37,17 @@
                         % for region in regions:
                             % region_systems = [s for s in systems if s.region == region]
                             <div class="section">
-                                <div class="header">
+                                <div class="header" onclick="toggleSection(this)">
                                     <h3>{{ region }}</h3>
+                                    % include('components/toggle')
                                 </div>
                                 <div class="content">
                                     <div class="container inline">
                                         % for region_system in sorted(region_systems):
                                             <div class="section">
-                                                <div class="header">
+                                                <div class="header" onclick="toggleSection(this)">
                                                     <h4>{{ region_system }}</h4>
+                                                    % include('components/toggle')
                                                 </div>
                                                 <div class="content">
                                                     <div class="button-container">
@@ -63,8 +67,9 @@
                         % end
                     % else:
                         <div class="section">
-                            <div class="header">
+                            <div class="header" onclick="toggleSection(this)">
                                 <h3>{{ system }}</h3>
+                                % include('components/toggle')
                             </div>
                             <div class="content">
                                 <div class="button-container">

--- a/views/pages/block/history.tpl
+++ b/views/pages/block/history.tpl
@@ -15,8 +15,9 @@
         % if len(records) > 0:
             <div class="sidebar container flex-1">
                 <div class="section">
-                    <div class="header">
+                    <div class="header" onclick="toggleSection(this)">
                         <h2>Overview</h2>
+                        % include('components/toggle')
                     </div>
                     <div class="content">
                         <div class="info-box">
@@ -41,8 +42,9 @@
         
         <div class="container flex-3">
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>History</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     % if len(records) == 0:

--- a/views/pages/block/overview.tpl
+++ b/views/pages/block/overview.tpl
@@ -24,8 +24,9 @@
 <div class="page-container">
     <div class="sidebar container flex-1">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Overview</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 % include('components/map', map_trips=trips, map_positions=positions)

--- a/views/pages/blocks/date.tpl
+++ b/views/pages/blocks/date.tpl
@@ -19,8 +19,9 @@
     <div class="page-container">
         <div class="sidebar container flex-1">
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>Overview</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     <div class="info-box">
@@ -43,9 +44,12 @@
         </div>
         <div class="container flex-3">
             <div class="section">
-                <div class="header">
-                    <h2>{{ date.format_long() }}</h2>
-                    <h3>{{ date.weekday }}</h3>
+                <div class="header" onclick="toggleSection(this)">
+                    <div class="column">
+                        <h2>{{ date.format_long() }}</h2>
+                        <p>{{ date.weekday }}</p>
+                    </div>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     % blocks = sorted([b for b in system.get_blocks() if date in b.schedule], key=lambda b: (b.get_start_time(date=date), b.get_end_time(date=date)))

--- a/views/pages/blocks/list.tpl
+++ b/views/pages/blocks/list.tpl
@@ -72,8 +72,9 @@
         <div class="page-container">
             <div class="sidebar container flex-1">
                 <div class="section">
-                    <div class="header">
+                    <div class="header" onclick="toggleSection(this)">
                         <h2>Overview</h2>
+                        % include('components/toggle')
                     </div>
                     <div class="content">
                         <div class="info-box">
@@ -88,18 +89,22 @@
                 % for (i, sheet) in enumerate(sheets):
                     % path_suffix = '' if i == 0 else str(i + 1)
                     <div class="section">
-                        <div class="header">
+                        <div class="header" onclick="toggleSection(this)">
                             <h2>{{ sheet }}</h2>
+                            % include('components/toggle')
                         </div>
                         <div class="content">
                             <div class="container inline">
                                 % for service_group in sheet.normal_service_groups:
                                     <div class="section">
-                                        <div class="header">
-                                            % for weekday in service_group.schedule.weekdays:
-                                                <div id="{{ weekday.short_name }}{{path_suffix}}"></div>
-                                            % end
-                                            <h3>{{ service_group }}</h3>
+                                        <div class="header" onclick="toggleSection(this)">
+                                            <div>
+                                                % for weekday in service_group.schedule.weekdays:
+                                                    <div id="{{ weekday.short_name }}{{path_suffix}}"></div>
+                                                % end
+                                                <h3>{{ service_group }}</h3>
+                                            </div>
+                                            % include('components/toggle')
                                         </div>
                                         <div class="content">
                                             <table>

--- a/views/pages/bus/history.tpl
+++ b/views/pages/bus/history.tpl
@@ -25,8 +25,9 @@
     % if overview is not None:
         <div class="sidebar container flex-1">
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>Overview</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     <div class="info-box">
@@ -54,8 +55,9 @@
     
     <div class="container flex-3">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>History</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 % if len(records) == 0:

--- a/views/pages/bus/overview.tpl
+++ b/views/pages/bus/overview.tpl
@@ -29,8 +29,9 @@
 <div class="page-container">
     <div class="sidebar container flex-1">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Realtime Information</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 % if position is None:
@@ -171,10 +172,11 @@
         
         % if bus.order is not None:
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>Details</h2>
+                    % include('components/toggle')
                 </div>
-                <div class="section">
+                <div class="content">
                     <div class="info-box">
                         % if bus.order.size > 1:
                             <div class="section">
@@ -208,8 +210,9 @@
             % upcoming_departures = position.find_upcoming_departures()
             % if len(upcoming_departures) > 0:
                 <div class="section">
-                    <div class="header">
+                    <div class="header" onclick="toggleSection(this)">
                         <h2>Upcoming Stops</h2>
+                        % include('components/toggle')
                     </div>
                     <div class="content">
                         % if len([d for d in upcoming_departures if d.timepoint]) > 0:
@@ -279,8 +282,9 @@
             % end
         % end
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Recent History</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 % if len(records) == 0:

--- a/views/pages/fleet.tpl
+++ b/views/pages/fleet.tpl
@@ -39,9 +39,10 @@
         <div class="content">
             <div class="page-container">
                 <div class="sidebar container flex-1">
-                    <div class="section">
-                        <div class="header">
+                    <div class="section closed">
+                        <div class="header" onclick="toggleSection(this)">
                             <h2>Statistics</h2>
+                            % include('components/toggle')
                         </div>
                         <div class="content">
                             <table>
@@ -82,8 +83,9 @@
                 <div class="container flex-3">
                     % for type in model_types:
                         <div class="section">
-                            <div class="header">
+                            <div class="header" onclick="toggleSection(this)">
                                 <h2>{{ type }}</h2>
+                                % include('components/toggle')
                             </div>
                             <div class="content">
                                 <div class="container">
@@ -91,8 +93,9 @@
                                     % for model in type_models:
                                         % model_orders = [o for o in orders if o.model == model]
                                         <div id="{{ model.id }}" class="section">
-                                            <div class="header">
+                                            <div class="header" onclick="toggleSection(this)">
                                                 <h3>{{! model }}</h3>
+                                                % include('components/toggle')
                                             </div>
                                             <div class="content">
                                                 <table>

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -12,9 +12,10 @@
 
 <div class="page-container">
     <div class="sidebar container flex-1">
-        <div class="section">
-            <div class="header">
+        <div class="section closed">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Filter by Date</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <div class="info-box">
@@ -60,9 +61,10 @@
         </div>
         
         % if overviews:
-            <div class="section">
-                <div class="header">
+            <div class="section closed">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>Statistics</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     % models = sorted({o.bus.model for o in overviews if o.bus.model is not None})
@@ -104,8 +106,9 @@
     
     <div class="container flex-3">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Vehicles</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 % if len(overviews) == 0:

--- a/views/pages/home.tpl
+++ b/views/pages/home.tpl
@@ -15,8 +15,9 @@
 <div class="page-container">
     <div class="sidebar container flex-1">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Quick Search</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <script type="text/javascript">
@@ -104,8 +105,9 @@
             </div>
         </div>
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Favourites</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <p>
@@ -238,8 +240,9 @@
     
     <div class="container flex-2">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Quick Navigation</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <div id="quick-navigation">
@@ -271,8 +274,9 @@
             </div>
         </div>
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Latest News</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <div class="container">
@@ -336,8 +340,9 @@
     
     <div class="container flex-1">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Community</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <p>Join the BCTracker Discord server - a home for transit riders and enthusiasts from around British Columbia!</p>

--- a/views/pages/nearby.tpl
+++ b/views/pages/nearby.tpl
@@ -10,8 +10,9 @@
 <div class="page-container">
     <div id="current-location" class="sidebar container flex-1 display-none">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Current Location</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <div id="map" class="preview"></div>
@@ -21,8 +22,9 @@
     
     <div class="container flex-3">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Upcoming Departures</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 % if system is None:

--- a/views/pages/personalize.tpl
+++ b/views/pages/personalize.tpl
@@ -8,8 +8,9 @@
 <div class="page-container">
     <div class="container flex-1">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Theme</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <p>
@@ -60,8 +61,9 @@
     </div>
     <div class="container flex-1">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Time Format</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <p>You can choose whether times are displayed as 12hr or 30hr.</p>
@@ -87,8 +89,9 @@
     </div>
     <div class="container flex-1">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Map Bus Icon Style</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <p>Choose a style for bus icons shown on the map screen.</p>

--- a/views/pages/realtime/models.tpl
+++ b/views/pages/realtime/models.tpl
@@ -63,9 +63,10 @@
     % model_types = sorted({m.type for m in models})
     <div class="page-container">
         <div class="sidebar container flex-1">
-            <div class="section">
-                <div class="header">
+            <div class="section closed">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>Statistics</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     <table>
@@ -117,8 +118,9 @@
             % for type in model_types:
                 % type_models = [m for m in models if m.type == type]
                 <div class="section">
-                    <div class="header">
+                    <div class="header" onclick="toggleSection(this)">
                         <h2>{{ type }}</h2>
+                        % include('components/toggle')
                     </div>
                     <div class="content">
                         <div class="container">
@@ -126,8 +128,9 @@
                                 % model_positions = sorted([p for p in positions if p.bus.model is not None and p.bus.model == model])
                                 % model_years = sorted({p.bus.order.year for p in model_positions})
                                 <div id="{{ model.id }}" class="section">
-                                    <div class="header">
+                                    <div class="header" onclick="toggleSection(this)">
                                         <h3>{{! model }}</h3>
+                                        % include('components/toggle')
                                     </div>
                                     <div class="content">
                                         <table>
@@ -172,8 +175,9 @@
             % unknown_positions = sorted([p for p in positions if p.bus.order is None])
             % if len(unknown_positions) > 0:
                 <div class="section">
-                    <div class="header">
+                    <div class="header" onclick="toggleSection(this)">
                         <h2>Unknown Year/Model</h2>
+                        % include('components/toggle')
                     </div>
                     <div class="content">
                         <table>

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -71,16 +71,17 @@
                 % continue
             % end
             <div class="section">
-                <div class="header">
-                    <h2 class="row">
-                        % include('components/route')
-                        <div>{{! route.display_name }}</div>
-                    </h2>
+                <div class="header" onclick="toggleSection(this)">
+                    <div class="column">
+                        <h2 class="row">
+                            % include('components/route')
+                            <div>{{! route.display_name }}</div>
+                        </h2>
+                        <a href="{{ get_url(route.system, f'routes/{route.number}') }}">View schedule and details</a>
+                    </div>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
-                    <p>
-                        <a href="{{ get_url(route.system, f'routes/{route.number}') }}">View schedule and details</a>
-                    </p>
                     <table>
                         <thead>
                             <tr>
@@ -169,8 +170,9 @@
         % no_route_positions = sorted([p for p in positions if p.trip is None])
         % if len(no_route_positions) > 0:
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>Not In Service</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     <table class="striped">

--- a/views/pages/route/date.tpl
+++ b/views/pages/route/date.tpl
@@ -17,8 +17,9 @@
 <div class="page-container">
     <div class="sidebar container flex-1">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Overview</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <div class="info-box">
@@ -41,9 +42,12 @@
     </div>
     <div class="container flex-3">
         <div class="section">
-            <div class="header">
-                <h2>{{ date.format_long() }}</h2>
-                <h3>{{ date.weekday }}</h3>
+            <div class="header" onclick="toggleSection(this)">
+                <div class="column">
+                    <h2>{{ date.format_long() }}</h2>
+                    <p>{{ date.weekday }}</p>
+                </div>
+                % include('components/toggle')
             </div>
             <div class="content">
                 % trips = route.get_trips(date=date)
@@ -68,8 +72,9 @@
                         % for direction in sorted({t.direction for t in trips}):
                             % direction_trips = [t for t in trips if t.direction == direction]
                             <div class="section">
-                                <div class="header">
-                                    <h4>{{ direction }}</h4>
+                                <div class="header" onclick="toggleSection(this)">
+                                    <h3>{{ direction }}</h3>
+                                    % include('components/toggle')
                                 </div>
                                 <div class="content">
                                     <table>

--- a/views/pages/route/overview.tpl
+++ b/views/pages/route/overview.tpl
@@ -18,8 +18,9 @@
     % if len(route.trips) > 0:
         <div class="sidebar container flex-1">
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>Overview</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     % include('components/map', map_trips=route.trips, map_positions=positions)
@@ -43,8 +44,9 @@
     <div class="container flex-3">
         % if len(positions) > 0:
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>Active Buses</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     <table>
@@ -115,8 +117,9 @@
         % end
         
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Today's Schedule</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 % if len(trips) == 0:
@@ -137,8 +140,9 @@
                             % direction_trips = [t for t in trips if t.direction == direction]
                             % if len(direction_trips) > 0:
                                 <div class="section">
-                                    <div class="header">
+                                    <div class="header" onclick="toggleSection(this)">
                                         <h3>{{ direction }}</h3>
+                                        % include('components/toggle')
                                     </div>
                                     <div class="content">
                                         % if system is None or system.realtime_enabled:

--- a/views/pages/route/schedule.tpl
+++ b/views/pages/route/schedule.tpl
@@ -35,8 +35,9 @@
     <div class="page-container">
         <div class="sidebar container flex-1">
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>Overview</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     <div class="info-box">
@@ -51,27 +52,32 @@
             % for (i, sheet) in enumerate(sheets):
                 % path_suffix = '' if i == 0 else str(i + 1)
                 <div class="section">
-                    <div class="header">
+                    <div class="header" onclick="toggleSection(this)">
                         <h2>{{ sheet }}</h2>
+                        % include('components/toggle')
                     </div>
                     <div class="content">
                         <div class="container inline">
                             % for service_group in sheet.normal_service_groups:
                                 % service_group_trips = route.get_trips(service_group=service_group)
                                 <div class="section">
-                                    <div class="header">
-                                        % for weekday in service_group.schedule.weekdays:
-                                            <div id="{{ weekday.short_name }}{{path_suffix}}"></div>
-                                        % end
-                                        <h3>{{ service_group }}</h3>
+                                    <div class="header" onclick="toggleSection(this)">
+                                        <div>
+                                            % for weekday in service_group.schedule.weekdays:
+                                                <div id="{{ weekday.short_name }}{{path_suffix}}"></div>
+                                            % end
+                                            <h3>{{ service_group }}</h3>
+                                        </div>
+                                        % include('components/toggle')
                                     </div>
                                     <div class="content">
                                         <div class="container inline">
                                             % for direction in sorted({t.direction for t in service_group_trips}):
                                                 % direction_trips = [t for t in service_group_trips if t.direction == direction]
                                                 <div class="section">
-                                                    <div class="header">
+                                                    <div class="header" onclick="toggleSection(this)">
                                                         <h4>{{ direction }}</h4>
+                                                        % include('components/toggle')
                                                     </div>
                                                     <div class="content">
                                                         <table>

--- a/views/pages/stop/date.tpl
+++ b/views/pages/stop/date.tpl
@@ -17,8 +17,9 @@
 <div class="page-container">
     <div class="sidebar container flex-1">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Overview</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 <div class="info-box">
@@ -41,9 +42,12 @@
     </div>
     <div class="container flex-3">
         <div class="section">
-            <div class="header">
-                <h2>{{ date.format_long() }}</h2>
-                <h3>{{ date.weekday }}</h3>
+            <div class="header" onclick="toggleSection(this)">
+                <div class="column">
+                    <h2>{{ date.format_long() }}</h2>
+                    <p>{{ date.weekday }}</p>
+                </div>
+                % include('components/toggle')
             </div>
             <div class="content">
                 % departures = stop.find_departures(date=date)

--- a/views/pages/stop/overview.tpl
+++ b/views/pages/stop/overview.tpl
@@ -21,8 +21,9 @@
 <div class="page-container">
     <div class="sidebar container flex-1">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Overview</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 % stop_departures = stop.find_departures()
@@ -50,8 +51,9 @@
         % nearby_stops = sorted(stop.nearby_stops)
         % if len(nearby_stops) > 0:
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>Nearby Stops</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     <table>
@@ -82,8 +84,9 @@
         % alt_systems = [s for s in systems if s.get_stop(number=stop.number) is not None and s != system]
         % if len(alt_systems) > 0:
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>Other Systems At This Stop</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     <table>
@@ -113,8 +116,9 @@
     <div class="container flex-3">
         % if len(departures) > 0:
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>Upcoming Departures</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     % upcoming_count = 3 + floor(len(routes) / 3)
@@ -166,8 +170,9 @@
         % end
         
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Today's Schedule</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 % if len(departures) == 0:

--- a/views/pages/stop/schedule.tpl
+++ b/views/pages/stop/schedule.tpl
@@ -35,8 +35,9 @@
     <div class="page-container">
         <div class="sidebar container flex-1">
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>Overview</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     <div class="info-box">
@@ -51,19 +52,23 @@
             % for (i, sheet) in enumerate(sheets):
                 % path_suffix = '' if i == 0 else str(i + 1)
                 <div class="section">
-                    <div class="header">
+                    <div class="header" onclick="toggleSection(this)">
                         <h2>{{ sheet }}</h2>
+                        % include('components/toggle')
                     </div>
                     <div class="content">
                         <div class="container inline">
                             % for service_group in sheet.normal_service_groups:
                                 % departures = stop.find_departures(service_group)
                                 <div class="section">
-                                    <div class="header">
-                                        % for weekday in service_group.schedule.weekdays:
-                                            <div id="{{ weekday.short_name }}{{path_suffix}}"></div>
-                                        % end
-                                        <h3>{{ service_group }}</h3>
+                                    <div class="header" onclick="toggleSection(this)">
+                                        <div>
+                                            % for weekday in service_group.schedule.weekdays:
+                                                <div id="{{ weekday.short_name }}{{path_suffix}}"></div>
+                                            % end
+                                            <h3>{{ service_group }}</h3>
+                                        </div>
+                                        % include('components/toggle')
                                     </div>
                                     <div class="content">
                                         <table>

--- a/views/pages/trip/history.tpl
+++ b/views/pages/trip/history.tpl
@@ -16,8 +16,9 @@
         % if len(records) > 0:
             <div class="sidebar container flex-1">
                 <div class="section">
-                    <div class="header">
+                    <div class="header" onclick="toggleSection(this)">
                         <h2>Overview</h2>
+                        % include('components/toggle')
                     </div>
                     <div class="content">
                         <div class="info-box">
@@ -42,8 +43,9 @@
         
         <div class="container flex-3">
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>History</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     % if len(records) == 0:

--- a/views/pages/trip/overview.tpl
+++ b/views/pages/trip/overview.tpl
@@ -20,8 +20,9 @@
 <div class="page-container">
     <div class="sidebar container flex-1">
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Overview</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 % include('components/map', map_trip=trip, map_positions=positions)
@@ -92,8 +93,9 @@
         % related_trips = trip.related_trips
         % if len(related_trips) > 0:
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>Related Trips</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     <table>
@@ -138,12 +140,13 @@
     <div class="container flex-3">
         % if len(positions) > 0:
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     % if len(positions) == 1:
                         <h2>Active Bus</h2>
                     % else:
                         <h2>Active Buses</h2>
                     % end
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     <table>
@@ -191,8 +194,9 @@
             % bus = assignment.bus
             % position = helpers.position.find(bus)
             <div class="section">
-                <div class="header">
+                <div class="header" onclick="toggleSection(this)">
                     <h2>Scheduled Bus</h2>
+                    % include('components/toggle')
                 </div>
                 <div class="content">
                     <p>This bus is currently assigned to this trip's block but may be swapped off before this trip runs.</p>
@@ -261,8 +265,9 @@
         % end
         
         <div class="section">
-            <div class="header">
+            <div class="header" onclick="toggleSection(this)">
                 <h2>Stop Schedule</h2>
+                % include('components/toggle')
             </div>
             <div class="content">
                 % if len([d for d in departures if d.timepoint]) > 0:


### PR DESCRIPTION
Allows users to open and close sections on mobile/tablet, making it easier to get to lower parts of the page without having to scroll as much.

Most sections are open by default. However a few currently start closed:
- History -> Filter By Date
- History -> Statistics
- Realtime -> Models -> Statistics
- Fleet -> Statistics

Down the road we can get user feedback if other sections should start closed, or if any of these should start open instead.

On desktop, the toggle icon is hidden and clicking the section header has no visible effect (it does still add/remove the `closed` class but this doesn't change the appearance of the section)

Overview of changes:
- Added `toggleSection` JavaScript function
- Added `onclick` to section headers calling the above function
- Added `toggle` component
  - No actual functionality, just an easier way to reference the dropdown icon with the `toggle` class wrapper
- Updated section header layouts
  - Added toggle icons using above component
  - Now has horizontal layout instead of vertical to ensure the icon is next to the section title
  - In some cases where headers have multiple lines of text, an explicit column layout div is added
- Added theme colours for toggle icons
  - Generally matches button/link/checkbox/radio button/favourite colours for each theme
- Other minor tweaks and improvements