### PR TITLE
Add estimates for stop upcoming departures

### DIFF
--- a/views/pages/stop/overview.tpl
+++ b/views/pages/stop/overview.tpl
@@ -132,6 +132,7 @@
                                 </span>
                                 <span>are scheduled but may be swapped off.</span>
                             </p>
+                            <p>Times in brackets are estimates based on current vehicle location.</p>
                         % end
                         <table>
                             <thead>
@@ -153,7 +154,7 @@
                                     % if last_hour == -1:
                                         % last_hour = this_hour
                                     % end
-                                    % include('rows/departure', show_divider=this_hour > last_hour)
+                                    % include('rows/departure', show_divider=this_hour > last_hour, show_time_estimate=True)
                                     % last_hour = this_hour
                                 % end
                             </tbody>

--- a/views/rows/departure.tpl
+++ b/views/rows/departure.tpl
@@ -1,11 +1,38 @@
 
+% from datetime import timedelta
+
 % trip = departure.trip
 % block = trip.block
 
 % show_divider = get('show_divider', False)
+% show_time_estimate = get('show_time_estimate', False)
 
 <tr class="{{'divider' if show_divider else ''}}">
-    <td>{{ departure.time.format_web(time_format) }}</td>
+    <td>
+        % if show_time_estimate:
+            % expected_time = None
+            % if trip.id in positions:
+                % position = positions[trip.id]
+                % if position.adherence and position.adherence.value != 0:
+                    % expected_time = departure.time - timedelta(minutes=position.adherence.value)
+                % end
+            % end
+            % if expected_time:
+                <div class="row non-mobile">
+                    {{ departure.time.format_web(time_format) }}
+                    <div class="lighter-text">({{ expected_time.format_web(time_format) }})</div>
+                </div>
+                <div class="column mobile-only">
+                    {{ departure.time.format_web(time_format) }}
+                    <div class="lighter-text smaller-font">({{ expected_time.format_web(time_format) }})</div>
+                </div>
+            % else:
+                {{ departure.time.format_web(time_format) }}
+            % end
+        % else:
+            {{ departure.time.format_web(time_format) }}
+        % end
+    </td>
     % if not system or system.realtime_enabled:
         % if trip.id in recorded_today:
             % bus = recorded_today[trip.id]


### PR DESCRIPTION
- Matches design for estimated times on bus overview page, with a few modifications
  - Since some buses may be on time and others may not, the estimate is only shown for some rows, as opposed to on individual buses in which all rows are affected
  - On mobile, the estimated time is shown in a smaller font underneath the scheduled time rather than next to it, as there is an additional column that makes the space tighter
- A couple of limitations:
  - Estimate is currently only shown for buses that are actively logged into the trip; buses on a previous trip don't show an estimate currently
    - Makes this a bit less useful for stops early in the trip unfortunately
    - There should be a way to make this work properly eventually, but that can be taken care of another time
  - The "Times in brackets" text currently appears at all times even if there aren't any estimates available, as we don't currently know ahead of building the table if there will be any shown
    - Again could be made to work properly with some effort but it would likely be pretty complicated

<img width="876" alt="Screenshot 2024-07-08 at 21 48 11" src="https://github.com/bumblesquashs/bctracker/assets/7077422/61031202-3bf5-4a87-84ea-1bf78be34a52">
<img width="399" alt="Screenshot 2024-07-08 at 21 57 40" src="https://github.com/bumblesquashs/bctracker/assets/7077422/979940c6-df51-4a90-9c98-36effbc2fbb0">
