### PR TITLE
Map bus icon improvements

### DIFF
--- a/models/position.py
+++ b/models/position.py
@@ -157,8 +157,6 @@ class Position:
         else:
             data['bus_order'] = 'Unknown Year/Model'
             data['bus_icon'] = 'ghost'
-        if self.lon == 0 and self.lat == 0:
-            data['bus_icon'] = 'fish'
         adornment = self.bus.find_adornment()
         if adornment and adornment.enabled:
             data['adornment'] = str(adornment)

--- a/views/components/map.tpl
+++ b/views/components/map.tpl
@@ -119,15 +119,81 @@
                 element.appendChild(bearing)
             }
             
+            let icon;
+            if (position.bus_number < 0) {
+                icon = document.createElement("div");
+            } else {
+                icon = document.createElement("a");
+                icon.href = "/bus/" + position.bus_number;
+                icon.innerHTML = "<div class='link'></div>";
+            }
+            icon.className = "icon";
+            element.appendChild(icon);
+            
+            if (busMarkerStyle === "route") {
+                icon.classList.add("bus_route");
+                if (position.lat === 0 && position.lon === 0) {
+                    icon.innerHTML += getSVG("fish");
+                } else {
+                    icon.innerHTML += position.route_number;
+                }
+                icon.style.backgroundColor = "#" + position.colour;
+            } else if (busMarkerStyle === "mini") {
+                element.classList.add("small");
+                icon.classList.add("mini");
+                icon.style.backgroundColor = "#" + position.colour;
+            } else if (busMarkerStyle === "adherence") {
+                icon.classList.add("adherence");
+                if (adherence === undefined || adherence === null) {
+                    if (position.lat === 0 && position.lon === 0) {
+                        icon.innerHTML += getSVG("fish");
+                    } else {
+                        icon.innerHTML += "N/A";
+                    }
+                } else {
+                    if (position.lat === 0 && position.lon === 0) {
+                        icon.innerHTML += getSVG("fish");
+                    } else {
+                        icon.innerHTML += adherence.value;
+                    }
+                    icon.classList.add(adherence.status_class);
+                    const adherenceValue = parseInt(adherence.value);
+                    if (adherenceValue >= 100 || adherenceValue <= -100) {
+                        icon.classList.add("smaller-font");
+                    }
+                }
+            } else if (busMarkerStyle === "occupancy") {
+                icon.classList.add("occupancy");
+                icon.classList.add(position.occupancy_status_class);
+                if (position.lat === 0 && position.lon === 0) {
+                    icon.innerHTML += getSVG("fish");
+                } else {
+                    icon.innerHTML += getSVG(position.occupancy_icon);
+                }
+            } else {
+                if (position.lat === 0 && position.lon === 0) {
+                    icon.innerHTML += getSVG("fish");
+                } else {
+                    icon.innerHTML += getSVG(position.bus_icon);
+                }
+                icon.style.backgroundColor = "#" + position.colour;
+            }
+            
             const details = document.createElement("div");
             details.className = "details";
+            element.appendChild(details);
             
             const title = document.createElement("div");
             title.className = "title";
             title.innerHTML = position.bus_display;
+            if (position.adornment != null) {
+                title.innerHTML += " <span class='adornment'>" + position.adornment + "</span>";
+            }
+            details.appendChild(title);
             
             const content = document.createElement("div");
             content.className = "content hover-only";
+            details.appendChild(content);
             
             const model = document.createElement("div");
             model.className = "lighter-text centred";
@@ -187,82 +253,6 @@
                 });
             }
             content.appendChild(footer);
