### PR TITLE
Add route variants to overview page

### DIFF
--- a/models/route.py
+++ b/models/route.py
@@ -152,6 +152,14 @@ class Route:
     def find_departures(self):
         '''Returns all departures for this route'''
         return self.departure_repository.find_all(self.system, route=self)
+    
+    def is_variant(self, route):
+        '''Checks if this route is a variant of another route'''
+        if self == route:
+            return False # Self is not a variant
+        self_key = tuple([k for k in self.key if type(k) == int])
+        route_key = tuple([k for k in route.key if type(k) == int])
+        return self_key and route_key and self_key == route_key
 
 def generate_colour(system, number):
     '''Generate a random colour based on system ID and route number'''

--- a/views/pages/route/overview.tpl
+++ b/views/pages/route/overview.tpl
@@ -35,6 +35,20 @@
                                 <div>{{ headsign }}</div>
                             % end
                         </div>
+                        % variants = [r for r in route.system.get_routes() if route.is_variant(r)]
+                        % if variants:
+                            <div class="column gap-5 section">
+                                <div class="lighter-text">Route {{ 'Variant' if len(variants) == 1 else 'Variants' }}</div>
+                                <div class="column">
+                                    % for variant in variants:
+                                        <div class="row">
+                                            % include('components/route', route=variant)
+                                            <a href="{{ get_url(variant.system, f'routes/{variant.number}') }}">{{! variant.display_name }}</a>
+                                        </div>
+                                    % end
+                                </div>
+                            </div>
+                        % end
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
With the introduction of route "variants" in a few systems, it makes sense to have links between the different variants to make it easier to navigate between them.

<img width="381" alt="Screenshot 2024-07-07 at 22 06 46" src="https://github.com/bumblesquashs/bctracker/assets/7077422/7d8c23e4-d6df-4e9b-84dc-1a6922b0f00b">

The variants section is only shown if there are variants available.