### PR TITLE
Add block timelines on trips

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -1271,6 +1271,14 @@ table tr.header td {
     z-index: 20;
 }
 
+.timeline .section.non-current {
+    opacity: 0.2;
+}
+
+.timeline .section.non-current:hover {
+    opacity: 1;
+}
+
 .timing-point {
     font-weight: bold;
 }

--- a/views/components/block_timeline.tpl
+++ b/views/components/block_timeline.tpl
@@ -5,6 +5,8 @@
 % service_group = get('service_group')
 % date = get('date')
 
+% current_trip = get('trip')
+
 % start_time = block.get_start_time(service_group=service_group, date=date)
 % end_time = block.get_end_time(service_group=service_group, date=date)
 % total_minutes = end_time.get_minutes() - start_time.get_minutes()
@@ -20,7 +22,7 @@
             % percentage = (trip_minutes / total_minutes) * 100
             % offset_minutes = trip.start_time.get_minutes() - start_time.get_minutes()
             % offset_percentage = (offset_minutes / total_minutes) * 100
-            <a href="{{ get_url(trip.system, f'trips/{trip.id}') }}" class="section tooltip-anchor" style="background-color: #{{ trip.route.colour }}; width: {{ percentage }}%; left: {{ offset_percentage }}%;">
+            <a href="{{ get_url(trip.system, f'trips/{trip.id}') }}" class="section tooltip-anchor {{ 'non-current' if current_trip and trip != current_trip else '' }}" style="background-color: #{{ trip.route.colour }}; width: {{ percentage }}%; left: {{ offset_percentage }}%;">
                 <div class="tooltip right">
                     <div class="title">{{ trip }}</div>
                     {{ trip.start_time.format_web(time_format) }} - {{ trip.end_time.format_web(time_format) }}

--- a/views/pages/trip/overview.tpl
+++ b/views/pages/trip/overview.tpl
@@ -42,6 +42,9 @@
                             <div class="lighter-text">Unknown Route</div>
                         % end
                     </div>
+                    <div class="section">
+                        % include('components/block_timeline', block=trip.block)
+                    </div>
                     <div class="row section">
                         % block = trip.block
                         <div class="name">Block</div>


### PR DESCRIPTION
Adds the block timeline on trip overview pages. The current trip is shown at 100% opacity; other trips are shown at 20% unless hovered over.

<img width="368" alt="Screenshot 2024-07-07 at 22 41 21" src="https://github.com/bumblesquashs/bctracker/assets/7077422/2d94c135-83b2-43ca-978d-6692d2e5ae55">
