### PR TITLE
Blocks Overview Page

### DIFF
--- a/models/time.py
+++ b/models/time.py
@@ -129,10 +129,10 @@ class Time:
             return False
         return self.second > other.second
     
-    def __lte__(self, other):
+    def __le__(self, other):
         return self < other or self == other
     
-    def __gte__(self, other):
+    def __ge__(self, other):
         return self > other or self == other
     
     def __add__(self, delta):

--- a/repositories/record.py
+++ b/repositories/record.py
@@ -34,6 +34,10 @@ class RecordRepository(ABC):
         raise NotImplementedError()
     
     @abstractmethod
+    def find_recorded_today_by_block(self, system) -> dict[str, Bus]:
+        raise NotImplementedError()
+    
+    @abstractmethod
     def count(self, system, bus, block, trip) -> int:
         raise NotImplementedError()
     

--- a/repositories/sql/record.py
+++ b/repositories/sql/record.py
@@ -132,6 +132,24 @@ class SQLRecordRepository(RecordRepository):
         agency = self.agency_repository.find('bc-transit')
         return {row['trip_id']: Bus.find(agency, row['bus_number']) for row in rows}
     
+    def find_recorded_today_by_block(self, system):
+        '''Returns all bus numbers matching the given system that werer ecorded on the current date'''
+        system_id = getattr(system, 'id', system)
+        date = Date.today(system.timezone)
+        rows = self.database.select('record',
+            columns={
+                'record.block_id': 'block_id',
+                'record.bus_number': 'bus_number'
+            },
+            filters={
+                'record.system_id': system_id,
+                'record.date': date.format_db()
+            },
+            order_by='record.last_seen ASC'
+        )
+        agency = self.agency_repository.find('bc-transit')
+        return {row['block_id']: Bus.find(agency, row['bus_number']) for row in rows}
+    
     def count(self, system=None, bus=None, block=None, trip=None):
         '''Returns the number of records for the given system, bus, block, and trip'''
         system_id = getattr(system, 'id', system)

--- a/server.py
+++ b/server.py
@@ -13,6 +13,7 @@ from models.bus import Bus
 from models.date import Date
 from models.event import Event
 from models.favourite import Favourite, FavouriteSet
+from models.time import Time
 
 from repositories import *
 from services import *
@@ -96,7 +97,8 @@ class Server(Bottle):
         self.add('/routes/<route_number>/map', callback=self.route_map)
         self.add('/routes/<route_number>/schedule', callback=self.route_schedule)
         self.add('/routes/<route_number>/schedule/<date_string:re:\\d{4}-\\d{2}-\\d{2}>', callback=self.route_schedule_date)
-        self.add('/blocks', callback=self.blocks)
+        self.add('/blocks', callback=self.blocks_overview)
+        self.add('/blocks/schedule', callback=self.blocks_schedule)
         self.add('/blocks/schedule/<date_string:re:\\d{4}-\\d{2}-\\d{2}>', callback=self.blocks_schedule_date)
         self.add('/blocks/<block_id>', callback=self.block_overview)
         self.add('/blocks/<block_id>/map', callback=self.block_map)
@@ -223,8 +225,12 @@ class Server(Bottle):
         hide_systems = self.query_cookie('hide_systems') == 'yes'
         if system:
             last_updated = system.get_last_updated(time_format)
+            today = Date.today(system.timezone)
+            now = Time.now(system.timezone, False)
         else:
             last_updated = self.realtime_service.get_last_updated(time_format)
+            today = Date.today()
+            now = Time.now()
         return template(f'pages/{name}',
             di=di,
             settings=self.settings,
@@ -249,6 +255,8 @@ class Server(Bottle):
             bus_marker_style=bus_marker_style,
             hide_systems=hide_systems,
             show_speed=request.get_cookie('speed') == '1994',
+            today=today,
+            now=now,
             **kwargs
         )
     
@@ -772,11 +780,25 @@ class Server(Bottle):
             favourites=self.get_favourites()
         )
     
-    def blocks(self, system, agency):
+    def blocks_overview(self, system, agency):
+        if system and system.realtime_enabled:
+            recorded_buses = self.record_repository.find_recorded_today_by_block(system)
+        else:
+            recorded_buses = {}
         return self.page(
-            name='blocks/list',
+            name='blocks/overview',
             title='Blocks',
             path='blocks',
+            system=system,
+            agency=agency,
+            recorded_buses=recorded_buses
+        )
+    
+    def blocks_schedule(self, system, agency):
+        return self.page(
+            name='blocks/schedule',
+            title='Blocks',
+            path='blocks/schedule',
             system=system,
             agency=agency,
             enable_refresh=False

--- a/server.py
+++ b/server.py
@@ -19,7 +19,7 @@ from repositories import *
 from services import *
 
 # Increase the version to force CSS reload
-VERSION = 41
+VERSION = 42
 
 class Server(Bottle):
     

--- a/style/contrast/dark.css
+++ b/style/contrast/dark.css
@@ -14,6 +14,18 @@
     color: #FFFFFF;
 }
 
+.percentage.low {
+    background-color: #A1004F;
+}
+
+.percentage.mid {
+    background-color: #9B6B00;
+}
+
+.percentage.high {
+    background-color: #1658FC;
+}
+
 .sheet a.modified-service:hover {
     background-color: #785200;
 }

--- a/style/contrast/light.css
+++ b/style/contrast/light.css
@@ -14,6 +14,18 @@
     color: #000000;
 }
 
+.percentage.low {
+    background-color: #DC267F;
+}
+
+.percentage.mid {
+    background-color: #FFB000;
+}
+
+.percentage.high {
+    background-color: #648FFF;
+}
+
 .sheet a.modified-service:hover {
     background-color: #C68900;
 }

--- a/style/dark.css
+++ b/style/dark.css
@@ -1,0 +1,84 @@
+
+.ahead {
+    --adherence-background: #FF6A00;
+}
+
+.behind {
+    --adherence-background: #FF6A00;
+}
+
+.modified-service {
+    background-color: #B65901;
+    color: #FFFFFF;
+}
+
+.negative {
+    color: #FF0000;
+}
+
+.no-service {
+    background-color: #700000;
+    color: #FFFFFF;
+}
+
+.normal-service {
+    background-color: #005900;
+    color: #FFFFFF;
+}
+
+.on-time {
+    --adherence-background: #0093A8;
+}
+
+.percentage {
+    background-color: #565656;
+}
+
+.percentage.low {
+    background-color: #700000;
+}
+
+.percentage.mid {
+    background-color: #B65901;
+}
+
+.percentage.high {
+    background-color: #005900;
+}
+
+.positive {
+    color: #428342;
+}
+
+.sheet a.modified-service:hover {
+    background-color: #934800;
+}
+
+.sheet a.no-service:hover {
+    background-color: #4A0000;
+}
+
+.sheet a.normal-service:hover {
+    background-color: #003B00;
+}
+
+.very-ahead {
+    --adherence-background: #FF0007;
+}
+
+.very-behind {
+    --adherence-background: #FF0007;
+}
+
+.weekdays a.weekday.no-service:hover {
+    background-color: #4A0000;
+}
+
+.weekdays a.weekday.normal-service:hover {
+    background-color: #003B00;
+}
+
+.weekdays {
+    background-color: #393939;
+    color: #FFFFFF;
+}