-            
-            if (position.bus_number < 0) {
-                const icon = document.createElement("div");
-                icon.className = "icon";
-                if (busMarkerStyle == "route") {
-                    icon.classList.add("bus_route");
-                    icon.innerHTML = position.route_number;
-                    icon.style.backgroundColor = "#" + position.colour;
-                } else if (busMarkerStyle == "mini") {
-                    element.classList.add("small");
-                    icon.classList.add("mini");
-                    icon.style.backgroundColor = "#" + position.colour;
-                } else if (busMarkerStyle == "adherence") {
-                    icon.classList.add("adherence");
-                    if (adherence === undefined || adherence === null) {
-                        icon.innerHTML = "N/A";
-                    } else {
-                        icon.innerHTML = adherence.value;
-                        icon.classList.add(adherence.status_class);
-                        const adherenceValue = parseInt(adherence.value);
-                        if (adherenceValue >= 100 || adherenceValue <= -100) {
-                            icon.classList.add("smaller-font");
-                        }
-                    }
-                } else if (busMarkerStyle == "occupancy") {
-                    icon.classList.add("occupancy");
-                    icon.classList.add(position.occupancy_status_class);
-                    icon.innerHTML = getSVG(position.occupancy_icon);
-                } else {
-                    icon.innerHTML = getSVG(position.bus_icon);
-                    icon.style.backgroundColor = "#" + position.colour;
-                }
-                element.appendChild(icon);
-            } else {
-                const icon = document.createElement("a");
-                icon.className = "icon";
-                icon.href = "/bus/" + position.bus_number;
-                if (busMarkerStyle == "route") {
-                    icon.classList.add("bus_route");
-                    icon.innerHTML = "<div class='link'></div>" + position.route_number;
-                    icon.style.backgroundColor = "#" + position.colour;
-                } else if (busMarkerStyle == "mini") {
-                    element.classList.add("small");
-                    icon.classList.add("mini");
-                    icon.innerHTML = "<div class='link'></div>";
-                    icon.style.backgroundColor = "#" + position.colour;
-                } else if (busMarkerStyle == "adherence") {
-                    icon.classList.add("adherence");
-                    if (adherence === undefined || adherence === null) {
-                        icon.innerHTML = "<div class='link'></div>N/A";
-                    } else {
-                        icon.innerHTML = "<div class='link'></div>" + adherence.value;
-                        icon.classList.add(adherence.status_class);
-                        const adherenceValue = parseInt(adherence.value);
-                        if (adherenceValue >= 100 || adherenceValue <= -100) {
-                            icon.classList.add("smaller-font");
-                        }
-                    }
-                } else if (busMarkerStyle == "occupancy") {
-                    icon.classList.add("occupancy");
-                    icon.classList.add(position.occupancy_status_class);
-                    icon.innerHTML = "<div class='link'></div>" + getSVG(position.occupancy_icon);
-                } else {
-                    icon.innerHTML = "<div class='link'></div>" + getSVG(position.bus_icon);
-                    icon.style.backgroundColor = "#" + position.colour;
-                }
-                element.appendChild(icon);
-            }
-            
-            if (position.adornment != null) {
-                title.innerHTML += " <span class='adornment'>" + position.adornment + "</span>";
-            }
-            
-            details.appendChild(title);
-            details.appendChild(content);
-            element.appendChild(details);
             
             map.addOverlay(new ol.Overlay({
                 position: ol.proj.fromLonLat([position.lon, position.lat]),

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -130,15 +130,87 @@
                     element.appendChild(bearing)
                 }
                 
+                let icon;
+                if (position.bus_number < 0) {
+                    icon = document.createElement("div");
+                } else {
+                    icon = document.createElement("a");
+                    icon.href = "/bus/" + position.bus_number;
+                    icon.innerHTML = "<div class='link'></div>"
+                }
+                icon.className = "icon";
+                icon.onmouseenter = function() {
+                    setHoverPosition(position);
+                }
+                icon.onmouseleave = function() {
+                    setHoverPosition(null);
+                }
+                element.appendChild(icon);
+                
+                if (busMarkerStyle === "route") {
+                    icon.classList.add("bus_route");
+                    if (position.lat === 0 && position.lon === 0) {
+                        icon.innerHTML += getSVG("fish");
+                    } else {
+                        icon.innerHTML += position.route_number;
+                    }
+                    icon.style.backgroundColor = "#" + position.colour;
+                } else if (busMarkerStyle === "mini") {
+                    element.classList.add("small");
+                    icon.classList.add("mini");
+                    icon.style.backgroundColor = "#" + position.colour;
+                } else if (busMarkerStyle === "adherence") {
+                    icon.classList.add("adherence");
+                    if (adherence === undefined || adherence === null) {
+                        if (position.lat === 0 && position.lon === 0) {
+                            icon.innerHTML += getSVG("fish");
+                        } else {
+                            icon.innerHTML += "N/A";
+                        }
+                    } else {
+                        if (position.lat === 0 && position.lon === 0) {
+                            icon.innerHTML += getSVG("fish");
+                        } else {
+                            icon.innerHTML += adherence.value;
+                        }
+                        icon.classList.add(adherence.status_class);
+                        const adherenceValue = parseInt(adherence.value);
+                        if (adherenceValue >= 100 || adherenceValue <= -100) {
+                            icon.classList.add("smaller-font");
+                        }
+                    }
+                } else if (busMarkerStyle === "occupancy") {
+                    icon.classList.add("occupancy");
+                    icon.classList.add(position.occupancy_status_class);
+                    if (position.lat === 0 && position.lon === 0) {
+                        icon.innerHTML += getSVG("fish");
+                    } else {
+                        icon.innerHTML += getSVG(position.occupancy_icon);
+                    }
+                } else {
+                    if (position.lat === 0 && position.lon === 0) {
+                        icon.innerHTML += getSVG("fish");
+                    } else {
+                        icon.innerHTML += getSVG(position.bus_icon);
+                    }
+                    icon.style.backgroundColor = "#" + position.colour;
+                }
+                
                 const details = document.createElement("div");
                 details.className = "details";
+                element.appendChild(details);
                 
                 const title = document.createElement("div");
                 title.className = "title";
                 title.innerHTML = position.bus_display;
+                if (position.adornment != null) {
+                    title.innerHTML += " <span class='adornment'>" + position.adornment + "</span>";
+                }
+                details.appendChild(title);
                 
                 const content = document.createElement("div");
                 content.className = "content hover-only";
+                details.appendChild(content);
                 
                 const model = document.createElement("div");
                 model.className = "lighter-text centred";
@@ -197,96 +269,6 @@
                     });
                 }
                 content.appendChild(footer);
