### PR TITLE
Timestamp cleanup

### DIFF
--- a/models/system.py
+++ b/models/system.py
@@ -43,7 +43,7 @@ class System:
     @property
     def realtime_loaded(self):
         '''Checks if realtime data has been loaded'''
-        return self.last_updated
+        return self.last_updated is not None
     
     @property
     def gtfs_enabled(self):

--- a/models/system.py
+++ b/models/system.py
@@ -26,8 +26,7 @@ class System:
         'colour_routes',
         'gtfs_loaded',
         'validation_errors',
-        'last_updated_date',
-        'last_updated_time',
+        'last_updated',
         'blocks',
         'routes',
         'routes_by_number',
@@ -44,7 +43,7 @@ class System:
     @property
     def realtime_loaded(self):
         '''Checks if realtime data has been loaded'''
-        return self.last_updated_date and self.last_updated_time
+        return self.last_updated
     
     @property
     def gtfs_enabled(self):
@@ -92,8 +91,7 @@ class System:
         
         self.gtfs_loaded = False
         self.validation_errors = 0
-        self.last_updated_date = None
-        self.last_updated_time = None
+        self.last_updated = None
         
         self.blocks = {}
         self.routes = {}
@@ -195,16 +193,6 @@ class System:
     def get_trips(self):
         '''Returns all trips'''
         return self.trips.values()
-    
-    def get_last_updated(self, time_format):
-        '''Returns the date/time that realtime data was last updated'''
-        date = self.last_updated_date
-        time = self.last_updated_time
-        if not date or not time:
-            return 'N/A'
-        if date.is_today:
-            return f'at {time.format_web(time_format)} {time.timezone_name}'
-        return date.format_since()
     
     def search_blocks(self, query):
         '''Returns all blocks that match the given query'''

--- a/models/timestamp.py
+++ b/models/timestamp.py
@@ -9,22 +9,23 @@ class Timestamp:
     
     __slots__ = (
         'value',
-        'timezone'
+        'timezone',
+        'accurate_seconds'
     )
     
     @classmethod
-    def now(cls, timezone=None):
+    def now(cls, timezone=None, accurate_seconds=True):
         '''Returns the current timestamp'''
-        return cls(datetime.now().timestamp(), timezone)
+        return cls.parse(datetime.now().timestamp(), timezone, accurate_seconds)
     
     @classmethod
-    def parse(cls, value, timezone=None):
+    def parse(cls, value, timezone=None, accurate_seconds=True):
         '''Returns a timestamp with the given value'''
         if not value:
             return None
         if not timezone:
             timezone = pytz.timezone('America/Vancouver')
-        return cls(value, timezone)
+        return cls(value, timezone, accurate_seconds)
     
     @property
     def datetime(self):
@@ -39,7 +40,7 @@ class Timestamp:
     @property
     def time(self):
         '''Returns the time of this timestamp'''
-        return Time.fromdatetime(self.datetime, self.timezone)
+        return Time.fromdatetime(self.datetime, self.timezone, self.accurate_seconds)
     
     @property
     def is_earlier(self):
@@ -66,9 +67,10 @@ class Timestamp:
         '''Returns the name of this timestamp's timezone'''
         return datetime.now(self.timezone).tzname()
     
-    def __init__(self, value, timezone):
+    def __init__(self, value, timezone, accurate_seconds):
         self.value = value
         self.timezone = timezone
+        self.accurate_seconds = accurate_seconds
     
     def __str__(self):
         date = self.date
@@ -107,3 +109,10 @@ class Timestamp:
     
     def __sub__(self, value):
         self.value -= value
+    
+    def format_web(self, time_format='30hr'):
+        '''Formats this timestamp for web display'''
+        date = self.date
+        if date.is_today:
+            return f'at {self.time.format_web(time_format)} {self.time.timezone_name}'
+        return date.format_since()

