### PR TITLE
Update models

### DIFF
--- a/static/models.json
+++ b/static/models.json
@@ -80,13 +80,13 @@
             "length": 40,
             "fuel": "Hybrid"
         },
-        "dennis-trident": {
+        "dennis-trident-iii": {
             "manufacturer": "Dennis",
             "name": "Trident III",
             "length": 40,
             "fuel": "Diesel"
         },
-        "transbus-trident": {
+        "transbus-trident-iii": {
             "manufacturer": "TransBus",
             "name": "Trident III",
             "length": 40,

--- a/static/models.json
+++ b/static/models.json
@@ -30,15 +30,27 @@
             "length": 40,
             "fuel": "CNG"
         },
-        "nova-bus-lfs": {
+        "nova-bus-lfs-2": {
             "manufacturer": "Nova Bus",
-            "name": "LFS",
+            "name": "LFS (2nd Gen)",
             "length": 40,
             "fuel": "Diesel"
         },
-        "nova-bus-lfs-suburban": {
+        "nova-bus-lfs-3": {
             "manufacturer": "Nova Bus",
-            "name": "LFS Suburban",
+            "name": "LFS (3rd Gen)",
+            "length": 40,
+            "fuel": "Diesel"
+        },
+        "nova-bus-lfs-4": {
+            "manufacturer": "Nova Bus",
+            "name": "LFS (4th Gen)",
+            "length": 40,
+            "fuel": "Diesel"
+        },
+        "nova-bus-lfs-suburban-2": {
+            "manufacturer": "Nova Bus",
+            "name": "LFS Suburban (2nd Gen)",
             "length": 40,
             "fuel": "Diesel"
         },
@@ -52,26 +64,32 @@
     "decker": {
         "alexander-dennis-enviro500": {
             "manufacturer": "Alexander Dennis",
-            "name": "Enviro 500",
+            "name": "Enviro500",
+            "length": 40,
+            "fuel": "Diesel"
+        },
+        "alexander-dennis-enviro500-lhd": {
+            "manufacturer": "Alexander Dennis",
+            "name": "Enviro500 LHD",
             "length": 42,
             "fuel": "Diesel"
         },
         "alexander-dennis-enviro500h": {
             "manufacturer": "Alexander Dennis",
-            "name": "Enviro 500H",
-            "length": 42,
+            "name": "Enviro500H",
+            "length": 40,
             "fuel": "Hybrid"
         },
         "dennis-trident": {
             "manufacturer": "Dennis",
-            "name": "Trident",
-            "length": 42,
+            "name": "Trident III",
+            "length": 40,
             "fuel": "Diesel"
         },
         "transbus-trident": {
             "manufacturer": "TransBus",
-            "name": "Trident",
-            "length": 42,
+            "name": "Trident III",
+            "length": 40,
             "fuel": "Diesel"
         }
     },

--- a/static/orders.json
+++ b/static/orders.json
@@ -57,7 +57,7 @@
             { "year": 2000, "low": 9051, "high": 9078 },
             { "year": 2001, "low": 9081, "high": 9085 }
         ],
-        "dennis-trident": [
+        "dennis-trident-iii": [
             { "year": 2000, "low": 9001, "high": 9010 }
         ],
         "ford-cbb-e450-polar-v": [
@@ -144,7 +144,7 @@
         "proterra-zx5": [
             { "year": 2022, "number": 9093, "demo": true }
         ],
-        "transbus-trident": [
+        "transbus-trident-iii": [
             { "year": 2002, "low": 9021, "high": 9039 }
         ],
         "unknown": [

--- a/static/orders.json
+++ b/static/orders.json
@@ -132,10 +132,10 @@
         "nova-bus-lfs-3": [
             { "year": 2009, "low": 9319, "high": 9433 },
             { "year": 2012, "number": 9434 },
-            { "year": 2013, "low": 9435, "high": 9446 },
-            { "year": 2015, "low": 9447, "high": 9486 }
+            { "year": 2013, "low": 9435, "high": 9446 }
         ],
         "nova-bus-lfs-4": [
+            { "year": 2015, "low": 9447, "high": 9486 },
             { "year": 2017, "low": 6000, "high": 6029 }
         ],
         "nova-bus-lfs-suburban-2": [

--- a/static/orders.json
+++ b/static/orders.json
@@ -4,7 +4,9 @@
             { "year": 2004, "low": 9041, "high": 9049 },
             { "year": 2008, "low": 9501, "high": 9526 },
             { "year": 2007, "number": 9528 },
-            { "year": 2008, "low": 9529, "high": 9531 },
+            { "year": 2008, "low": 9529, "high": 9531 }
+        ],
+        "alexander-dennis-enviro500-lhd": [
             { "year": 2020, "low": 9532, "high": 9542 },
             { "year": 2022, "low": 9543, "high": 9550 }
         ],
@@ -121,18 +123,22 @@
             { "year": 2021, "low": 1213, "high": 1232 },
             { "year": 2022, "low": 1233, "high": 1253 }
         ],
-        "nova-bus-lfs": [
-            { "year": 2017, "low": 6000, "high": 6029 },
+        "nova-bus-lfs-2": [
             { "year": 2006, "low": 9201, "high": 9231 },
             { "year": 2007, "low": 9232, "high": 9267 },
             { "year": 2008, "low": 9268, "high": 9289 },
-            { "year": 2008, "low": 9301, "high": 9318 },
+            { "year": 2008, "low": 9301, "high": 9318 }
+        ],
+        "nova-bus-lfs-3": [
             { "year": 2009, "low": 9319, "high": 9433 },
             { "year": 2012, "number": 9434 },
             { "year": 2013, "low": 9435, "high": 9446 },
             { "year": 2015, "low": 9447, "high": 9486 }
         ],
-        "nova-bus-lfs-suburban": [
+        "nova-bus-lfs-4": [
+            { "year": 2017, "low": 6000, "high": 6029 }
+        ],
+        "nova-bus-lfs-suburban-2": [
             { "year": 2008, "low": 9290, "high": 9300 }
         ],
         "proterra-zx5": [


### PR DESCRIPTION
- Separated Nova Bus into 2nd, 3rd, and 4th gen models
- Separated Enviro500 LHD into a separate model
- Renamed "Enviro 500" to "Enviro500"
- Renamed "Trident" to "Trident III"
- Fixed lengths for older double deckers
- Updated orders to use new models