### PR TITLE
More occupancy indicators

### DIFF
--- a/views/pages/block/overview.tpl
+++ b/views/pages/block/overview.tpl
@@ -197,8 +197,9 @@
                                 <tr>
                                     <td>
                                         <div class="column">
-                                            <div class="row">
+                                            <div class="row gap-5">
                                                 % include('components/bus')
+                                                % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
                                                 % include('components/adherence', adherence=position.adherence)
                                             </div>
                                             <span class="non-desktop smaller-font">

--- a/views/pages/block/overview.tpl
+++ b/views/pages/block/overview.tpl
@@ -197,10 +197,12 @@
                                 <tr>
                                     <td>
                                         <div class="column">
-                                            <div class="row gap-5">
+                                            <div class="row">
                                                 % include('components/bus')
-                                                % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
-                                                % include('components/adherence', adherence=position.adherence)
+                                                <div class="row gap-5">
+                                                    % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
+                                                    % include('components/adherence', adherence=position.adherence)
+                                                </div>
                                             </div>
                                             <span class="non-desktop smaller-font">
                                                 % include('components/order', order=bus.order)

--- a/views/pages/home.tpl
+++ b/views/pages/home.tpl
@@ -143,11 +143,13 @@
                                                     % position = di[PositionRepository].find(value)
                                                     <tr>
                                                         <td>
-                                                            <div class="row gap-5">
+                                                            <div class="row">
                                                                 % include('components/bus', bus=value)
                                                                 % if position:
-                                                                    % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
-                                                                    % include('components/adherence', adherence=position.adherence)
+                                                                    <div class="row gap-5">
+                                                                        % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
+                                                                        % include('components/adherence', adherence=position.adherence)
+                                                                    </div>
                                                                 % end
                                                             </div>
                                                         </td>

--- a/views/pages/home.tpl
+++ b/views/pages/home.tpl
@@ -143,9 +143,10 @@
                                                     % position = di[PositionRepository].find(value)
                                                     <tr>
                                                         <td>
-                                                            <div class="row">
+                                                            <div class="row gap-5">
                                                                 % include('components/bus', bus=value)
                                                                 % if position:
+                                                                    % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
                                                                     % include('components/adherence', adherence=position.adherence)
                                                                 % end
                                                             </div>

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -76,8 +76,9 @@
                                 <tr class="{{'' if same_order else 'divider'}}">
                                     <td>
                                         <div class="column">
-                                            <div class="row">
+                                            <div class="row gap-5">
                                                 % include('components/bus')
+                                                % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
                                                 % include('components/adherence', adherence=position.adherence)
                                             </div>
                                             <span class="non-desktop smaller-font">

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -76,10 +76,12 @@
                                 <tr class="{{'' if same_order else 'divider'}}">
                                     <td>
                                         <div class="column">
-                                            <div class="row gap-5">
+                                            <div class="row">
                                                 % include('components/bus')
-                                                % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
-                                                % include('components/adherence', adherence=position.adherence)
+                                                <div class="row gap-5">
+                                                    % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
+                                                    % include('components/adherence', adherence=position.adherence)
+                                                </div>
                                             </div>
                                             <span class="non-desktop smaller-font">
                                                 % include('components/order')

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -48,8 +48,9 @@
                 <tr class="{{'' if same_speed else 'divider'}}">
                     <td>
                         <div class="column">
-                            <div class="row">
+                            <div class="row gap-5">
                                 % include('components/bus')
+                                % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
                                 % include('components/adherence', adherence=position.adherence)
                             </div>
                             <span class="non-desktop smaller-font">

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -48,10 +48,12 @@
                 <tr class="{{'' if same_speed else 'divider'}}">
                     <td>
                         <div class="column">
-                            <div class="row gap-5">
+                            <div class="row">
                                 % include('components/bus')
-                                % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
-                                % include('components/adherence', adherence=position.adherence)
+                                <div class="row gap-5">
+                                    % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
+                                    % include('components/adherence', adherence=position.adherence)
+                                </div>
                             </div>
                             <span class="non-desktop smaller-font">
                                 % include('components/order', order=bus.order)

--- a/views/pages/route/overview.tpl
+++ b/views/pages/route/overview.tpl
@@ -82,10 +82,12 @@
                                 <tr>
                                     <td>
                                         <div class="column">
-                                            <div class="row gap-5">
+                                            <div class="row">
                                                 % include('components/bus')
-                                                % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
-                                                % include('components/adherence', adherence=position.adherence)
+                                                <div class="row gap-5">
+                                                    % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
+                                                    % include('components/adherence', adherence=position.adherence)
+                                                </div>
                                             </div>
                                             <span class="non-desktop smaller-font">
                                                 % include('components/order', order=bus.order)
@@ -189,12 +191,14 @@
                                                                 % bus = recorded_today[trip.id]
                                                                 <td>
                                                                     <div class="column">
-                                                                        <div class="row gap-5">
+                                                                        <div class="row">
                                                                             % include('components/bus')
                                                                             % if trip.id in trip_positions:
                                                                                 % position = trip_positions[trip.id]
-                                                                                % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
-                                                                                % include('components/adherence', adherence=position.adherence)
+                                                                                <div class="row gap-5">
+                                                                                    % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
+                                                                                    % include('components/adherence', adherence=position.adherence)
+                                                                                </div>
                                                                             % end
                                                                         </div>
                                                                         <span class="non-desktop smaller-font">

--- a/views/pages/route/overview.tpl
+++ b/views/pages/route/overview.tpl
@@ -82,8 +82,9 @@
                                 <tr>
                                     <td>
                                         <div class="column">
-                                            <div class="row">
+                                            <div class="row gap-5">
                                                 % include('components/bus')