--- a/server.py
+++ b/server.py
@@ -225,12 +225,12 @@ class Server(Bottle):
         bus_marker_style = self.query_cookie('bus_marker_style')
         hide_systems = self.query_cookie('hide_systems') == 'yes'
         if system:
-            last_updated = system.get_last_updated(time_format)
+            last_updated = system.last_updated
             today = Date.today(system.timezone)
             now = Time.now(system.timezone, False)
             timestamp = Timestamp.now(system.timezone)
         else:
-            last_updated = self.realtime_service.get_last_updated(time_format)
+            last_updated = self.realtime_service.get_last_updated()
             today = Date.today()
             now = Time.now()
             timestamp = Timestamp.now()
@@ -1229,15 +1229,19 @@ class Server(Bottle):
         return 'Online'
     
     def api_map(self, system, agency):
-        time_format = request.get_cookie('time_format')
         if system:
-            last_updated = system.get_last_updated(time_format)
+            last_updated = system.last_updated
         else:
-            last_updated = self.realtime_service.get_last_updated(time_format)
+            last_updated = self.realtime_service.get_last_updated()
+        if last_updated:
+            time_format = request.get_cookie('time_format')
+            last_updated_text = last_updated.format_web(time_format)
+        else:
+            last_updated_text = None
         positions = sorted(self.position_repository.find_all(system, has_location=True), key=lambda p: p.lat)
         return {
             'positions': [p.get_json() for p in positions],
-            'last_updated': last_updated
+            'last_updated': last_updated_text
         }
     
     def api_shape(self, system, agency, shape_id):

--- a/services/realtime.py
+++ b/services/realtime.py
@@ -1,6 +1,10 @@
 
 from __future__ import annotations
+from typing import TYPE_CHECKING
 from abc import ABC, abstractmethod
+
+if TYPE_CHECKING:
+    from models.timestamp import Timestamp
 
 class RealtimeService(ABC):
     
@@ -13,7 +17,7 @@ class RealtimeService(ABC):
         raise NotImplementedError()
     
     @abstractmethod
-    def get_last_updated(self, time_format) -> str | None:
+    def get_last_updated(self, time_format) -> Timestamp | None:
         raise NotImplementedError()
     
     @abstractmethod

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -204,6 +204,7 @@
             }
             
             const timestampOffset = getTimestampOffset();
+            const updateTimestampFunctions = [];
             
             function getDifference(t1, t2) {
                 let difference = t1 - t2;
@@ -351,11 +352,9 @@
                             All Transit Systems
                         % end
                     </div>
-                    <div id="last-updated">
-                        % if not system or (system.realtime_enabled and system.realtime_loaded):
-                            Updated {{ last_updated }}
-                        % end
-                    </div>
+                    % if last_updated:
+                        <div id="last-updated">Updated {{ last_updated.format_web(time_format) }}</div>
+                    % end
                 </div>
                 <div id="refresh-button" class="disabled">
                     % include('components/svg', name='refresh')
@@ -773,5 +772,17 @@
         if ("map" in window) {
             map.updateSize();
         }
+    }
+    
+    function updateAllTimestamps() {
+        const currentTime = new Date().getTime();
+        for (const func of updateTimestampFunctions) {
+            func(currentTime);
+        }
+    }
+    
+    if (updateTimestampFunctions.length > 0) {
+        updateAllTimestamps();
+        setInterval(updateAllTimestamps, 1000)
     }
 </script>

--- a/views/components/map.tpl
+++ b/views/components/map.tpl
@@ -89,8 +89,6 @@
         const positions = JSON.parse('{{! json.dumps([p.get_json() for p in map_positions]) }}');
         const busMarkerStyle = "{{ bus_marker_style }}";
         
-        const updateTimestamps = [];
-        
         for (const position of positions) {
             const adherence = position.adherence;
             
@@ -183,13 +181,10 @@
                 }
                 const timestamp = document.createElement("span");
                 footer.appendChild(timestamp);
