### PR TITLE
Fix bus history systems

### DIFF
--- a/server.py
+++ b/server.py
@@ -528,8 +528,11 @@ class Server(Bottle):
         else:
             records = self.record_repository.find_all(bus=bus, limit=items_per_page, page=page)
         transfers = self.transfer_repository.find_all(bus=bus)
+        tracked_systems = set()
         events = []
         if overview:
+            tracked_systems.add(overview.first_seen_system)
+            tracked_systems.add(overview.last_seen_system)
             events.append(Event(overview.first_seen_date, 'First Seen'))
             if overview.first_record:
                 events.append(Event(overview.first_record.date, 'First Tracked'))
@@ -537,6 +540,8 @@ class Server(Bottle):
             if overview.last_record:
                 events.append(Event(overview.last_record.date, 'Last Tracked'))
             for transfer in transfers:
+                tracked_systems.add(transfer.old_system)
+                tracked_systems.add(transfer.new_system)
                 events.append(Event(transfer.date, 'Transferred',  f'{transfer.old_system} to {transfer.new_system}'))
         return self.page(
             name='bus/history',
@@ -546,6 +551,7 @@ class Server(Bottle):
             bus=bus,
             records=records,
             overview=overview,
+            tracked_systems=tracked_systems,
             events=events,
             favourite=Favourite('vehicle', bus),
             favourites=self.get_favourites(),

--- a/views/pages/bus/history.tpl
+++ b/views/pages/bus/history.tpl
@@ -38,16 +38,11 @@
                             <div class="name">Total Records</div>
                             <div class="value">{{ total_items }}</div>
                         </div>
-                        % record_systems = {r.system for r in records}
-                        % if overview:
-                            % record_systems.add(overview.first_seen_system)
-                            % record_systems.add(overview.last_seen_system)
-                        % end
                         <div class="row section align-start">
-                            <div class="name">{{ 'System' if len(record_systems) == 1 else 'Systems' }}</div>
+                            <div class="name">{{ 'System' if len(tracked_systems) == 1 else 'Systems' }}</div>
                             <div class="value">
-                                % for record_system in sorted(record_systems):
-                                    <a href="{{ get_url(record_system) }}">{{ record_system }}</a>
+                                % for tracked_system in sorted(tracked_systems):
+                                    <a href="{{ get_url(tracked_system) }}">{{ tracked_system }}</a>
                                 % end
                             </div>
                         </div>


### PR DESCRIPTION
When we added paging to bus history, it inadvertently broke the list of systems that a bus has been assigned to, showing just the first and last systems, and any other systems found on the first page of history. Eg 9309 currently only shows Comox and South Okanagan, despite having also operated in Victoria and Whistler.

Fixed by including all old and new systems from the bus' transfers, meaning we no longer need to rely on all records to get the systems list.