+                                                % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
                                                 % include('components/adherence', adherence=position.adherence)
                                             </div>
                                             <span class="non-desktop smaller-font">
@@ -188,10 +189,11 @@
                                                                 % bus = recorded_today[trip.id]
                                                                 <td>
                                                                     <div class="column">
-                                                                        <div class="row">
+                                                                        <div class="row gap-5">
                                                                             % include('components/bus')
                                                                             % if trip.id in trip_positions:
                                                                                 % position = trip_positions[trip.id]
+                                                                                % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
                                                                                 % include('components/adherence', adherence=position.adherence)
                                                                             % end
                                                                         </div>

--- a/views/pages/trip/overview.tpl
+++ b/views/pages/trip/overview.tpl
@@ -168,8 +168,9 @@
                                 <tr>
                                     <td>
                                         <div class="column">
-                                            <div class="row">
+                                            <div class="row gap-5">
                                                 % include('components/bus')
+                                                % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
                                                 % include('components/adherence', adherence=position.adherence)
                                             </div>
                                             <span class="mobile-only smaller-font">

--- a/views/pages/trip/overview.tpl
+++ b/views/pages/trip/overview.tpl
@@ -168,10 +168,12 @@
                                 <tr>
                                     <td>
                                         <div class="column">
-                                            <div class="row gap-5">
+                                            <div class="row">
                                                 % include('components/bus')
-                                                % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
-                                                % include('components/adherence', adherence=position.adherence)
+                                                <div class="row gap-5">
+                                                    % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
+                                                    % include('components/adherence', adherence=position.adherence)
+                                                </div>
                                             </div>
                                             <span class="mobile-only smaller-font">
                                                 % include('components/order', order=bus.order)

--- a/views/rows/departure.tpl
+++ b/views/rows/departure.tpl
@@ -38,10 +38,11 @@
             % bus = recorded_today[trip.id]
             <td>
                 <div class="column">
-                    <div class="row">
+                    <div class="row gap-5">
                         % include('components/bus')
                         % if trip.id in positions:
                             % position = positions[trip.id]
+                            % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
                             % include('components/adherence', adherence=position.adherence)
                         % end
                     </div>
@@ -58,7 +59,7 @@
             % bus = assignment.bus
             <td>
                 <div class="column">
-                    <div class="row">
+                    <div class="row gap-5">
                         % include('components/bus')
                         % include('components/scheduled')
                     </div>

--- a/views/rows/departure.tpl
+++ b/views/rows/departure.tpl
@@ -38,12 +38,14 @@
             % bus = recorded_today[trip.id]
             <td>
                 <div class="column">
-                    <div class="row gap-5">
+                    <div class="row">
                         % include('components/bus')
                         % if trip.id in positions:
                             % position = positions[trip.id]
-                            % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
-                            % include('components/adherence', adherence=position.adherence)
+                            <div class="row gap-5">
+                                % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
+                                % include('components/adherence', adherence=position.adherence)
+                            </div>
                         % end
                     </div>
                     <span class="non-desktop smaller-font">
@@ -59,7 +61,7 @@
             % bus = assignment.bus
             <td>
                 <div class="column">
-                    <div class="row gap-5">
+                    <div class="row">
                         % include('components/bus')
                         % include('components/scheduled')
                     </div>

--- a/views/rows/realtime.tpl
+++ b/views/rows/realtime.tpl
@@ -5,8 +5,9 @@
 <tr>
     <td>
         <div class="column">
-            <div class="row">
+            <div class="row gap-5">
                 % include('components/bus')
+                % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
                 % include('components/adherence', adherence=position.adherence)
             </div>
             % if not system:

--- a/views/rows/realtime.tpl
+++ b/views/rows/realtime.tpl
@@ -5,10 +5,12 @@
 <tr>
     <td>
         <div class="column">
-            <div class="row gap-5">
+            <div class="row">
                 % include('components/bus')
-                % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
-                % include('components/adherence', adherence=position.adherence)
+                <div class="row gap-5">
+                    % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
+                    % include('components/adherence', adherence=position.adherence)
+                </div>
             </div>
             % if not system:
                 <span class="non-desktop smaller-font">{{ position.system }}</span>


### PR DESCRIPTION
Added occupancy indicators to table rows in the following places:
- Realtime pages (All, By Route, By Model, and By Speed)
- Route overview page (Active and Scheduled Today)
- Stop overview page (Upcoming Departures and Today's Schedule)
- Block overview page (Active Bus)
- Trip overview page (Active Bus)
- Home page (Favourites)

I also decreased the gap slightly between the bus number and its various icons from 10px to 5px, to compact the design slightly (though the width is overall still bigger)

![Screenshot from 2024-08-18 10-55-49](https://github.com/user-attachments/assets/e54a398f-915d-4077-8464-aa8127582ce0)
![Screenshot from 2024-08-18 10-56-05](https://github.com/user-attachments/assets/9e35ebf7-78af-4380-8f3f-3ff3d1e9c4f9)
![Screenshot from 2024-08-18 10-56-16](https://github.com/user-attachments/assets/7547e39d-a2b9-4824-9fd1-e4bccb2ce85e)
![Screenshot from 2024-08-18 10-56-30](https://github.com/user-attachments/assets/59dea00c-34e7-4081-826a-49fffe6e2117)
![Screenshot from 2024-08-18 10-56-54](https://github.com/user-attachments/assets/0942b3e8-1997-4864-8b1d-8896205882c1)
![Screenshot from 2024-08-18 11-05-58](https://github.com/user-attachments/assets/78496f00-5c5a-4728-b3c6-b1b46b5b6c26)