--- a/style/light.css
+++ b/style/light.css
@@ -1,0 +1,84 @@
+
+.ahead {
+    --adherence-background: #FF9A3A;
+}
+
+.behind {
+    --adherence-background: #FF9A3A;
+}
+
+.modified-service {
+    background-color: #FFA560;
+    color: #000000;
+}
+
+.negative {
+    color: #FF0000;
+}
+
+.no-service {
+    background-color: #FF7F7F;
+    color: #000000;
+}
+
+.normal-service {
+    background-color: #7DBD88;
+    color: #000000;
+}
+
+.on-time {
+    --adherence-background: #3C5ABE;
+}
+
+.percentage {
+    background-color: #ABABAB;
+}
+
+.percentage.low {
+    background-color: #FF7F7F;
+}
+
+.percentage.mid {
+    background-color: #FFA560;
+}
+
+.percentage.high {
+    background-color: #7DBD88;
+}
+
+.positive {
+    color: #1A671A;
+}
+
+.sheet a.modified-service:hover {
+    background-color: #E6853A;
+}
+
+.sheet a.no-service:hover {
+    background-color: #DC5050;
+}
+
+.sheet a.normal-service:hover {
+    background-color: #509F5E;
+}
+
+.very-ahead {
+    --adherence-background: #FD393E;
+}
+
+.very-behind {
+    --adherence-background: #FD393E;
+}
+
+.weekdays a.weekday.no-service:hover {
+    background-color: #DC5050;
+}
+
+.weekdays a.weekday.normal-service:hover {
+    background-color: #509F5E;
+}
+
+.weekdays {
+    background-color: #C4C4C4;
+    color: #000000;
+}

--- a/style/main.css
+++ b/style/main.css
@@ -1073,6 +1073,12 @@ table tr.header td {
     cursor: default;
 }
 
