### PR TITLE
Reorder stop/route columns

### DIFF
--- a/views/pages/route/overview.tpl
+++ b/views/pages/route/overview.tpl
@@ -166,14 +166,14 @@
                                                 <tr>
                                                     <th class="non-mobile">Start Time</th>
                                                     <th class="mobile-only">Start</th>
-                                                    % if not system or system.realtime_enabled:
-                                                        <th>Bus</th>
-                                                        <th class="desktop-only">Model</th>
-                                                    % end
                                                     <th class="desktop-only">Headsign</th>
                                                     <th class="non-mobile">Block</th>
                                                     <th>Trip</th>
                                                     <th class="desktop-only">First Stop</th>
+                                                    % if not system or system.realtime_enabled:
+                                                        <th>Bus</th>
+                                                        <th class="desktop-only">Model</th>
+                                                    % end
                                                 </tr>
                                             </thead>
                                             <tbody>
@@ -186,6 +186,23 @@
                                                     % end
                                                     <tr class="{{'divider' if this_hour > last_hour else ''}}">
                                                         <td>{{ trip.start_time.format_web(time_format) }}</td>
+                                                        <td class="desktop-only">
+                                                            % include('components/headsign')
+                                                        </td>
+                                                        <td class="non-mobile">
+                                                            <a href="{{ get_url(trip.block.system, f'blocks/{trip.block.id}') }}">{{ trip.block.id }}</a>
+                                                        </td>
+                                                        <td>
+                                                            <div class="column">
+                                                                % include('components/trip')
+                                                                <span class="non-desktop smaller-font">
+                                                                    % include('components/headsign')
+                                                                </span>
+                                                            </div>
+                                                        </td>
+                                                        <td class="desktop-only">
+                                                            <a href="{{ get_url(first_stop.system, f'stops/{first_stop.number}') }}">{{ first_stop }}</a>
+                                                        </td>
                                                         % if not system or system.realtime_enabled:
                                                             % if trip.id in recorded_today:
                                                                 % bus = recorded_today[trip.id]
@@ -231,23 +248,6 @@
                                                                 <td class="non-desktop lighter-text">Unavailable</td>
                                                             % end
                                                         % end
-                                                        <td class="desktop-only">
-                                                            % include('components/headsign')
-                                                        </td>
-                                                        <td class="non-mobile">
-                                                            <a href="{{ get_url(trip.block.system, f'blocks/{trip.block.id}') }}">{{ trip.block.id }}</a>
-                                                        </td>
-                                                        <td>
-                                                            <div class="column">
-                                                                % include('components/trip')
-                                                                <span class="non-desktop smaller-font">
-                                                                    % include('components/headsign')
-                                                                </span>
-                                                            </div>
-                                                        </td>
-                                                        <td class="desktop-only">
-                                                            <a href="{{ get_url(first_stop.system, f'stops/{first_stop.number}') }}">{{ first_stop }}</a>
-                                                        </td>
                                                     </tr>
                                                     % if this_hour > last_hour:
                                                         % last_hour = this_hour

--- a/views/pages/stop/overview.tpl
+++ b/views/pages/stop/overview.tpl
@@ -138,13 +138,13 @@
                             <thead>
                                 <tr>
                                     <th>Time</th>
+                                    <th class="non-mobile">Headsign</th>
+                                    <th class="desktop-only">Block</th>
+                                    <th>Trip</th>
                                     % if not system or system.realtime_enabled:
                                         <th>Bus</th>
                                         <th class="desktop-only">Model</th>
                                     % end
-                                    <th class="non-mobile">Headsign</th>
-                                    <th class="desktop-only">Block</th>
-                                    <th>Trip</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -192,13 +192,13 @@
                         <thead>
                             <tr>
                                 <th>Time</th>
+                                <th class="non-mobile">Headsign</th>
+                                <th class="desktop-only">Block</th>
+                                <th>Trip</th>
                                 % if not system or system.realtime_enabled:
                                     <th>Bus</th>
                                     <th class="desktop-only">Model</th>
                                 % end
-                                <th class="non-mobile">Headsign</th>
-                                <th class="desktop-only">Block</th>
-                                <th>Trip</th>
                             </tr>
                         </thead>
                         <tbody>

--- a/views/rows/departure.tpl
+++ b/views/rows/departure.tpl
@@ -33,6 +33,42 @@
             {{ departure.time.format_web(time_format) }}
         % end
     </td>
+    <td class="non-mobile">
+        <div class="column">
+            % include('components/headsign')
+            % if not departure.pickup_type.is_normal:
+                <span class="smaller-font italics">{{ departure.pickup_type }}</span>
+            % elif departure == trip.last_departure:
+                <span class="smaller-font italics">No pick up</span>
+            % end
+            % if not departure.dropoff_type.is_normal:
+                <span class="smaller-font italics">{{ departure.dropoff_type }}</span>
+            % end
+        </div>
+    </td>
+    <td class="desktop-only">
+        % if block:
+            <a href="{{ get_url(block.system, f'blocks/{block.id}') }}">{{ block.id }}</a>
+        % else:
+            <span class="lighter-text">Loading</span>
+        % end
+    </td>
+    <td>
+        <div class="column">
+            % include('components/trip')
+            <span class="mobile-only smaller-font">
+                % include('components/headsign')
+            </span>
+            % if not departure.pickup_type.is_normal:
+                <span class="mobile-only smaller-font italics">{{ departure.pickup_type }}</span>
+            % elif departure == trip.last_departure:
+                <span class="mobile-only smaller-font italics">No pick up</span>
+            % end
+            % if not departure.dropoff_type.is_normal:
+                <span class="mobile-only smaller-font italics">{{ departure.dropoff_type }}</span>
+            % end
+        </div>
+    </td>
     % if not system or system.realtime_enabled:
         % if trip.id in recorded_today:
             % bus = recorded_today[trip.id]
@@ -78,40 +114,4 @@
             <td class="non-desktop lighter-text">Unavailable</td>
         % end
     % end
-    <td class="non-mobile">
-        <div class="column">
-            % include('components/headsign')
-            % if not departure.pickup_type.is_normal:
-                <span class="smaller-font italics">{{ departure.pickup_type }}</span>
-            % elif departure == trip.last_departure:
-                <span class="smaller-font italics">No pick up</span>
-            % end
-            % if not departure.dropoff_type.is_normal:
-                <span class="smaller-font italics">{{ departure.dropoff_type }}</span>
-            % end
-        </div>
-    </td>
-    <td class="desktop-only">
-        % if block:
-            <a href="{{ get_url(block.system, f'blocks/{block.id}') }}">{{ block.id }}</a>
-        % else:
-            <span class="lighter-text">Loading</span>
-        % end
-    </td>
-    <td>
-        <div class="column">
-            % include('components/trip')
-            <span class="mobile-only smaller-font">
-                % include('components/headsign')
-            </span>
-            % if not departure.pickup_type.is_normal:
-                <span class="mobile-only smaller-font italics">{{ departure.pickup_type }}</span>
-            % elif departure == trip.last_departure:
-                <span class="mobile-only smaller-font italics">No pick up</span>
-            % end
-            % if not departure.dropoff_type.is_normal:
-                <span class="mobile-only smaller-font italics">{{ departure.dropoff_type }}</span>
-            % end
-        </div>
-    </td>
 </tr>


### PR DESCRIPTION
Moves headsign/block/trip info to before the bus/model info in stop and route overview pages