-                function updateTimestamp() {
-                    const currentTime = new Date().getTime();
+                updateTimestampFunctions.push(function(currentTime) {
                     const difference = getDifference(currentTime, (position.timestamp * 1000) + timestampOffset);
                     timestamp.innerHTML = difference;
-                }
-                updateTimestamp();
-                updateTimestamps.push(updateTimestamp);
+                });
             }
             content.appendChild(footer);
             
@@ -280,12 +275,6 @@
                 area.combine(position.lat, position.lon);
             }
         }
-        
-        setInterval(function() {
-            for (updateTimestamp of updateTimestamps) {
-                updateTimestamp();
-            }
-        }, 1000);
     </script>
 % end
 

--- a/views/pages/bus/overview.tpl
+++ b/views/pages/bus/overview.tpl
@@ -8,6 +8,12 @@
 
 % model = bus.model
 
+% if position and position.timestamp:
+    <script>
+        const originalTimestamp = parseFloat("{{ position.timestamp.value }}") * 1000;
+    </script>
+% end
+
 <div id="page-header">
     <h1 class="row">
         <span>Bus</span>
@@ -89,17 +95,10 @@
                                 <div class="name">Last Update</div>
                                 <div id="timestamp"></div>
                                 <script>
-                                    const originalTimestamp = parseFloat("{{ position.timestamp.value }}") * 1000;
-                                    
-                                    function updateTimestamp() {
-                                        const currentTime = new Date().getTime();
+                                    updateTimestampFunctions.push(function(currentTime) {
                                         const difference = getDifference(currentTime, originalTimestamp + timestampOffset);
                                         document.getElementById("timestamp").innerHTML = difference;
-                                    }
-                                    
-                                    updateTimestamp();
-                                    
-                                    setInterval(updateTimestamp, 1000);
+                                    });
                                 </script>
                             </div>
                         % end
@@ -155,17 +154,10 @@
                                 <div class="value">
                                     <div id="timestamp"></div>
                                     <script>
-                                        const originalTimestamp = parseFloat("{{ position.timestamp.value }}") * 1000;
-                                        
-                                        function updateTimestamp() {
-                                            const currentTime = new Date().getTime();
+                                        updateTimestampFunctions.push(function(currentTime) {
                                             const difference = getDifference(currentTime, originalTimestamp + timestampOffset);
                                             document.getElementById("timestamp").innerHTML = difference;
-                                        }
-                                        
-                                        updateTimestamp();
-                                        
-                                        setInterval(updateTimestamp, 1000);
+                                        });
                                     </script>
                                 </div>
                             </div>

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -68,8 +68,6 @@
         
         const shapes = {};
         
-        const updateTimestamps = [];
-        
         document.body.onload = function() {
             map.updateSize();
         }
@@ -193,13 +191,10 @@
                     }
                     const timestamp = document.createElement("span");
                     footer.appendChild(timestamp);
-                    function updateTimestamp() {
-                        const currentTime = new Date().getTime();
+                    updateTimestampFunctions.push(function(currentTime) {
                         const difference = getDifference(currentTime, (position.timestamp * 1000) + timestampOffset);
                         timestamp.innerHTML = difference;
-                    }
-                    updateTimestamp();
-                    updateTimestamps.push(updateTimestamp);
+                    });
                 }
                 content.appendChild(footer);
                 
@@ -505,12 +500,6 @@
                 }
             }, 1000 * 60);
         }, 1000 * (timeToNextUpdate + 15));
-        
-        setInterval(function() {
-            for (updateTimestamp of updateTimestamps) {
-                updateTimestamp();
-            }
-        }, 1000);
     </script>
 
     % include('components/map_toggle')


### PR DESCRIPTION
- Systems and realtime service now store just `last_updated` as a timestamp, rather than separate `last_updated_date` and `last_updated_time`
- Timestamps now have a `format_web` function
- Logic and intervals for updating timestamps has been extracted to the base html file
  - Individual pages/templates can push new functions to the `updateTimestampFunctions` array
  - Interval will only be started if there are functions in that array