+.percentage {
+    cursor: default;
+    padding: 1px 4px;
+    border-radius: 4px;
+}
+
 .placeholder {
     display: flex;
     flex-direction: column;

--- a/style/themes/bc-hydro.css
+++ b/style/themes/bc-hydro.css
@@ -16,6 +16,8 @@
  * Other colors may also be used for specific purposes
 */
 
+@import "../light.css";
+
 :root {
     --tooltip-background: #666666;
     --tooltip-text: #FFFFFF;
@@ -288,10 +290,6 @@ table tr:nth-child(2n-1) {
     background-color: #347800;
 }
 
-.ahead {
-    --adherence-background: #FF9A3A;
-}
-
 .banner {
     background-color: #FFA027;
     color: #FFFFFF;
@@ -300,10 +298,6 @@ table tr:nth-child(2n-1) {
 
 .banner a {
     color: #FFFFFF;
-}
-
-.behind {
-    --adherence-background: #FF9A3A;
 }
 
 .button {
@@ -408,15 +402,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
 }
 
-.modified-service {
-    background-color: #FFA560;
-    color: #000000;
-}
-
-.negative {
-    color: #FF0000;
-}
-
 .news-post {
     background-color: #D8D8D8;
     border-color: #666666;
@@ -426,20 +411,6 @@ table tr:nth-child(2n-1) {
     background-color: #249B9B;
     color: #FFFFFF;
     border-bottom-color: #666666;
-}
-
-.no-service {
-    background-color: #FF7F7F;
-    color: #000000;
-}
-
-.normal-service {
-    background-color: #7DBD88;
-    color: #000000;
-}
-
-.on-time {
-    --adherence-background: #3C5ABE;
 }
 
 .option {
@@ -476,10 +447,6 @@ table tr:nth-child(2n-1) {
     background-color: #61C315;
 }
 
-.positive {
-    color: #1A671A;
-}
-
 .record-warnings {
     --image-color: #FF0000;
 }
@@ -496,18 +463,6 @@ table tr:nth-child(2n-1) {
 
 .sheet {
     background-color: #CCCCCC;
-}
-
-.sheet a.normal-service:hover {
-    background-color: #509F5E;
-}
-
-.sheet a.modified-service:hover {
-    background-color: #E6853A;
-}
-
-.sheet a.no-service:hover {
-    background-color: #DC5050;
 }
 
 .sheet-list .footer {
@@ -544,25 +499,4 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #666666;
-}
-
-.very-ahead {
-    --adherence-background: #FD393E;
-}
-
-.very-behind {
-    --adherence-background: #FD393E;
-}
-
-.weekdays a.weekday.no-service:hover {
-    background-color: #DC5050;
-}
-
-.weekdays a.weekday.normal-service:hover {
-    background-color: #509F5E;
-}
-
-.weekdays {
-    background-color: #C4C4C4;
-    color: #000000;
 }

--- a/style/themes/bc-transit-classic.css
+++ b/style/themes/bc-transit-classic.css
@@ -16,6 +16,8 @@
  * Other colors may also be used for specific purposes
 */
 
+@import "../light.css";
+
 :root {
     --tooltip-background: #666666;
     --tooltip-text: #FFFFFF;
@@ -288,10 +290,6 @@ table tr:nth-child(2n-1) {
     background-color: #840000;
 }
 
-.ahead {
-    --adherence-background: #FF9A3A;
-}
-
 .banner {
     background-color: #FFA027;
     color: #FFFFFF;
@@ -300,10 +298,6 @@ table tr:nth-child(2n-1) {
 
 .banner a {
     color: #FFFFFF;
-}
-
-.behind {
-    --adherence-background: #FF9A3A;
 }
 
 .button {
@@ -408,15 +402,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
 }
 
-.modified-service {
-    background-color: #FFA560;
-    color: #000000;
-}
-
-.negative {
-    color: #FF0000;
-}
-
 .news-post {
     background-color: #E6E6E6;
     border-color: #666666;
@@ -426,20 +411,6 @@ table tr:nth-child(2n-1) {
     background-color: #023496;
     color: #FFFFFF;
     border-bottom-color: #666666;
-}
-
-.no-service {
-    background-color: #FF7F7F;
-    color: #000000;
-}
-
-.normal-service {
-    background-color: #7DBD88;
-    color: #000000;
-}
-
-.on-time {
-    --adherence-background: #3C5ABE;
 }
 
 .option {
@@ -476,10 +447,6 @@ table tr:nth-child(2n-1) {
     background-color: #E20000;
 }
 
-.positive {
-    color: #1A671A;
-}
-
 .record-warnings {
     --image-color: #FF0000;
 }
@@ -496,18 +463,6 @@ table tr:nth-child(2n-1) {
 
 .sheet {
     background-color: #DDDDDD;
-}
-
-.sheet a.modified-service:hover {
-    background-color: #E6853A;
-}
-
-.sheet a.no-service:hover {
-    background-color: #DC5050;
-}
-
-.sheet a.normal-service:hover {
-    background-color: #509F5E;
 }
 
 .sheet-list .footer {
@@ -544,25 +499,4 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #666666;
-}
-
-.very-ahead {
-    --adherence-background: #FD393E;
-}
-
-.very-behind {
-    --adherence-background: #FD393E;
-}
-
-.weekdays a.weekday.no-service:hover {
-    background-color: #DC5050;
-}
-
-.weekdays a.weekday.normal-service:hover {
-    background-color: #509F5E;
-}
-
-.weekdays {
-    background-color: #C4C4C4;
-    color: #000000;
 }

--- a/style/themes/bc-transit.dark.css
+++ b/style/themes/bc-transit.dark.css
@@ -16,6 +16,8 @@
  * Other colors may also be used for specific purposes
 */
 
+@import "../dark.css";
+
 :root {
     color-scheme: dark;
     --tooltip-background: #2F2F2F;
@@ -296,10 +298,6 @@ table tr:nth-child(2n-1) {
     background-color: #053305;
 }
 
-.ahead {
-    --adherence-background: #FF6A00;
-}
-
 .banner {
     background-color: #8A4D00;
     color: #FFFFFF;
@@ -308,10 +306,6 @@ table tr:nth-child(2n-1) {
 
 .banner a {
     color: #FFFFFF;
-}
-
-.behind {
-    --adherence-background: #FF6A00;
 }
 
 .button {
@@ -421,15 +415,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
 }
 
-.modified-service {
-    background-color: #B65901;
-    color: #FFFFFF;
-}
-
-.negative {
-    color: #FF0000;
-}
-
 .news-post {
     background-color: #393939;
     border-color: #565656;
@@ -438,20 +423,6 @@ table tr:nth-child(2n-1) {
 .news-post .header {
     background-color: #276227;
     border-bottom-color: #565656;
-}
-
-.no-service {
-    background-color: #700000;
-    color: #FFFFFF;
-}
-
-.normal-service {
-    background-color: #005900;
-    color: #FFFFFF;
-}
-
-.on-time {
-    --adherence-background: #0093A8;
 }
 
 .option {
@@ -488,10 +459,6 @@ table tr:nth-child(2n-1) {
     background-color: #2247B7;
 }
 
-.positive {
-    color: #428342;
-}
-
 .record-warnings {
     --image-color: #FF0000;
 }
@@ -508,18 +475,6 @@ table tr:nth-child(2n-1) {
 
 .sheet {
     background-color: #565656;
-}
-
-.sheet a.modified-service:hover {
-    background-color: #934800;
-}
-
-.sheet a.no-service:hover {
-    background-color: #4A0000;
-}
-
-.sheet a.normal-service:hover {
-    background-color: #003B00;
 }
 
 .sheet-list .footer {
@@ -555,25 +510,4 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #565656;
-}
-
-.very-ahead {
-    --adherence-background: #FF0007;
-}
-
-.very-behind {
-    --adherence-background: #FF0007;
-}
-
-.weekdays a.weekday.no-service:hover {
-    background-color: #4A0000;
-}
-
-.weekdays a.weekday.normal-service:hover {
-    background-color: #003B00;
-}
-
-.weekdays {
-    background-color: #393939;
-    color: #FFFFFF;
 }

--- a/style/themes/bc-transit.light.css
+++ b/style/themes/bc-transit.light.css
@@ -16,6 +16,8 @@
  * Other colors may also be used for specific purposes
 */
 
+@import "../light.css";
+
 :root {
     --tooltip-background: #666666;
     --tooltip-text: #FFFFFF;
@@ -288,10 +290,6 @@ table tr:nth-child(2n-1) {
     background-color: #094409;
 }
 
-.ahead {
-    --adherence-background: #FF9A3A;
-}
-
 .banner {
     background-color: #FFA027;
     color: #FFFFFF;
@@ -300,10 +298,6 @@ table tr:nth-child(2n-1) {
 
 .banner a {
     color: #FFFFFF;
-}
-
-.behind {
-    --adherence-background: #FF9A3A;
 }
 
 .button {
@@ -408,15 +402,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
 }
 
-.modified-service {
-    background-color: #FFA560;
-    color: #000000;
-}
-
-.negative {
-    color: #FF0000;
-}
-
 .news-post {
     background-color: #E6E6E6;
     border-color: #666666;
@@ -426,20 +411,6 @@ table tr:nth-child(2n-1) {
     background-color: #48A348;
     color: white;
     border-bottom-color: #666666;
-}
-
-.no-service {
-    background-color: #FF7F7F;
-    color: #000000;
-}
-
-.normal-service {
-    background-color: #7DBD88;
-    color: #000000;
-}
-
-.on-time {
-    --adherence-background: #3C5ABE;
 }
 
 .option {
@@ -476,10 +447,6 @@ table tr:nth-child(2n-1) {
     background-color: #365CCB;
 }
 
-.positive {
-    color: #1A671A;
-}
-
 .record-warnings {
     --image-color: #FF0000;
 }
@@ -496,18 +463,6 @@ table tr:nth-child(2n-1) {
 
 .sheet {
     background-color: #DDDDDD;
-}
-
-.sheet a.modified-service:hover {
-    background-color: #E6853A;
-}
-
-.sheet a.no-service:hover {
-    background-color: #DC5050;
-}
-
-.sheet a.normal-service:hover {
-    background-color: #509F5E;
 }
 
 .sheet-list .footer {
@@ -544,25 +499,4 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #666666;
-}
-
-.very-ahead {
-    --adherence-background: #FD393E;
-}
-
-.very-behind {
-    --adherence-background: #FD393E;
-}
-
-.weekdays a.weekday.no-service:hover {
-    background-color: #DC5050;
-}
-
-.weekdays a.weekday.normal-service:hover {
-    background-color: #509F5E;
-}
-
-.weekdays {
-    background-color: #C4C4C4;
-    color: #000000;
 }

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -16,6 +16,8 @@
  * Other colors may also be used for specific purposes
 */
 
+@import "../light.css";
+
 :root {
     --tooltip-background: #666666;
     --tooltip-text: #FFFFFF;
@@ -284,10 +286,6 @@ table tr:nth-child(2n-1) {
     background-color: #0A4499;
 }
 
-.ahead {
-    --adherence-background: #FF9A3A;
-}
-
 .banner {
     background-color: #0A4499;
     color: #FFFFFF;
@@ -296,10 +294,6 @@ table tr:nth-child(2n-1) {
 
 .banner a {
     color: #FFFFFF;
-}
-
-.behind {
-    --adherence-background: #FF9A3A;
 }
 
 .button {
@@ -388,15 +382,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
 }
 
-.modified-service {
-    background-color: #FFA560;
-    color: #000000;
-}
-
-.negative {
-    color: #FF0000;
-}
-
 .news-post {
     background-color: #E6E6E6;
     border-color: #000000;
@@ -406,20 +391,6 @@ table tr:nth-child(2n-1) {
     background-color: #E39B35;
     color: white;
     border-bottom-color: #000000;
-}
-
-.no-service {
-    background-color: #FF7F7F;
-    color: #000000;
-}
-
-.normal-service {
-    background-color: #7DBD88;
-    color: #000000;
-}
-
-.on-time {
-    --adherence-background: #3C5ABE;
 }
 
 .option {
@@ -456,10 +427,6 @@ table tr:nth-child(2n-1) {
     background-color: #165ABE;
 }
 
-.positive {
-    color: #1A671A;
-}
-
 .record-warnings {
     --image-color: #FF0000;
 }
@@ -476,18 +443,6 @@ table tr:nth-child(2n-1) {
 
 .sheet {
     background-color: #DDDDDD;
-}
-
-.sheet a.modified-service:hover {
-    background-color: #E6853A;
-}
-
-.sheet a.no-service:hover {
-    background-color: #DC5050;
-}
-
-.sheet a.normal-service:hover {
-    background-color: #509F5E;
 }
 
 .sheet-list .footer {
@@ -524,25 +479,4 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #000000;
-}
-
-.very-ahead {
-    --adherence-background: #FD393E;
-}
-
-.very-behind {
-    --adherence-background: #FD393E;
-}
-
-.weekdays a.weekday.no-service:hover {
-    background-color: #DC5050;
-}
-
-.weekdays a.weekday.normal-service:hover {
-    background-color: #509F5E;
-}
-
-.weekdays {
-    background-color: #C4C4C4;
-    color: #000000;
 }

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -16,6 +16,8 @@
  * Other colors may also be used for specific purposes
 */
 
+@import "../light.css";
+
 :root {
     --tooltip-background: #69BB65;
     --tooltip-text: #FFFFFF;
@@ -288,10 +290,6 @@ table tr:nth-child(2n-1) {
     background-color: #7A0000;
 }
 
-.ahead {
-    --adherence-background: #FF9A3A;
-}
-
 .banner {
     background-color: #FFA027;
     color: #FFFFFF;
@@ -300,10 +298,6 @@ table tr:nth-child(2n-1) {
 
 .banner a {
     color: #FFFFFF;
-}
-
-.behind {
-    --adherence-background: #FF9A3A;
 }
 
 .button {
@@ -408,15 +402,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
 }
 
-.modified-service {
-    background-color: #FFA560;
-    color: #000000;
-}
-
-.negative {
-    color: #FF0000;
-}
-
 .news-post {
     background-color: #E4F6E3;
     border-color: #69BB65;
@@ -426,20 +411,6 @@ table tr:nth-child(2n-1) {
     background-color: #D70000;
     color: white;
     border-bottom-color: #69BB65;
-}
-
-.no-service {
-    background-color: #FF7F7F;
-    color: #000000;
-}
-
-.normal-service {
-    background-color: #7DBD88;
-    color: #000000;
-}
-
-.on-time {
-    --adherence-background: #3C5ABE;
 }
 
 .option {
@@ -476,10 +447,6 @@ table tr:nth-child(2n-1) {
     background-color: #AB0000;
 }
 
-.positive {
-    color: #1A671A;
-}
-
 .record-warnings {
     --image-color: #FF0000;
 }
@@ -496,18 +463,6 @@ table tr:nth-child(2n-1) {
 
 .sheet {
     background-color: #C3E9C1;
-}
-
-.sheet a.modified-service:hover {
-    background-color: #E6853A;
-}
-
-.sheet a.no-service:hover {
-    background-color: #DC5050;
-}
-
-.sheet a.normal-service:hover {
-    background-color: #509F5E;
 }
 
 .sheet-list .footer {
@@ -544,25 +499,4 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #69BB65;
-}
-
-.very-ahead {
-    --adherence-background: #FD393E;
-}
-
-.very-behind {
-    --adherence-background: #FD393E;
-}
-
-.weekdays a.weekday.no-service:hover {
-    background-color: #DC5050;
-}
-
-.weekdays a.weekday.normal-service:hover {
-    background-color: #509F5E;
-}
-
-.weekdays {
-    background-color: #C4C4C4;
-    color: #000000;
 }

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -16,6 +16,8 @@
  * Other colors may also be used for specific purposes
 */
 
+@import "../light.css";
+
 :root {
     --tooltip-background: #888888;
     --tooltip-text: #FFFFFF;
@@ -279,10 +281,6 @@ table tr {
     background-color: #DDDDDD;
 }
 
-.ahead {
-    --adherence-background: #FF9A3A;
-}
-
 .banner {
     background-color: #FFF7ED;
     color: #000000;
@@ -291,10 +289,6 @@ table tr {
 
 .banner a {
     color: #000000;
-}
-
-.behind {
-    --adherence-background: #FF9A3A;
 }
 
 .button {
@@ -399,15 +393,6 @@ table tr {
     color: #FFFFFF;
 }
 
-.modified-service {
-    background-color: #FFA560;
-    color: #000000;
-}
-
-.negative {
-    color: #FF0000;
-}
-
 .news-post {
     background-color: #EEEEEE;
     border-color: #DDDDDD;
@@ -417,20 +402,6 @@ table tr {
     background-color: #DDDDDD;
     color: #000000;
     border-bottom-color: #DDDDDD;
-}
-
-.no-service {
-    background-color: #FF7F7F;
-    color: #000000;
-}
-
-.normal-service {
-    background-color: #7DBD88;
-    color: #000000;
-}
-
-.on-time {
-    --adherence-background: #3C5ABE;
 }
 
 .option {
@@ -467,10 +438,6 @@ table tr {
     background-color: #AAAAAA;
 }
 
-.positive {
-    color: #1A671A;
-}
-
 .record-warnings {
     --image-color: #FF0000;
 }
@@ -487,18 +454,6 @@ table tr {
 
 .sheet {
     background-color: #DDDDDD;
-}
-
-.sheet a.modified-service:hover {
-    background-color: #E6853A;
-}
-
-.sheet a.no-service:hover {
-    background-color: #DC5050;
-}
-
-.sheet a.normal-service:hover {
-    background-color: #509F5E;
 }
 
 .sheet-list .footer {
@@ -535,25 +490,4 @@ table tr {
 
 .timeline .section:hover {
     border-color: #888888;
-}
-
-.very-ahead {
-    --adherence-background: #FD393E;
-}
-
-.very-behind {
-    --adherence-background: #FD393E;
-}
-
-.weekdays a.weekday.no-service:hover {
-    background-color: #DC5050;
-}
-
-.weekdays a.weekday.normal-service:hover {
-    background-color: #509F5E;
-}
-
-.weekdays {
-    background-color: #C4C4C4;
-    color: #000000;
 }

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -16,6 +16,8 @@
  * Other colors may also be used for specific purposes
 */
 
+@import "../dark.css";
+
 :root {
     color-scheme: dark;
     --tooltip-background: #2F2F2F;
@@ -296,10 +298,6 @@ table tr:nth-child(2n-1) {
     background-color: #B24C00;
 }
 
-.ahead {
-    --adherence-background: #FF6A00;
-}
-
 .banner {
     background-color: #8A4D00;
     color: #FFFFFF;
@@ -308,10 +306,6 @@ table tr:nth-child(2n-1) {
 
 .banner a {
     color: #FFFFFF;
-}
-
-.behind {
-    --adherence-background: #FF6A00;
 }
 
 .button {
@@ -421,15 +415,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
 }
 
-.modified-service {
-    background-color: #B65901;
-    color: #FFFFFF;
-}
-
-.negative {
-    color: #FF0000;
-}
-
 .news-post {
     background-color: #393939;
     border-color: #565656;
@@ -438,20 +423,6 @@ table tr:nth-child(2n-1) {
 .news-post .header {
     background-color: #FF6C00;
     border-bottom-color: #565656;
-}
-
-.no-service {
-    background-color: #700000;
-    color: #FFFFFF;
-}
-
-.normal-service {
-    background-color: #005900;
-    color: #FFFFFF;
-}
-
-.on-time {
-    --adherence-background: #0093A8;
 }
 
 .option {
@@ -488,10 +459,6 @@ table tr:nth-child(2n-1) {
     background-color: #E56100;
 }
 
-.positive {
-    color: #428342;
-}
-
 .record-warnings {
     --image-color: #FF0000;
 }
@@ -508,18 +475,6 @@ table tr:nth-child(2n-1) {
 
 .sheet {
     background-color: #565656;
-}
-
-.sheet a.modified-service:hover {
-    background-color: #934800;
-}
-
-.sheet a.no-service:hover {
-    background-color: #4A0000;
-}
-
-.sheet a.normal-service:hover {
-    background-color: #003B00;
 }
 
 .sheet-list .footer {
@@ -555,25 +510,4 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #565656;
-}
-
-.very-ahead {
-    --adherence-background: #FF0007;
-}
-
-.very-behind {
-    --adherence-background: #FF0007;
-}
-
-.weekdays a.weekday.no-service:hover {
-    background-color: #4A0000;
-}
-
-.weekdays a.weekday.normal-service:hover {
-    background-color: #003B00;
-}
-
-.weekdays {
-    background-color: #393939;
-    color: #FFFFFF;
 }

--- a/style/themes/pride.dark.css
+++ b/style/themes/pride.dark.css
@@ -1,5 +1,8 @@
 
+@import "../dark.css";
+
 :root {
+    color-scheme: dark;
     --tooltip-background: #000000;
     --tooltip-text: #FFFFFF;
     
@@ -281,10 +284,6 @@ table tr {
     background-color: rgba(0, 0, 0, 0.8);
 }
 
-.ahead {
-    --adherence-background: #FF6A00;
-}
-
 .banner {
     background-color: #8A4D00;
     color: #FFFFFF;
@@ -293,10 +292,6 @@ table tr {
 
 .banner a {
     color: #FFFFFF;
-}
-
-.behind {
-    --adherence-background: #FF6A00;
 }
 
 .button {
@@ -406,15 +401,6 @@ table tr {
     color: #FFFFFF;
 }
 
-.modified-service {
-    background-color: #B65901;
-    color: #FFFFFF;
-}
-
-.negative {
-    color: #FF0000;
-}
-
 .news-post {
     background-color: rgba(0, 0, 0, 0.6);
     border-color: rgba(255, 255, 255, 0.3);
@@ -423,20 +409,6 @@ table tr {
 .news-post .header {
     background-color: rgba(0, 0, 0, 0.6);
     border-bottom-color: rgba(255, 255, 255, 0.3);
-}
-
-.no-service {
-    background-color: #700000;
-    color: #FFFFFF;
-}
-
-.normal-service {
-    background-color: #005900;
-    color: #FFFFFF;
-}
-
-.on-time {
-    --adherence-background: #0093A8;
 }
 
 .option {
@@ -473,10 +445,6 @@ table tr {
     background-color: #000000;
 }
 
-.positive {
-    color: #428342;
-}
-
 .record-warnings {
     --image-color: #FF0000;
 }
@@ -493,18 +461,6 @@ table tr {
 
 .sheet {
     background-color: rgba(0, 0, 0, 0.5);
-}
-
-.sheet a.modified-service:hover {
-    background-color: #934800;
-}
-
-.sheet a.no-service:hover {
-    background-color: #4A0000;
-}
-
-.sheet a.normal-service:hover {
-    background-color: #003B00;
 }
 
 .sheet-list .footer {
@@ -543,25 +499,4 @@ table tr {
 
 .timeline .section:hover {
     border-color: #000000;
-}
-
-.very-ahead {
-    --adherence-background: #FF0007;
-}
-
-.very-behind {
-    --adherence-background: #FF0007;
-}
-
-.weekdays a.weekday.no-service:hover {
-    background-color: #4A0000;
-}
-
-.weekdays a.weekday.normal-service:hover {
-    background-color: #003B00;
-}
-
-.weekdays {
-    background-color: #393939;
-    color: #FFFFFF;
 }

--- a/style/themes/pride.light.css
+++ b/style/themes/pride.light.css
@@ -1,4 +1,6 @@
 
+@import "../light.css";
+
 :root {
     --tooltip-background: #000000;
     --tooltip-text: #FFFFFF;
@@ -281,10 +283,6 @@ table tr {
     background-color: rgba(0, 0, 0, 0.4);
 }
 
-.ahead {
-    --adherence-background: #FF9A3A;
-}
-
 .banner {
     background-color: #FFA027;
     color: #FFFFFF;
@@ -293,10 +291,6 @@ table tr {
 
 .banner a {
     color: #FFFFFF;
-}
-
-.behind {
-    --adherence-background: #FF9A3A;
 }
 
 .button {
@@ -401,15 +395,6 @@ table tr {
     color: #FFFFFF;
 }
 
-.modified-service {
-    background-color: #FFA560;
-    color: #000000;
-}
-
-.negative {
-    color: #FF0000;
-}
-
 .news-post {
     background-color: rgba(255, 255, 255, 0.6);
     border-color: rgba(0, 0, 0, 0.5);
@@ -418,20 +403,6 @@ table tr {
 .news-post .header {
     background-color: rgba(255, 255, 255, 0.6);
     border-bottom-color: rgba(0, 0, 0, 0.5);
-}
-
-.no-service {
-    background-color: #FF7F7F;
-    color: #000000;
-}
-
-.normal-service {
-    background-color: #7DBD88;
-    color: #000000;
-}
-
-.on-time {
-    --adherence-background: #3C5ABE;
 }
 
 .option {
@@ -468,10 +439,6 @@ table tr {
     background-color: #000000;
 }
 
-.positive {
-    color: #1A671A;
-}
-
 .record-warnings {
     --image-color: #FF0000;
 }
@@ -488,18 +455,6 @@ table tr {
 
 .sheet {
     background-color: rgba(255, 255, 255, 0.5);
-}
-
-.sheet a.modified-service:hover {
-    background-color: #E6853A;
-}
-
-.sheet a.no-service:hover {
-    background-color: #DC5050;
-}
-
-.sheet a.normal-service:hover {
-    background-color: #509F5E;
 }
 
 .sheet-list .footer {
@@ -538,25 +493,4 @@ table tr {
 
 .timeline .section:hover {
     border-color: #000000;
-}
-
-.very-ahead {
-    --adherence-background: #FD393E;
-}
-
-.very-behind {
-    --adherence-background: #FD393E;
-}
-
-.weekdays a.weekday.no-service:hover {
-    background-color: #DC5050;
-}
-
-.weekdays a.weekday.normal-service:hover {
-    background-color: #509F5E;
-}
-
-.weekdays {
-    background-color: #C4C4C4;
-    color: #000000;
 }

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -3,6 +3,8 @@
  * Based on tcomm.bustrainferry.com
 */
 
+@import "../light.css";
+
 :root {
     --tooltip-background: #000000;
     --tooltip-text: #FFFFFF;
@@ -500,15 +502,6 @@ table tr {
     text-shadow: none;
 }
 
-.modified-service {
-    background-color: #FFA560;
-    color: #000000;
-}
-
-.negative {
-    color: #FF0000;
-}
-
 .news-post {
     background: #FFF9DF;
     border-color: #F7C942;
@@ -522,16 +515,6 @@ table tr {
     background-color: #FFF9DF;
     border-bottom-color: #F7C942;
     background-image: linear-gradient( #FFFADF,#FFF3A5 );
-}
-
-.no-service {
-    background-color: #FF7F7F;
-    color: #000000;
-}
-
-.normal-service {
-    background-color: #7DBD88;
-    color: #000000;
 }
 
 .on-time {
@@ -577,8 +560,8 @@ table tr {
     background-image: linear-gradient( #5393c5,#6facd5 );
 }
 
-.positive {
-    color: #1A671A;
+.percentage {
+    text-shadow: none;
 }
 
 .record-warnings {
@@ -604,18 +587,6 @@ table tr {
 
 .sheet a {
     text-shadow: none;
-}
-
-.sheet a.modified-service:hover {
-    background-color: #E6853A;
-}
-
-.sheet a.no-service:hover {
-    background-color: #DC5050;
-}
-
-.sheet a.normal-service:hover {
-    background-color: #509F5E;
 }
 
 .sheet-list {
@@ -680,17 +651,4 @@ table tr {
 
 .weekdays .weekday {
     text-shadow: none;
-}
-
-.weekdays a.weekday.no-service:hover {
-    background-color: #DC5050;
-}
-
-.weekdays a.weekday.normal-service:hover {
-    background-color: #509F5E;
-}
-
-.weekdays {
-    background-color: #CBCBCB;
-    color: #000000;
 }

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -16,6 +16,8 @@
  * Other colors may also be used for specific purposes
 */
 
+@import "../light.css";
+
 :root {
     --tooltip-background: #666666;
     --tooltip-text: #FFFFFF;
@@ -288,10 +290,6 @@ table tr:nth-child(2n-1) {
     background-color: #7E3704;
 }
 
-.ahead {
-    --adherence-background: #FF9A3A;
-}
-
 .banner {
     background-color: #FFA027;
     color: #FFFFFF;
@@ -300,10 +298,6 @@ table tr:nth-child(2n-1) {
 
 .banner a {
     color: #FFFFFF;
-}
-
-.behind {
-    --adherence-background: #FF9A3A;
 }
 
 .button {
@@ -408,15 +402,6 @@ table tr:nth-child(2n-1) {
     color: #FFFFFF;
 }
 
-.modified-service {
-    background-color: #FFA560;
-    color: #000000;
-}
-
-.negative {
-    color: #FF0000;
-}
-
 .news-post {
     background-color: #E6E6E6;
     border-color: #666666;
@@ -426,20 +411,6 @@ table tr:nth-child(2n-1) {
     background-color: #DC9B41;
     color: #FFFFFF;
     border-bottom-color: #666666;
-}
-
-.no-service {
-    background-color: #FF7F7F;
-    color: #000000;
-}
-
-.normal-service {
-    background-color: #7DBD88;
-    color: #000000;
-}
-
-.on-time {
-    --adherence-background: #3C5ABE;
 }
 
 .option {
@@ -476,10 +447,6 @@ table tr:nth-child(2n-1) {
     background-color: #C7743B;
 }
 
-.positive {
-    color: #1A671A;
-}
-
 .record-warnings {
     --image-color: #FF0000;
 }
@@ -496,18 +463,6 @@ table tr:nth-child(2n-1) {
 
 .sheet {
     background-color: #DDDDDD;
-}
-
-.sheet a.modified-service:hover {
-    background-color: #E6853A;
-}
-
-.sheet a.no-service:hover {
-    background-color: #DC5050;
-}
-
-.sheet a.normal-service:hover {
-    background-color: #509F5E;
 }
 
 .sheet-list .footer {
@@ -544,25 +499,4 @@ table tr:nth-child(2n-1) {
 
 .timeline .section:hover {
     border-color: #666666;
-}
-
-.very-ahead {
-    --adherence-background: #FD393E;
-}
-
-.very-behind {
-    --adherence-background: #FD393E;
-}
-
-.weekdays a.weekday.no-service:hover {
-    background-color: #DC5050;
-}
-
-.weekdays a.weekday.normal-service:hover {
-    background-color: #509F5E;
-}
-
-.weekdays {
-    background-color: #C4C4C4;
-    color: #000000;
 }

--- a/views/components/percentage.tpl
+++ b/views/components/percentage.tpl
@@ -31,13 +31,19 @@
     % high_cutoff = get('high_cutoff', 75)
     % if percentage < low_cutoff:
         % percentage_class = 'low'
-    % elif percentage > high_cutoff:
+    % elif percentage >= high_cutoff:
         % percentage_class = 'high'
     % else:
         % percentage_class = 'mid'
     % end   
     <div class="percentage {{ percentage_class }} tooltip-anchor">
         {{ numerator }} / {{ denominator }}
-        <div class="tooltip right">{{ str(round(percentage, 2)) }}%</div>
+        <div class="tooltip right">
+            % percentage_rounded = round(percentage, 2)
+            % if percentage_rounded % 1 == 0:
+                % percentage_rounded = int(percentage_rounded)
+            % end
+            {{ percentage_rounded }}%
+        </div>
     </div>
 % end

--- a/views/components/percentage.tpl
+++ b/views/components/percentage.tpl
@@ -1,0 +1,43 @@
+
+<style>
+    .percentage {
+        cursor: default;
+        padding: 1px 4px;
+        border-radius: 4px;
+        background-color: #ABABAB;
+    }
+    
+    .percentage.low {
+        background-color: #FF7F7F;
+    }
+    
+    .percentage.mid {
+        background-color: #FFA560;
+    }
+    
+    .percentage.high {
+        background-color: #7DBD88;
+    }
+</style>
+
+% if denominator == 0:
+    <div class="percentage tooltip-anchor">
+        {{ numerator }} / {{ denominator }}
+        <div class="tooltip right">???</div>
+    </div>
+% else:
+    % percentage = (numerator / denominator) * 100
+    % low_cutoff = get('low_cutoff', 25)
+    % high_cutoff = get('high_cutoff', 75)
+    % if percentage < low_cutoff:
+        % percentage_class = 'low'
+    % elif percentage > high_cutoff:
+        % percentage_class = 'high'
+    % else:
+        % percentage_class = 'mid'
+    % end   
+    <div class="percentage {{ percentage_class }} tooltip-anchor">
+        {{ numerator }} / {{ denominator }}
+        <div class="tooltip right">{{ str(round(percentage, 2)) }}%</div>
+    </div>
+% end

--- a/views/components/percentage.tpl
+++ b/views/components/percentage.tpl
@@ -1,29 +1,8 @@
 
-<style>
-    .percentage {
-        cursor: default;
-        padding: 1px 4px;
-        border-radius: 4px;
-        background-color: #ABABAB;
-    }
-    
-    .percentage.low {
-        background-color: #FF7F7F;
-    }
-    
-    .percentage.mid {
-        background-color: #FFA560;
-    }
-    
-    .percentage.high {
-        background-color: #7DBD88;
-    }
-</style>
-
 % if denominator == 0:
     <div class="percentage tooltip-anchor">
         {{ numerator }} / {{ denominator }}
-        <div class="tooltip right">???</div>
+        <div class="tooltip right">💥</div>
     </div>
 % else:
     % percentage = (numerator / denominator) * 100

--- a/views/components/percentage.tpl
+++ b/views/components/percentage.tpl
@@ -6,11 +6,9 @@
     </div>
 % else:
     % percentage = (numerator / denominator) * 100
-    % low_cutoff = get('low_cutoff', 25)
-    % high_cutoff = get('high_cutoff', 75)
-    % if percentage < low_cutoff:
+    % if percentage < get('low_cutoff', 25):
         % percentage_class = 'low'
-    % elif percentage >= high_cutoff:
+    % elif percentage >= get('high_cutoff', 75):
         % percentage_class = 'high'
     % else:
         % percentage_class = 'mid'

--- a/views/pages/blocks/date.tpl
+++ b/views/pages/blocks/date.tpl
@@ -3,6 +3,10 @@
 
 <div id="page-header">
     <h1>Blocks</h1>
+    <div class="tab-button-bar">
+        <a href="{{ get_url(system, 'blocks') }}" class="tab-button">Overview</a>
+        <span class="tab-button current">Schedule</span>
+    </div>
 </div>
 
 % if system:
@@ -21,12 +25,12 @@
                             <a class="button" href="{{ get_url(system, f'blocks/schedule/{previous_date.format_db()}') }}">&lt;</a>
                             <div class="centred">
                                 <h3>{{ date.format_long() }}</h3>
-                                <a href="{{ get_url(system, 'blocks') }}">Go to weekly schedule</a>
+                                <a href="{{ get_url(system, 'blocks/schedule') }}">Go to weekly schedule</a>
                             </div>
                             <a class="button" href="{{ get_url(system, f'blocks/schedule/{next_date.format_db()}') }}">&gt;</a>
                         </div>
                         <div class="section">
-                            % include('components/sheet_list', sheets=system.get_sheets(), schedule_path='blocks', date_path='blocks/schedule')
+                            % include('components/sheet_list', sheets=system.get_sheets(), schedule_path='blocks/schedule')
                         </div>
                     </div>
                 </div>

--- a/views/pages/blocks/overview.tpl
+++ b/views/pages/blocks/overview.tpl
@@ -1,0 +1,178 @@
+
+% rebase('base')
+
+<div id="page-header">
+    <h1>Blocks</h1>
+    <div class="tab-button-bar">
+        <span class="tab-button current">Overview</span>
+        <a href="{{ get_url(system, 'blocks/schedule') }}" class="tab-button">Schedule</a>
+    </div>
+</div>
+
+% if system:
+    % blocks = system.get_blocks()
+    % today_blocks = sorted([b for b in blocks if today in b.schedule], key=lambda b: (b.get_start_time(date=today), b.get_end_time(date=today)))
+    % blocks_so_far = [b for b in today_blocks if b.get_start_time(date=today) <= now]
+    <div class="page-container">
+        <div class="sidebar container flex-1">
+            <div class="section">
+                <div class="header" onclick="toggleSection(this)">
+                    <h2>Overview</h2>
+                    % include('components/toggle')
+                </div>
+                <div class="content">
+                    <div class="info-box">
+                        <div class="section">
+                            % include('components/sheet_list', sheets=system.get_sheets(), schedule_path='blocks/schedule')
+                        </div>
+                        % if today_blocks:
+                            <h3 class="title">Today</h3>
+                            <div class="section row">
+                                <div class="name">Service Starts</div>
+                                <div class="value">
+                                    % start_times = [b.get_start_time(date=today) for b in today_blocks]
+                                    {{ min(start_times).format_web(time_format) }}
+                                </div>
+                            </div>
+                            <div class="section row">
+                                <div class="name">Service Ends</div>
+                                <div class="value">
+                                    % end_times = [b.get_end_time(date=today) for b in today_blocks]
+                                    {{ max(end_times).format_web(time_format) }}
+                                </div>
+                            </div>
+                            <div class="section row">
+                                <div class="name">Total Blocks</div>
+                                <div class="value">{{ len(today_blocks) }}</div>
+                            </div>
+                            % if system.realtime_enabled:
+                                <div class="section row">
+                                    <div class="name column">
+                                        <div>Assigned Buses</div>
+                                        <div class="lighter-text smaller-font">As of {{ now.format_web(time_format) }}</div>
+                                    </div>
+                                    <div class="value">
+                                        % include('components/percentage', numerator=len([b for b in blocks_so_far if b.id in recorded_buses]), denominator=len(blocks_so_far), low_cutoff=70, high_cutoff=90)
+                                    </div>
+                                </div>
+                            % end
+                        % end
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="container inline flex-3">
+            <div class="section">
+                <div class="header" onclick="toggleSection(this)">
+                    <h2>Today's Schedule</h2>
+                    % include('components/toggle')
+                </div>
+                <div class="content">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Block</th>
+                                <th>Routes</th>
+                                <th class="non-mobile">Start Time</th>
+                                <th class="non-mobile">End Time</th>
+                                <th class="mobile-only">Time</th>
+                                <th class="desktop-only">Duration</th>
+                                % if system.realtime_enabled:
+                                    <th class="desktop-only">Bus</th>
+                                    <th class="desktop-only">Model</th>
+                                % end
+                            </tr>
+                        </thead>
+                        <tbody>
+                            % for block in today_blocks:
+                                % start_time = block.get_start_time(date=today).format_web(time_format)
+                                % end_time = block.get_end_time(date=today).format_web(time_format)
+                                <tr>
+                                    <td><a href="{{ get_url(block.system, f'blocks/{block.id}') }}">{{ block.id }}</a></td>
+                                    <td>
+                                        % include('components/route_list', routes=block.get_routes(date=today))
+                                    </td>
+                                    <td class="non-mobile">{{ start_time }}</td>
+                                    <td class="non-mobile">{{ end_time }}</td>
+                                    <td class="mobile-only">{{ start_time }} - {{ end_time }}</td>
+                                    <td class="desktop-only">{{ block.get_duration(date=today) }}</td>
+                                    % if system.realtime_enabled:
+                                        % if block.id in recorded_buses:
+                                            % bus = recorded_buses[block.id]
+                                            <td>
+                                                <div class="column">
+                                                    % include('components/bus')
+                                                    <span class="non-desktop smaller-font">
+                                                        % include('components/order', order=bus.order)
+                                                    </span>
+                                                </div>
+                                            </td>
+                                            <td class="desktop-only">
+                                                % include('components/order', order=bus.order)
+                                            </td>
+                                        % else:
+                                            <td class="desktop-only lighter-text" colspan="2">Unavailable</td>
+                                        % end
+                                    % end
+                                </tr>
+                            % end
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    % include('components/top_button')
+% else:
+    <div class="placeholder">
+        <p>Choose a system to see blocks.</p>
+        <table>
+            <thead>
+                <tr>
+                    <th>System</th>
+                    <th class="non-mobile align-right">Blocks</th>
+                    <th>Service Days</th>
+                </tr>
+            </thead>
+            <tbody>
+                % for region in regions:
+                    % region_systems = [s for s in systems if s.region == region]
+                    % if region_systems:
+                        <tr class="header">
+                            <td colspan="3">{{ region }}</td>
+                        </tr>
+                        <tr class="display-none"></tr>
+                        % for region_system in sorted(region_systems):
+                            % count = len(region_system.get_blocks())
+                            <tr>
+                                <td>
+                                    <div class="column">
+                                        <a href="{{ get_url(region_system, path) }}">{{ region_system }}</a>
+                                        <span class="mobile-only smaller-font">
+                                            % if region_system.gtfs_loaded:
+                                                % if count == 1:
+                                                    1 Block
+                                                % else:
+                                                    {{ count }} Blocks
+                                                % end
+                                            % end
+                                        </span>
+                                    </div>
+                                </td>
+                                % if region_system.gtfs_loaded:
+                                    <td class="non-mobile align-right">{{ count }}</td>
+                                    <td>
+                                        % include('components/weekdays', schedule=region_system.schedule, compact=True, schedule_path='blocks')
+                                    </td>
+                                % else:
+                                    <td class="lighter-text" colspan="2">Blocks are loading...</td>
+                                % end
+                            </tr>
+                        % end
+                    % end
+                % end
+            </tbody>
+        </table>
+    </div>
+% end

--- a/views/pages/blocks/overview.tpl
+++ b/views/pages/blocks/overview.tpl
@@ -11,119 +11,146 @@
 
 % if system:
     % blocks = system.get_blocks()
-    % today_blocks = sorted([b for b in blocks if today in b.schedule], key=lambda b: (b.get_start_time(date=today), b.get_end_time(date=today)))
-    % blocks_so_far = [b for b in today_blocks if b.get_start_time(date=today) <= now]
-    <div class="page-container">
-        <div class="sidebar container flex-1">
-            <div class="section">
-                <div class="header" onclick="toggleSection(this)">
-                    <h2>Overview</h2>
-                    % include('components/toggle')
-                </div>
-                <div class="content">
-                    <div class="info-box">
-                        <div class="section">
-                            % include('components/sheet_list', sheets=system.get_sheets(), schedule_path='blocks/schedule')
-                        </div>
-                        % if today_blocks:
-                            <h3 class="title">Today</h3>
-                            <div class="section row">
-                                <div class="name">Service Starts</div>
-                                <div class="value">
-                                    % start_times = [b.get_start_time(date=today) for b in today_blocks]
-                                    {{ min(start_times).format_web(time_format) }}
-                                </div>
+    % if blocks:
+        % today_blocks = sorted([b for b in blocks if today in b.schedule], key=lambda b: (b.get_start_time(date=today), b.get_end_time(date=today)))
+        % blocks_so_far = [b for b in today_blocks if b.get_start_time(date=today) <= now]
+        <div class="page-container">
+            <div class="sidebar container flex-1">
+                <div class="section">
+                    <div class="header" onclick="toggleSection(this)">
+                        <h2>Overview</h2>
+                        % include('components/toggle')
+                    </div>
+                    <div class="content">
+                        <div class="info-box">
+                            <div class="section">
+                                % include('components/sheet_list', sheets=system.get_sheets(), schedule_path='blocks/schedule')
                             </div>
-                            <div class="section row">
-                                <div class="name">Service Ends</div>
-                                <div class="value">
-                                    % end_times = [b.get_end_time(date=today) for b in today_blocks]
-                                    {{ max(end_times).format_web(time_format) }}
-                                </div>
-                            </div>
-                            <div class="section row">
-                                <div class="name">Total Blocks</div>
-                                <div class="value">{{ len(today_blocks) }}</div>
-                            </div>
-                            % if system.realtime_enabled:
+                            % if today_blocks:
+                                <h3 class="title">Today</h3>
                                 <div class="section row">
-                                    <div class="name column">
-                                        <div>Assigned Buses</div>
-                                        <div class="lighter-text smaller-font">As of {{ now.format_web(time_format) }}</div>
-                                    </div>
+                                    <div class="name">Service Starts</div>
                                     <div class="value">
-                                        % include('components/percentage', numerator=len([b for b in blocks_so_far if b.id in recorded_buses]), denominator=len(blocks_so_far), low_cutoff=70, high_cutoff=90)
+                                        % start_times = [b.get_start_time(date=today) for b in today_blocks]
+                                        {{ min(start_times).format_web(time_format) }}
                                     </div>
                                 </div>
+                                <div class="section row">
+                                    <div class="name">Service Ends</div>
+                                    <div class="value">
+                                        % end_times = [b.get_end_time(date=today) for b in today_blocks]
+                                        {{ max(end_times).format_web(time_format) }}
+                                    </div>
+                                </div>
+                                <div class="section row">
+                                    <div class="name">Total Blocks</div>
+                                    <div class="value">{{ len(today_blocks) }}</div>
+                                </div>
+                                % if system.realtime_enabled:
+                                    <div class="section row">
+                                        <div class="name column">
+                                            <div>Assigned Buses</div>
+                                            <div class="lighter-text smaller-font">As of {{ now.format_web(time_format) }}</div>
+                                        </div>
+                                        <div class="value">
+                                            % include('components/percentage', numerator=len([b for b in blocks_so_far if b.id in recorded_buses]), denominator=len(blocks_so_far), low_cutoff=80, high_cutoff=95)
+                                        </div>
+                                    </div>
+                                % end
                             % end
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="container inline flex-3">
+                <div class="section">
+                    <div class="header" onclick="toggleSection(this)">
+                        <h2>Today's Schedule</h2>
+                        % include('components/toggle')
+                    </div>
+                    <div class="content">
+                        % if today_blocks:
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th>Block</th>
+                                        <th>Routes</th>
+                                        <th class="non-mobile">Start Time</th>
+                                        <th class="non-mobile">End Time</th>
+                                        <th class="desktop-only">Duration</th>
+                                        % if system.realtime_enabled:
+                                            <th>Bus</th>
+                                            <th class="non-mobile">Model</th>
+                                        % end
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    % for block in today_blocks:
+                                        % start_time = block.get_start_time(date=today).format_web(time_format)
+                                        % end_time = block.get_end_time(date=today).format_web(time_format)
+                                        <tr>
+                                            <td>
+                                                <div class="column">
+                                                    <a href="{{ get_url(block.system, f'blocks/{block.id}') }}">{{ block.id }}</a>
+                                                    <div class="mobile-only smaller-font">{{ start_time }} - {{ end_time }}</div>
+                                                </div>
+                                            </td>
+                                            <td>
+                                                % include('components/route_list', routes=block.get_routes(date=today))
+                                            </td>
+                                            <td class="non-mobile">{{ start_time }}</td>
+                                            <td class="non-mobile">{{ end_time }}</td>
+                                            <td class="desktop-only">{{ block.get_duration(date=today) }}</td>
+                                            % if system.realtime_enabled:
+                                                % if block.id in recorded_buses:
+                                                    % bus = recorded_buses[block.id]
+                                                    <td>
+                                                        <div class="column">
+                                                            % include('components/bus')
+                                                            <span class="mobile-only smaller-font">
+                                                                % include('components/order', order=bus.order)
+                                                            </span>
+                                                        </div>
+                                                    </td>
+                                                    <td class="non-mobile">
+                                                        % include('components/order', order=bus.order)
+                                                    </td>
+                                                % else:
+                                                    <td class="non-mobile lighter-text" colspan="2">Unavailable</td>
+                                                    <td class="mobile-only lighter-text">Unavailable</td>
+                                                % end
+                                            % end
+                                        </tr>
+                                    % end
+                                </tbody>
+                            </table>
+                        % else:
+                            <div class="placeholder">
+                                % if system.gtfs_loaded:
+                                    <h3>There are no blocks today</h3>
+                                    <p>You can check the <a href="{{ get_url(system, 'blocks/schedule') }}">full schedule</a> for more information about when this system operates.</p>
+                                % else:
+                                    <h3>Blocks are unavailable</h3>
+                                    <p>System data is currently loading and will be available soon.</p>
+                                % end
+                            </div>
                         % end
                     </div>
                 </div>
             </div>
         </div>
-        <div class="container inline flex-3">
-            <div class="section">
-                <div class="header" onclick="toggleSection(this)">
-                    <h2>Today's Schedule</h2>
-                    % include('components/toggle')
-                </div>
-                <div class="content">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Block</th>
-                                <th>Routes</th>
-                                <th class="non-mobile">Start Time</th>
-                                <th class="non-mobile">End Time</th>
-                                <th class="mobile-only">Time</th>
-                                <th class="desktop-only">Duration</th>
-                                % if system.realtime_enabled:
-                                    <th class="desktop-only">Bus</th>
-                                    <th class="desktop-only">Model</th>
-                                % end
-                            </tr>
-                        </thead>
-                        <tbody>
-                            % for block in today_blocks:
-                                % start_time = block.get_start_time(date=today).format_web(time_format)
-                                % end_time = block.get_end_time(date=today).format_web(time_format)
-                                <tr>
-                                    <td><a href="{{ get_url(block.system, f'blocks/{block.id}') }}">{{ block.id }}</a></td>
-                                    <td>
-                                        % include('components/route_list', routes=block.get_routes(date=today))
-                                    </td>
-                                    <td class="non-mobile">{{ start_time }}</td>
-                                    <td class="non-mobile">{{ end_time }}</td>
-                                    <td class="mobile-only">{{ start_time }} - {{ end_time }}</td>
-                                    <td class="desktop-only">{{ block.get_duration(date=today) }}</td>
-                                    % if system.realtime_enabled:
-                                        % if block.id in recorded_buses:
-                                            % bus = recorded_buses[block.id]
-                                            <td>
-                                                <div class="column">
-                                                    % include('components/bus')
-                                                    <span class="non-desktop smaller-font">
-                                                        % include('components/order', order=bus.order)
-                                                    </span>
-                                                </div>
-                                            </td>
-                                            <td class="desktop-only">
-                                                % include('components/order', order=bus.order)
-                                            </td>
-                                        % else:
-                                            <td class="desktop-only lighter-text" colspan="2">Unavailable</td>
-                                        % end
-                                    % end
-                                </tr>
-                            % end
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </div>
 
-    % include('components/top_button')
+        % include('components/top_button')
+    % else:
+        <div class="placeholder">
+            <h3>Block information for {{ system }} is unavailable</h3>
+            % if system.gtfs_loaded:
+                <p>Please check again later!</p>
+            % else:
+                <p>System data is currently loading and will be available soon.</p>
+            % end
+        </div>
+    % end
 % else:
     <div class="placeholder">
         <p>Choose a system to see blocks.</p>

--- a/views/pages/blocks/overview.tpl
+++ b/views/pages/blocks/overview.tpl
@@ -62,7 +62,7 @@
                     </div>
                 </div>
             </div>
-            <div class="container inline flex-3">
+            <div class="container flex-3">
                 <div class="section">
                     <div class="header" onclick="toggleSection(this)">
                         <h2>Today's Schedule</h2>

--- a/views/pages/blocks/schedule.tpl
+++ b/views/pages/blocks/schedule.tpl
@@ -3,6 +3,10 @@
 
 <div id="page-header">
     <h1>Blocks</h1>
+    <div class="tab-button-bar">
+        <a href="{{ get_url(system, 'blocks') }}" class="tab-button">Overview</a>
+        <span class="tab-button current">Schedule</span>
+    </div>
 </div>
 
 % if system:
@@ -19,7 +23,7 @@
                     <div class="content">
                         <div class="info-box">
                             <div class="section">
-                                % include('components/sheet_list', schedule_path='blocks', date_path='blocks/schedule')
+                                % include('components/sheet_list', schedule_path='blocks/schedule')
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
- The main Blocks page (`/blocks`) is now split into two tabs: **Overview** and **Schedule**
  - **Schedule** (found at `/blocks/schedule`) is identical to the old main blocks page
  - **Overview** shows the blocks running on the current date, what bus is running each, and some general stats in the side bar
  - Overall matches the style of route and stop pages, which have similar behaviour
  - Schedules for individual dates are already found at `/blocks/schedule/<date>` so this convention remains consistent
- Added function for loading recorded buses for the current date by block
  - Similar function already exists, but it groups by trip instead of block
  - Used to show which bus ran each block
- Added `percentage` UI component
  - Shows a numerator and denominator with a background colour based on how high or low the percentage is
  - By default low colour shows at < 25% and high colour shows at >= 75%, with mid colour in between
  - For blocks specifically, those cutoffs are modified to < 80% and >= 95% - assumption is that anything less than _most_ blocks is not great
- Introduced `light` and `dark` base CSS files
  - Contain generic styles used by light and dark themes, so they don't need to be duplicated in all theme files
  - Includes adherence, service levels, postive/negative, and now percentages as well
  - Can still be overwritten if needed - eg the tcomm theme uses custom adherence colours
- Added contrast colours for percentages

![Screenshot from 2024-07-11 21-03-01](https://github.com/user-attachments/assets/2ac9452b-3e70-41ad-81f3-5e9967f01298)
![Screenshot from 2024-07-11 21-03-17](https://github.com/user-attachments/assets/8f346bff-b23d-4ccb-892a-c2eae0d79ebd)
![Screenshot from 2024-07-11 21-04-04](https://github.com/user-attachments/assets/d5727fd3-b04f-4a23-90b5-2e80f4f9f9b9)
![Screenshot from 2024-07-11 21-04-17](https://github.com/user-attachments/assets/44d3ff10-f0d3-4f95-bfe5-76d272f3fb54)
![Screenshot from 2024-07-11 21-05-19](https://github.com/user-attachments/assets/8bfc2734-75ad-4fb6-88f6-300d12f051e7)
