### PR TITLE
Add block timeline timespans

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -1292,6 +1292,8 @@ table tr.header td {
     top: -2px;
     bottom: -2px;
     width: 2px;
+    z-index: 10;
+    transform: translateX(-1px);
 }
 
 .timeline .section {

--- a/style/main.css
+++ b/style/main.css
@@ -1315,6 +1315,24 @@ table tr.header td {
     opacity: 1;
 }
 
+.timespan {
+    position: relative;
+    height: 4px;
+}
+
+.timespan .time {
+    position: absolute;
+    top: 0px;
+    height: 2px;
+    width: 2px;
+    transform: translateX(-1px);
+}
+
+.timespan .time.hour {
+    height: 6px;
+    top: -2px;
+}
+
 .timing-point {
     font-weight: bold;
 }

--- a/style/themes/bc-hydro.css
+++ b/style/themes/bc-hydro.css
@@ -498,3 +498,7 @@ table tr:nth-child(2n-1) {
 .timeline .section:hover {
     border-color: #666666;
 }
+
+.timespan .time {
+    background-color: #ABABAB;
+}

--- a/style/themes/bc-transit-classic.css
+++ b/style/themes/bc-transit-classic.css
@@ -498,3 +498,7 @@ table tr:nth-child(2n-1) {
 .timeline .section:hover {
     border-color: #666666;
 }
+
+.timespan .time {
+    background-color: #ABABAB;
+}

--- a/style/themes/bc-transit.dark.css
+++ b/style/themes/bc-transit.dark.css
@@ -509,3 +509,7 @@ table tr:nth-child(2n-1) {
 .timeline .section:hover {
     border-color: #565656;
 }
+
+.timespan .time {
+    background-color: #989898;
+}

--- a/style/themes/bc-transit.light.css
+++ b/style/themes/bc-transit.light.css
@@ -498,3 +498,7 @@ table tr:nth-child(2n-1) {
 .timeline .section:hover {
     border-color: #666666;
 }
+
+.timespan .time {
+    background-color: #ABABAB;
+}

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -478,3 +478,7 @@ table tr:nth-child(2n-1) {
 .timeline .section:hover {
     border-color: #000000;
 }
+
+.timespan .time {
+    background-color: #ABABAB;
+}

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -498,3 +498,7 @@ table tr:nth-child(2n-1) {
 .timeline .section:hover {
     border-color: #69BB65;
 }
+
+.timespan .time {
+    background-color: #ABABAB;
+}

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -489,3 +489,7 @@ table tr {
 .timeline .section:hover {
     border-color: #888888;
 }
+
+.timespan .time {
+    background-color: #AAAAAA;
+}

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -509,3 +509,7 @@ table tr:nth-child(2n-1) {
 .timeline .section:hover {
     border-color: #565656;
 }
+
+.timespan .time {
+    background-color: #989898;
+}

--- a/style/themes/pride.dark.css
+++ b/style/themes/pride.dark.css
@@ -498,3 +498,7 @@ table tr {
 .timeline .section:hover {
     border-color: #000000;
 }
+
+.timespan .time {
+    background-color: #989898;
+}

--- a/style/themes/pride.light.css
+++ b/style/themes/pride.light.css
@@ -492,3 +492,7 @@ table tr {
 .timeline .section:hover {
     border-color: #000000;
 }
+
+.timespan .time {
+    background-color: #ABABAB;
+}

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -639,6 +639,10 @@ table tr {
     text-shadow: none;
 }
 
+.timespan .time {
+    background-color: #ABABAB;
+}
+
 .very-ahead {
     --adherence-background: #F00E0E;
 }

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -498,3 +498,7 @@ table tr:nth-child(2n-1) {
 .timeline .section:hover {
     border-color: #666666;
 }
+
+.timespan .time {
+    background-color: #ABABAB;
+}

--- a/views/components/block_timeline.tpl
+++ b/views/components/block_timeline.tpl
@@ -1,4 +1,6 @@
 
+% from datetime import timedelta
+
 % from models.date import Date
 % from models.time import Time
 
@@ -38,6 +40,19 @@
             <div class="now" style="left: {{ offset_percentage }}%;">
                 
             </div>
+        % end
+    </div>
+    <div class="timespan">
+        % clock_time = Time(start_time.hour, 0, 0, start_time.timezone)
+        % while clock_time <= end_time:
+            % if clock_time >= start_time:
+                % offset_minutes = clock_time.get_minutes() - start_time.get_minutes()
+                % offset_percentage = (offset_minutes / total_minutes) * 100
+                <div class="time {{ 'hour' if clock_time.minute == 0 else '' }}" style="left: {{ offset_percentage }}%;">
+                    
+                </div>
+            % end
+            % clock_time += timedelta(minutes=15)
         % end
     </div>
 </div>

--- a/views/components/block_timeline.tpl
+++ b/views/components/block_timeline.tpl
@@ -43,7 +43,7 @@
         % end
     </div>
     <div class="timespan">
-        % clock_time = Time(start_time.hour, 0, 0, start_time.timezone)
+        % clock_time = Time(start_time.hour, 0, None, start_time.timezone)
         % while clock_time <= end_time:
             % if clock_time >= start_time:
                 % offset_minutes = clock_time.get_minutes() - start_time.get_minutes()


### PR DESCRIPTION
Added `timespan` to `block_timeline` component:
- Sits below main timeline
- Displays small ticks every 15 minutes with a large tick on the hour, aligned with the block timeline above it

![Screenshot from 2024-08-27 20-58-00](https://github.com/user-attachments/assets/3bbc20be-a304-4ba3-86b0-e75fa787a5a2)
![Screenshot from 2024-08-27 20-57-32](https://github.com/user-attachments/assets/00c39cba-4420-4a41-9391-04eb7b158be9)
![Screenshot from 2024-08-27 20-57-15](https://github.com/user-attachments/assets/c12b7ae7-6243-4892-bb8c-0c9423be39f2)
![Screenshot from 2024-08-27 20-56-59](https://github.com/user-attachments/assets/3ad46a94-e6dd-4e9a-9670-f38cb6417077)