-                
-                if (position.bus_number < 0) {
-                    const icon = document.createElement("div");
-                    icon.className = "icon";
-                    if (busMarkerStyle == "route") {
-                        icon.classList.add("bus_route");
-                        icon.innerHTML = position.route_number;
-                        icon.style.backgroundColor = "#" + position.colour;
-                    } else if (busMarkerStyle == "mini") {
-                        element.classList.add("small");
-                        icon.classList.add("mini");
-                        icon.style.backgroundColor = "#" + position.colour;
-                    } else if (busMarkerStyle == "adherence") {
-                        icon.classList.add("adherence");
-                        if (adherence === undefined || adherence === null) {
-                            icon.innerHTML = "N/A";
-                        } else {
-                            icon.innerHTML = adherence.value;
-                            icon.classList.add(adherence.status_class);
-                            const adherenceValue = parseInt(adherence.value);
-                            if (adherenceValue >= 100 || adherenceValue <= -100) {
-                                icon.classList.add("smaller-font");
-                            }
-                        }
-                    } else if (busMarkerStyle == "occupancy") {
-                        icon.classList.add("occupancy");
-                        icon.classList.add(position.occupancy_status_class);
-                        icon.innerHTML = getSVG(position.occupancy_icon);
-                    } else {
-                        icon.innerHTML = getSVG(position.bus_icon);
-                        icon.style.backgroundColor = "#" + position.colour;
-                    }
-                    
-                    icon.onmouseenter = function() {
-                        setHoverPosition(position);
-                    }
-                    icon.onmouseleave = function() {
-                        setHoverPosition(null);
-                    }
-                    element.appendChild(icon);
-                } else {
-                    const icon = document.createElement("a");
-                    icon.className = "icon";
-                    icon.href = "/bus/" + position.bus_number;
-                    if (busMarkerStyle == "route") {
-                        icon.classList.add("bus_route");
-                        icon.innerHTML = "<div class='link'></div>" + position.route_number;
-                        icon.style.backgroundColor = "#" + position.colour;
-                    } else if (busMarkerStyle == "mini") {
-                        element.classList.add("small");
-                        icon.classList.add("mini");
-                        icon.innerHTML = "<div class='link'></div>";
-                        icon.style.backgroundColor = "#" + position.colour;
-                    } else if (busMarkerStyle == "adherence") {
-                        icon.classList.add("adherence");
-                        if (adherence === undefined || adherence === null) {
-                            icon.innerHTML = "<div class='link'></div>N/A";
-                        } else {
-                            icon.innerHTML = "<div class='link'></div>" + adherence.value;
-                            icon.classList.add(adherence.status_class);
-                            const adherenceValue = parseInt(adherence.value);
-                            if (adherenceValue >= 100 || adherenceValue <= -100) {
-                                icon.classList.add("smaller-font");
-                            }
-                        }
-                    } else if (busMarkerStyle == "occupancy") {
-                        icon.classList.add("occupancy");
-                        icon.classList.add(position.occupancy_status_class);
-                        icon.innerHTML = "<div class='link'></div>" + getSVG(position.occupancy_icon);
-                    } else {
-                        icon.innerHTML = "<div class='link'></div>" + getSVG(position.bus_icon);
-                        icon.style.backgroundColor = "#" + position.colour;
-                    }
-                    
-                    icon.onmouseenter = function() {
-                        setHoverPosition(position);
-                    }
-                    icon.onmouseleave = function() {
-                        setHoverPosition(null);
-                    }
-                    element.appendChild(icon);
-                }
-                
-                if (position.adornment != null) {
-                    title.innerHTML += " <span class='adornment'>" + position.adornment + "</span>";
-                }
-                
-                details.appendChild(title);
-                details.appendChild(content);
-                element.appendChild(details);
                 
                 if (position.lat != 0 && position.lon != 0) {
                     area.combine(position.lat, position.lon);


### PR DESCRIPTION
- Code order when creating bus markers is updated to reflect the UI layout (ie making the icon above the text details)
- Icon logic is simplified to reduce duplicate code between known and unknown buses
- The fish icon easter egg is now applied to all marker types, not just default (except for mini, which still has no icon)
- All the above changes are done for both the main map and map components - ideally I'd like to unify this logic eventually but that can be done later