### PR TITLE
Add bus occupancy to map details hover

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -804,7 +804,7 @@ table tr.header td {
     padding: 2px;
     display: flex;
     flex-direction: column;
-    gap: 1px;
+    gap: 2px;
 }
 
 .marker .details .content .adherence-indicator {
@@ -814,6 +814,10 @@ table tr.header td {
 }
 
 .marker .details .content .route {
+    font-size: 8pt;
+}
+
+.marker .details .content .occupancy-name {
     font-size: 8pt;
 }
 

--- a/views/components/map.tpl
+++ b/views/components/map.tpl
@@ -149,6 +149,22 @@
             }
             content.appendChild(headsign);
             
+            const occupancy = document.createElement("div");
+            occupancy.className = "row center gap-5";
+            
+            const occupancyIcon = document.createElement("div");
+            occupancyIcon.className = "occupancy-icon";
+            occupancyIcon.classList.add(position.occupancy_status_class);
+            occupancyIcon.innerHTML = getSVG(position.occupancy_icon);
+            occupancy.appendChild(occupancyIcon);
+            
+            const occupancyName = document.createElement("div");
+            occupancyName.className = "occupancy-name";
+            occupancyName.innerText = position.occupancy_name;
+            occupancy.appendChild(occupancyName);
+            
+            content.appendChild(occupancy);
+            
             if ("{{ system is None }}" === "True") {
                 const system = document.createElement("div");
                 system.className = "lighter-text centred";

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -159,6 +159,22 @@
                 }
                 content.appendChild(headsign);
                 
+                const occupancy = document.createElement("div");
+                occupancy.className = "row center gap-5";
+                
+                const occupancyIcon = document.createElement("div");
+                occupancyIcon.className = "occupancy-icon";
+                occupancyIcon.classList.add(position.occupancy_status_class);
+                occupancyIcon.innerHTML = getSVG(position.occupancy_icon);
+                occupancy.appendChild(occupancyIcon);
+                
+                const occupancyName = document.createElement("div");
+                occupancyName.className = "occupancy-name";
+                occupancyName.innerText = position.occupancy_name;
+                occupancy.appendChild(occupancyName);
+                
+                content.appendChild(occupancy);
+                
                 if ("{{ system is None }}" === "True") {
                     const system = document.createElement("div");
                     system.className = "lighter-text centred";


### PR DESCRIPTION
- Added occupancy row to bus position markers on the main map page and in map components
- Minor CSS changes to make it look better

![Screenshot from 2024-08-11 09-23-37](https://github.com/user-attachments/assets/1529f8a9-ea69-4c86-a3e2-2feb484f7b8e)
![Screenshot from 2024-08-11 09-23-17](https://github.com/user-attachments/assets/d67eed65-eb71-4bac-bda1-18202fd6405a)
![Screenshot from 2024-08-11 09-22-45](https://github.com/user-attachments/assets/605b1628-d773-40a0-8ff8-961da3730bf5)
