### PR TITLE
Stops filtering/sorting

### DIFF
--- a/models/date.py
+++ b/models/date.py
@@ -27,7 +27,9 @@ class Date:
     @classmethod
     def today(cls, timezone=None):
         '''Returns the current date'''
-        return cls.fromdatetime(datetime.now(), timezone)
+        if not timezone:
+            timezone = pytz.timezone('America/Vancouver')
+        return cls.fromdatetime(datetime.now(timezone), timezone)
     
     @classmethod
     def fromdatetime(cls, datetime, timezone=None):

--- a/models/time.py
+++ b/models/time.py
@@ -32,7 +32,9 @@ class Time:
     @classmethod
     def now(cls, timezone=None, accurate_seconds=True):
         '''Returns the current time'''
-        return cls.fromdatetime(datetime.now(), timezone, accurate_seconds)
+        if not timezone:
+            timezone = pytz.timezone('America/Vancouver')
+        return cls.fromdatetime(datetime.now(timezone), timezone, accurate_seconds)
     
     @classmethod
     def fromdatetime(cls, datetime, timezone=None, accurate_seconds=True):

--- a/models/timestamp.py
+++ b/models/timestamp.py
@@ -16,7 +16,9 @@ class Timestamp:
     @classmethod
     def now(cls, timezone=None, accurate_seconds=True):
         '''Returns the current timestamp'''
-        return cls.parse(datetime.now().timestamp(), timezone, accurate_seconds)
+        if not timezone:
+            timezone = pytz.timezone('America/Vancouver')
+        return cls.parse(datetime.now(timezone).timestamp(), timezone, accurate_seconds)
     
     @classmethod
     def parse(cls, value, timezone=None, accurate_seconds=True):

--- a/style/devices/mobile.css
+++ b/style/devices/mobile.css
@@ -30,6 +30,10 @@ button {
     width: 100%;
 }
 
+button.compact {
+    width: unset;
+}
+
 form input[type="text"] {
     font-size: 16pt;
 }

--- a/style/devices/tablet.css
+++ b/style/devices/tablet.css
@@ -223,6 +223,10 @@ table {
     display: block;
 }
 
+button.compact {
+    width: unset;
+}
+
 .container > .section > .header > .toggle {
     --image-size: 28px;
 }

--- a/style/main.css
+++ b/style/main.css
@@ -735,9 +735,16 @@ table tr.header td {
 }
 
 .info-box {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
     padding: 10px;
     border-width: 1px;
     border-style: solid;
+}
+
+.info-box.columns {
+    flex-direction: row;
 }
 
 .info-box > .title {
@@ -749,16 +756,27 @@ table tr.header td {
 }
 
 .info-box > .section {
+    border-width: 0px;
     border-bottom-width: 1px;
-    border-bottom-style: solid;
+    border-style: solid;
     padding-bottom: 10px;
-    margin-bottom: 10px;
 }
 
 .info-box > .section:last-child {
     border-bottom-width: 0px;
     padding-bottom: 0px;
-    margin-bottom: 0px;
+}
+
+.info-box.columns > .section {
+    border-bottom-width: 0px;
+    border-right-width: 1px;
+    padding-bottom: 0px;
+    padding-right: 10px;
+}
+
+.info-box.columns > .section:last-child {
+    border-right-width: 0px;
+    padding-right: 0px;
 }
 
 .info-box > .section.column {
@@ -1043,6 +1061,11 @@ table tr.header td {
     border-radius: 10px;
 }
 
+.option.space-between {
+    align-self: stretch;
+    justify-content: space-between;
+}
+
 .option .checkbox {
     border: 2px solid var(--checkbox-color);
     border-radius: 5px;
@@ -1053,11 +1076,11 @@ table tr.header td {
 }
 
 .option .checkbox svg {
-    display: none;
+    opacity: 0;
 }
 
 .option .checkbox.selected svg {
-    display: initial;
+    opacity: 1;
 }
 
 .option .radio-button {

--- a/style/themes/bc-hydro.css
+++ b/style/themes/bc-hydro.css
@@ -136,6 +136,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-menu .menu-button.disabled {
     color: #ABABAB;
+    --image-color: #ABABAB;
 }
 
 #navigation-menu-toggle .line {

--- a/style/themes/bc-hydro.css
+++ b/style/themes/bc-hydro.css
@@ -365,7 +365,7 @@ table tr:nth-child(2n-1) {
 }
 
 .info-box .section {
-    border-bottom-color: #CBCBCB;
+    border-color: #CBCBCB;
 }
 
 .info-box .option {

--- a/style/themes/bc-transit-classic.css
+++ b/style/themes/bc-transit-classic.css
@@ -136,6 +136,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-menu .menu-button.disabled {
     color: #ABABAB;
+    --image-color: #ABABAB;
 }
 
 #navigation-menu-toggle .line {

--- a/style/themes/bc-transit-classic.css
+++ b/style/themes/bc-transit-classic.css
@@ -365,7 +365,7 @@ table tr:nth-child(2n-1) {
 }
 
 .info-box .section {
-    border-bottom-color: #CBCBCB;
+    border-color: #CBCBCB;
 }
 
 .info-box .option {

--- a/style/themes/bc-transit.dark.css
+++ b/style/themes/bc-transit.dark.css
@@ -146,6 +146,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-menu .menu-button.disabled {
     color: #ABABAB;
+    --image-color: #ABABAB;
 }
 
 #navigation-menu-toggle .line {

--- a/style/themes/bc-transit.dark.css
+++ b/style/themes/bc-transit.dark.css
@@ -374,7 +374,7 @@ table tr:nth-child(2n-1) {
 }
 
 .info-box .section {
-    border-bottom-color: #565656;
+    border-color: #565656;
 }
 
 .info-box .option {

--- a/style/themes/bc-transit.light.css
+++ b/style/themes/bc-transit.light.css
@@ -136,6 +136,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-menu .menu-button.disabled {
     color: #ABABAB;
+    --image-color: #ABABAB;
 }
 
 #navigation-menu-toggle .line {

--- a/style/themes/bc-transit.light.css
+++ b/style/themes/bc-transit.light.css
@@ -365,7 +365,7 @@ table tr:nth-child(2n-1) {
 }
 
 .info-box .section {
-    border-bottom-color: #CBCBCB;
+    border-color: #CBCBCB;
 }
 
 .info-box .option {

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -345,7 +345,7 @@ table tr:nth-child(2n-1) {
 }
 
 .info-box .section {
-    border-bottom-color: #CBCBCB;
+    border-color: #CBCBCB;
 }
 
 .info-box .option {

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -132,6 +132,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-menu .menu-button.disabled {
     color: #ABABAB;
+    --image-color: #ABABAB;
 }
 
 #navigation-menu-toggle .line {

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -367,7 +367,7 @@ table tr:nth-child(2n-1) {
 }
 
 .info-box .section {
-    border-bottom-color: #C3E9C1;
+    border-color: #C3E9C1;
 }
 
 .info-box .option {

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -138,6 +138,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-menu .menu-button.disabled {
     color: #ABABAB;
+    --image-color: #ABABAB;
 }
 
 #navigation-menu-toggle .line {

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -133,6 +133,7 @@ table tr {
 
 #navigation-menu .menu-button.disabled {
     color: #888888;
+    --image-color: #888888;
 }
 
 #navigation-menu-toggle .line {

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -358,7 +358,7 @@ table tr {
 }
 
 .info-box .section {
-    border-bottom-color: #DDDDDD;
+    border-color: #DDDDDD;
 }
 
 .info-box .option {

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -146,6 +146,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-menu .menu-button.disabled {
     color: #ABABAB;
+    --image-color: #ABABAB;
 }
 
 #navigation-menu-toggle .line {

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -374,7 +374,7 @@ table tr:nth-child(2n-1) {
 }
 
 .info-box .section {
-    border-bottom-color: #565656;
+    border-color: #565656;
 }
 
 .info-box .option {

--- a/style/themes/pride.dark.css
+++ b/style/themes/pride.dark.css
@@ -135,6 +135,7 @@ table tr {
 
 #navigation-menu .menu-button.disabled {
     color: #ABABAB;
+    --image-color: #ABABAB;
 }
 
 #navigation-menu-toggle .line {

--- a/style/themes/pride.dark.css
+++ b/style/themes/pride.dark.css
@@ -361,7 +361,7 @@ table tr {
 }
 
 .info-box .section {
-    border-bottom-color: rgba(255, 255, 255, 0.2);
+    border-color: rgba(255, 255, 255, 0.2);
 }
 
 .info-box .option {

--- a/style/themes/pride.light.css
+++ b/style/themes/pride.light.css
@@ -360,7 +360,7 @@ table tr {
 }
 
 .info-box .section {
-    border-bottom-color: rgba(0, 0, 0, 0.2);
+    border-color: rgba(0, 0, 0, 0.2);
 }
 
 .info-box .option {

--- a/style/themes/pride.light.css
+++ b/style/themes/pride.light.css
@@ -134,6 +134,7 @@ table tr {
 
 #navigation-menu .menu-button.disabled {
     color: #ABABAB;
+    --image-color: #ABABAB;
 }
 
 #navigation-menu-toggle .line {

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -461,7 +461,7 @@ table tr {
 }
 
 .info-box .section {
-    border-bottom-color: #CBCBCB;
+    border-color: #CBCBCB;
 }
 
 .info-box .option {

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -150,6 +150,7 @@ table tr {
 
 #navigation-menu .menu-button.disabled {
     color: #666666;
+    --image-color: #666666;
 }
 
 #navigation-menu-toggle .line {

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -136,6 +136,7 @@ table tr:nth-child(2n-1) {
 
 #navigation-menu .menu-button.disabled {
     color: #ABABAB;
+    --image-color: #ABABAB;
 }
 
 #navigation-menu-toggle .line {

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -365,7 +365,7 @@ table tr:nth-child(2n-1) {
 }
 
 .info-box .section {
-    border-bottom-color: #CBCBCB;
+    border-color: #CBCBCB;
 }
 
 .info-box .option {

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -127,11 +127,22 @@
         
         <script>
             const svgs = {};
+            let systemID;        
             
             function getSVG(name) {
                 return svgs[name];
             }
         </script>
+        
+        % if system:
+            <script>
+                systemID = "{{ system.id }}";
+            </script>
+        % else:
+            <script>
+                systemID = null;
+            </script>
+        % end
         
         % include('components/svg_script', name='bus')
         % include('components/svg_script', name='bus-artic')
@@ -162,11 +173,25 @@
                 return a
             }
             
-            function getUrl(systemID, path) {
+            function getUrl(systemID, path, params=null) {
+                let url;
                 if (systemID === null || systemID === undefined) {
-                    return "{{ settings.all_systems_domain }}".format(path)
+                    url = "{{ settings.all_systems_domain }}".format(path);
+                } else {
+                    url = "{{ settings.system_domain if system else settings.system_domain_path }}".format(systemID, path);
                 }
-                return "{{ settings.system_domain if system else settings.system_domain_path }}".format(systemID, path)
+                const query = [];
+                if (params) {
+                    for (const key in params) {
+                        if (params.hasOwnProperty(key) && params[key] !== undefined && params[key] !== null) {
+                            query.push(key + "=" + params[key]);
+                        }
+                    }
+                }
+                if (query.length === 0) {
+                    return url;
+                }
+                return url + "?" + query.join("&")
             }
             
             function setCookie(key, value) {

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -276,15 +276,13 @@
                 <a class="navigation-item non-mobile" href="{{ get_url(system, 'realtime') }}">Realtime</a>
                 <a class="navigation-item desktop-only" href="{{ get_url(system, 'history') }}">History</a>
             % else:
-                <span class="navigation-item desktop-only disabled">Map</span>
-                <span class="navigation-item desktop-only disabled">Realtime</span>
-                <span class="navigation-item desktop-only disabled">History</span>
-                
-                <a class="navigation-item tablet-only" href="{{ get_url(system, 'routes') }}">Routes</a>
-                <a class="navigation-item tablet-only" href="{{ get_url(system, 'blocks') }}">Blocks</a>
+                <div class="navigation-item non-mobile disabled">Map</div>
+                <div class="navigation-item non-mobile disabled">Realtime</div>
+                <div class="navigation-item desktop-only disabled">History</div>
             % end
             
             <a class="navigation-item desktop-only" href="{{ get_url(system, 'routes') }}">Routes</a>
+            <a class="navigation-item desktop-only" href="{{ get_url(system, 'stops') }}">Stops</a>
             <a class="navigation-item desktop-only" href="{{ get_url(system, 'blocks') }}">Blocks</a>
             
             <a class="navigation-item desktop-only" href="{{ get_url(system, 'about') }}">About</a>
@@ -332,25 +330,32 @@
                     % include('components/svg', name='history')
                     <span>History</span>
                 </a>
-                <a class="menu-button" href="{{ get_url(system, 'routes') }}">
-                    % include('components/svg', name='route')
-                    <span>Routes</span>
-                </a>
-                <a class="menu-button" href="{{ get_url(system, 'blocks') }}">
-                    % include('components/svg', name='block')
-                    <span>Blocks</span>
-                </a>
             % else:
-                <a class="menu-button mobile-only" href="{{ get_url(system, 'routes') }}">
-                    % include('components/svg', name='route')
-                    <span>Routes</span>
-                </a>
-                <a class="menu-button mobile-only" href="{{ get_url(system, 'blocks') }}">
-                    % include('components/svg', name='block')
-                    <span>Blocks</span>
-                </a>
+                <div class="menu-button mobile-only disabled">
+                    % include('components/svg', name='map')
+                    <span>Map</span>
+                </div>
+                <div class="menu-button mobile-only disabled">
+                    % include('components/svg', name='realtime')
+                    <span>Realtime</span>
+                </div>
+                <div class="menu-button disabled">
+                    % include('components/svg', name='history')
+                    <span>History</span>
+                </div>
             % end
-            
+            <a class="menu-button" href="{{ get_url(system, 'routes') }}">
+                % include('components/svg', name='route')
+                <span>Routes</span>
+            </a>
+            <a class="menu-button" href="{{ get_url(system, 'stops') }}">
+                % include('components/svg', name='stop')
+                <span>Stops</span>
+            </a>
+            <a class="menu-button" href="{{ get_url(system, 'blocks') }}">
+                % include('components/svg', name='block')
+                <span>Blocks</span>
+            </a>
             <a class="menu-button" href="{{ get_url(system, 'about') }}">
                 % include('components/svg', name='about')
                 <span>About</span>

--- a/views/components/paging.tpl
+++ b/views/components/paging.tpl
@@ -29,7 +29,11 @@
             % if page_number == page:
                 <div class="page current flex-1">{{ page_number }}</div>
             % else:
-                <a class="page flex-1" href="?page={{ page_number }}">{{ page_number }}</a>
+                % if get('use_path', False):
+                    <a class="page flex-1" href="{{ get_url(system, path, page=page_number, **path_args) }}">{{ page_number }}</a>
+                % else:
+                    <a class="page flex-1" href="?page={{ page_number }}">{{ page_number }}</a>
+                % end
             % end
             % previous_page = page_number
         % end

--- a/views/pages/admin.tpl
+++ b/views/pages/admin.tpl
@@ -90,8 +90,6 @@
 </div>
 
 <script>
-    let systemID
-    
     function reloadAdornments() {
         const request = new XMLHttpRequest();
         request.open("POST", getUrl(systemID, "api/admin/reload-adornments"), true);
@@ -140,13 +138,3 @@
         request.send();
     }
 </script>
-
-% if system:
-    <script>
-        systemID = "{{ system.id }}";
-    </script>
-% else:
-    <script>
-        systemID = null;
-    </script>
-% end

--- a/views/pages/stops.tpl
+++ b/views/pages/stops.tpl
@@ -49,6 +49,40 @@
     </script>
     <div class="page-container">
         <div class="sidebar container flex-1">
+            <div class="section {{ 'closed' if sort == 'name' and sort_order == 'asc' else '' }}">
+                <div class="header" onclick="toggleSection(this)">
+                    <h2>Sorting</h2>
+                    % include('components/toggle')
+                </div>
+                <div class="content">
+                    <div class="info-box columns">
+                        <div class="section">
+                            <div class="options-container">
+                                <div class="option" onclick="setSort('name')">
+                                    <div class="radio-button {{ 'selected' if sort == 'name' else '' }}"></div>
+                                    <div>Stop Name</div>
+                                </div>
+                                <div class="option" onclick="setSort('number')">
+                                    <div class="radio-button {{ 'selected' if sort == 'number' else '' }}"></div>
+                                    <div>Stop Number</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="section">
+                            <div class="options-container">
+                                <div class="option" onclick="setSortOrder('asc')">
+                                    <div class="radio-button {{ 'selected' if sort_order == 'asc' else '' }}"></div>
+                                    <div>Ascending</div>
+                                </div>
+                                <div class="option" onclick="setSortOrder('desc')">
+                                    <div class="radio-button {{ 'selected' if sort_order == 'desc' else '' }}"></div>
+                                    <div>Descending</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
             <div class="section {{ '' if search or routes_filter else 'closed' }}">
                 <div class="header" onclick="toggleSection(this)">
                     <h2>Filters</h2>
@@ -90,40 +124,6 @@
                                         </div>
                                     </div>
                                 % end
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="section {{ 'closed' if sort == 'name' and sort_order == 'asc' else '' }}">
-                <div class="header" onclick="toggleSection(this)">
-                    <h2>Sorting</h2>
-                    % include('components/toggle')
-                </div>
-                <div class="content">
-                    <div class="info-box columns">
-                        <div class="section">
-                            <div class="options-container">
-                                <div class="option" onclick="setSort('name')">
-                                    <div class="radio-button {{ 'selected' if sort == 'name' else '' }}"></div>
-                                    <div>Stop Name</div>
-                                </div>
-                                <div class="option" onclick="setSort('number')">
-                                    <div class="radio-button {{ 'selected' if sort == 'number' else '' }}"></div>
-                                    <div>Stop Number</div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="section">
-                            <div class="options-container">
-                                <div class="option" onclick="setSortOrder('asc')">
-                                    <div class="radio-button {{ 'selected' if sort_order == 'asc' else '' }}"></div>
-                                    <div>Ascending</div>
-                                </div>
-                                <div class="option" onclick="setSortOrder('desc')">
-                                    <div class="radio-button {{ 'selected' if sort_order == 'desc' else '' }}"></div>
-                                    <div>Descending</div>
-                                </div>
                             </div>
                         </div>
                     </div>

--- a/views/pages/stops.tpl
+++ b/views/pages/stops.tpl
@@ -6,7 +6,6 @@
 </div>
 
 % if system:
-    % stops = system.get_stops()
     <script>
         const routesFilter = new Set("{{ ','.join(routes_filter) }}".split(",").filter(function(route) {
             return route !== "";
@@ -146,18 +145,32 @@
                     % include('components/toggle')
                 </div>
                 <div class="content">
-                    % if search:
-                        % stops = [s for s in stops if search.lower() in s.name.lower()]
-                    % end
-                    % for route_number in routes_filter:
-                        % stops = [s for s in stops if route_number in {r.number for r in s.routes}]
-                    % end
-                    % if sort == 'number':
-                        % stops.sort(key=lambda s: s.number, reverse=sort_order == 'desc')
-                    % elif sort == 'name':
-                        % stops.sort(key=lambda s: s.name, reverse=sort_order == 'desc')
-                    % end
-                    % if stops:
+                    % if total_items == 0:
+                        <div class="placeholder">
+                            % if search or routes_filter:
+                                <h3>No stops found</h3>
+                                % if search and routes_filter:
+                                    <p>Please try a different search or selecting different routes!</p>
+                                % elif search:
+                                    <p>Please try a different search!</p>
+                                % else:
+                                    <p>Please try selecting different routes!</p>
+                                % end
+                            % else:
+                                <h3>Stop information for {{ system }} is unavailable</h3>
+                                % if system.gtfs_loaded:
+                                    <p>Please check again later!</p>
+                                % else:
+                                    <p>System data is currently loading and will be available soon.</p>
+                                % end
+                            % end
+                        </div>
+                    % elif stops:
+                        % paging_args = dict(path_args)
+                        % if routes_filter:
+                            % paging_args['routes'] = ','.join(sorted(routes_filter))
+                        % end
+                        % include('components/paging', use_path=True, path_args=paging_args)
                         <table>
                             <thead>
                                 <tr>
@@ -189,26 +202,27 @@
                                 % end
                             </tbody>
                         </table>
+                        % include('components/paging', use_path=True, path_args=paging_args)
                         
                         % include('components/top_button')
                     % else:
                         <div class="placeholder">
-                            % if search or routes_filter:
-                                <h3>No stops found</h3>
-                                % if search and routes_filter:
-                                    <p>Please try a different search or selecting different routes!</p>
-                                % elif search:
-                                    <p>Please try a different search!</p>
-                                % else:
-                                    <p>Please try selecting different routes!</p>
-                                % end
+                            % if page == 0:
+                                <h3>Page {{ page }} does not exist...?</h3>
+                                <p>If you're a software developer you may be thinking right now, "Hey, wait a minute, why doesn't this list start at 0?!‽"</p>
+                                <p>
+                                    Look, we agree with you, it feels weird to be showing this error message at all.
+                                    Sadly too many people are expecting page 1 to be the first because "it makes more sense" or "0 isn't a real number" or something equally silly.
+                                    But you should know that we're right and they're just mad about it.
+                                </p>
+                                <p>Unfortunately you do still need to return to a <a href="?page=1">valid page</a> but remember that one day the zero-based indexers shall rise up and claim our rightful place once and for all!</p>
                             % else:
-                                <h3>Stop information for {{ system }} is unavailable</h3>
-                                % if system.gtfs_loaded:
-                                    <p>Please check again later!</p>
-                                % else:
-                                    <p>System data is currently loading and will be available soon.</p>
-                                % end
+                                <h3>Page {{ page }} does not exist!</h3>
+                                <p>If you got to this page through <i>nefarious tomfoolery</i> or <i>skullduggery</i>, please return to a <a href="?page=1">valid page</a>, then go sit in a corner and think about what you've done.</p>
+                                <p>
+                                    If you got to this page by accident, we're very sorry.
+                                    Please email <a href="mailto:james@bctracker.ca">james@bctracker.ca</a> to let us know!
+                                </p>
                             % end
                         </div>
                     % end

--- a/views/pages/stops.tpl
+++ b/views/pages/stops.tpl
@@ -3,82 +3,219 @@
 
 <div id="page-header">
     <h1>Stops</h1>
-    % if search:
-        <h2>Search results for "{{ search }}"</h2>
-    % end
 </div>
 
 % if system:
     % stops = system.get_stops()
-    % if stops or search:
-        % if search:
-            % stops = [s for s in stops if search.lower() in s.name.lower()]
-        % end
+    <script>
+        const routesFilter = new Set("{{ ','.join(routes_filter) }}".split(",").filter(function(route) {
+            return route !== "";
+        }));
+        let sort = "{{ sort }}";
+        let sortOrder = "{{ sort_order }}";
         
-        <script>
-            function stopSearch() {
-                let value = document.getElementById('stop_id_search').value;
-                if (value.length > 0) {
-                    window.location = "{{ get_url(system) }}/stops?search=" + value;
-                } else {
-                    window.location = "{{ get_url(system) }}/stops";
-                }
+        function toggleRouteFilter(number) {
+            if (routesFilter.has(number)) {
+                routesFilter.delete(number);
+            } else {
+                routesFilter.add(number);
             }
-        </script>
+            updateFilters();
+        }
         
-        <form onsubmit="stopSearch()" action="javascript:void(0)">
-            <label for="stop_id_search">Stop Name:</label>
-            <div class="input-container">
-                <input type="text" id="stop_id_search" name="stop_id" method="post" value="{{ search or '' }}" size="10">
-                <input type="submit" value="Search" class="button">
+        function resetRoutesFilter() {
+            routesFilter.clear();
+            updateFilters();
+        }
+        
+        function setSort(newSort) {
+            sort = newSort;
+            updateFilters();
+        }
+        
+        function setSortOrder(newSortOrder) {
+            sortOrder = newSortOrder;
+            updateFilters();
+        }
+        
+        function updateFilters() {
+            const search = document.getElementById('stop_id_search').value;
+            window.location = getUrl(systemID, "stops", {
+                "search": search.length === 0 ? null : search,
+                "routes": routesFilter.size === 0 ? null : Array.from(routesFilter).sort().join(","),
+                "sort": sort === "name" ? null : sort,
+                "sort_order": sortOrder === "asc" ? null : sortOrder
+            })
+        }
+    </script>
+    <div class="page-container">
+        <div class="sidebar container flex-1">
+            <div class="section {{ '' if search or routes_filter else 'closed' }}">
+                <div class="header" onclick="toggleSection(this)">
+                    <h2>Filters</h2>
+                    % include('components/toggle')
+                </div>
+                <div class="content gap-20">
+                    <form onsubmit="updateFilters()" action="javascript:void(0)">
+                        <label for="stop_id_search">Stop Name:</label>
+                        <div class="input-container">
+                            <input type="text" id="stop_id_search" name="stop_id" method="post" value="{{ search or '' }}" size="10">
+                            <input type="submit" value="Search" class="button">
+                        </div>
+                    </form>
+                    <div class="info-box">
+                        <div class="row section">
+                            <div class="lighter-text">
+                                % if routes_filter:
+                                    % if len(routes_filter) == 1:
+                                        1 route selected
+                                    % else:
+                                        {{ len(routes_filter) }} routes selected
+                                    % end
+                                % else:
+                                    No routes selected
+                                % end
+                            </div>
+                            <button class="button compact" onclick="resetRoutesFilter()">Reset</button>
+                        </div>
+                        <div class="section">
+                            <div class="options-container">
+                                % for route in system.get_routes():
+                                    <div class="option space-between" onclick="toggleRouteFilter('{{ route.number }}')">
+                                        <div class="row">
+                                            % include('components/route')
+                                            {{! route.display_name }}
+                                        </div>
+                                        <div class="checkbox {{ 'selected' if route.number in routes_filter else '' }}">
+                                            % include('components/svg', name='check')
+                                        </div>
+                                    </div>
+                                % end
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
-        </form>
-        
-        % if stops:
-            <table>
-                <thead>
-                    <tr>
-                        <th class="desktop-only">Stop Number</th>
-                        <th class="non-desktop">Number</th>
-                        <th class="desktop-only">Stop Name</th>
-                        <th class="non-desktop">Name</th>
-                        <th class="non-mobile">Routes</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    % for stop in sorted(stops):
-                        <tr>
-                            <td><a href="{{ get_url(stop.system, f'stops/{stop.number}') }}">{{ stop.number }}</a></td>
-                            <td>
-                                {{ stop }}
-                                <div class="mobile-only">
-                                    % include('components/route_list', routes=stop.routes)
+            <div class="section {{ 'closed' if sort == 'name' and sort_order == 'asc' else '' }}">
+                <div class="header" onclick="toggleSection(this)">
+                    <h2>Sorting</h2>
+                    % include('components/toggle')
+                </div>
+                <div class="content">
+                    <div class="info-box columns">
+                        <div class="section">
+                            <div class="options-container">
+                                <div class="option" onclick="setSort('name')">
+                                    <div class="radio-button {{ 'selected' if sort == 'name' else '' }}"></div>
+                                    <div>Stop Name</div>
                                 </div>
-                            </td>
-                            <td class="non-mobile">
-                                % include('components/route_list', routes=stop.routes)
-                            </td>
-                        </tr>
-                    % end
-                </tbody>
-            </table>
-        % else:
-            <div class="placeholder">
-                <h3>No stops found</h3>
+                                <div class="option" onclick="setSort('number')">
+                                    <div class="radio-button {{ 'selected' if sort == 'number' else '' }}"></div>
+                                    <div>Stop Number</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="section">
+                            <div class="options-container">
+                                <div class="option" onclick="setSortOrder('asc')">
+                                    <div class="radio-button {{ 'selected' if sort_order == 'asc' else '' }}"></div>
+                                    <div>Ascending</div>
+                                </div>
+                                <div class="option" onclick="setSortOrder('desc')">
+                                    <div class="radio-button {{ 'selected' if sort_order == 'desc' else '' }}"></div>
+                                    <div>Descending</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
-        % end
-
-        % include('components/top_button')
-    % else:
-        <div class="placeholder">
-            <h3>Stop information for {{ system }} is unavailable</h3>
-            % if system.gtfs_loaded:
-                <p>Please check again later!</p>
-            % else:
-                <p>System data is currently loading and will be available soon.</p>
-            % end
         </div>
-    % end
+        <div class="container flex-3">
+            <div class="section">
+                <div class="header" onclick="toggleSection(this)">
+                    <h2>
+                        % if search:
+                            Results for "{{ search }}"
+                        % elif routes_filter:
+                            Results
+                        % else:
+                            All Stops
+                        % end
+                    </h2>
+                    % include('components/toggle')
+                </div>
+                <div class="content">
+                    % if search:
+                        % stops = [s for s in stops if search.lower() in s.name.lower()]
+                    % end
+                    % for route_number in routes_filter:
+                        % stops = [s for s in stops if route_number in {r.number for r in s.routes}]
+                    % end
+                    % if sort == 'number':
+                        % stops.sort(key=lambda s: s.number, reverse=sort_order == 'desc')
+                    % elif sort == 'name':
+                        % stops.sort(key=lambda s: s.name, reverse=sort_order == 'desc')
+                    % end
+                    % if stops:
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th class="desktop-only">Stop Number</th>
+                                    <th class="non-desktop">Number</th>
+                                    <th class="desktop-only">Stop Name</th>
+                                    <th class="non-desktop">Name</th>
+                                    <th class="non-mobile">Routes</th>
+                                    <th class="desktop-only">Service Days</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                % for stop in stops:
+                                    <tr>
+                                        <td><a href="{{ get_url(stop.system, f'stops/{stop.number}') }}">{{ stop.number }}</a></td>
+                                        <td>
+                                            {{ stop }}
+                                            <div class="mobile-only">
+                                                % include('components/route_list', routes=stop.routes)
+                                            </div>
+                                        </td>
+                                        <td class="non-mobile">
+                                            % include('components/route_list', routes=stop.routes)
+                                        </td>
+                                        <td class="desktop-only">
+                                            % include('components/weekdays', schedule=stop.schedule, compact=True, schedule_path=f'stops/{stop.number}/schedule')
+                                        </td>
+                                    </tr>
+                                % end
+                            </tbody>
+                        </table>
+                        
+                        % include('components/top_button')
+                    % else:
+                        <div class="placeholder">
+                            % if search or routes_filter:
+                                <h3>No stops found</h3>
+                                % if search and routes_filter:
+                                    <p>Please try a different search or selecting different routes!</p>
+                                % elif search:
+                                    <p>Please try a different search!</p>
+                                % else:
+                                    <p>Please try selecting different routes!</p>
+                                % end
+                            % else:
+                                <h3>Stop information for {{ system }} is unavailable</h3>
+                                % if system.gtfs_loaded:
+                                    <p>Please check again later!</p>
+                                % else:
+                                    <p>System data is currently loading and will be available soon.</p>
+                                % end
+                            % end
+                        </div>
+                    % end
+                </div>
+            </div>
+        </div>
+    </div>
 % else:
     <div class="placeholder">
         <p>Choose a system to see individual stops.</p>


### PR DESCRIPTION
- Updates to the stops list page (`/stops`) to allow filtering by route, sorting, and paging
  - Route selection acts as an AND join, so selecting multiple will filter to stops that serve _all_ selected routes
  - Search logic is moved into the `Filters` section on-screen but is otherwise unchanged
  - Sorting can be done on stop name (default) or number, in ascending (default) or descending order
    - IAQ (infrequently asked question): why not have toggles in the table headers? Answer: although it would make sense on this page, sorting on other pages in the future may be done on items that do not have their own column, such as by adherence on the realtime page. Additionally, some columns may get merged on tablet/mobile with the same result. Therefore it's easier to keep the sorting options separate
  - When changing systems, sort/order/search parameters are kept but routes are reset, since those change from system to system
  - On mobile/tablet, these sections are collapsed by default _unless_ a non-default value is selected, matching the filter logic on the history page
  - Paging uses the same logic as on the bus history pages
- Added `Service Days` column to stops table
  - Only available on desktop right now as it gets too cramped on smaller sizes, but we can consider changing that in the future
- Updated navigation bar/menu
  - Added `Stops`
  - Simplified some logic for tablet/mobile - systems without realtime info will now still show that navigation in a disabled state instead of hiding it completely, matching desktop
    - We don't currently have non-realtime systems right now, but this may apply in the future

A few other things to note:
- I opted to do filtering/sorting on this page first because it's relatively simple. We can use this page to get feedback from users on the usability and design before applying it elsewhere
- Some of the new/improved logic for querying and building URLs in javascript will be reusable for filtering/sorting other stuff in the future

![Screenshot from 2024-09-23 23-44-32](https://github.com/user-attachments/assets/c25419e4-57ad-459f-907f-d7c168d882b3)
![Screenshot from 2024-09-23 23-44-43](https://github.com/user-attachments/assets/b157f962-f8fe-4e68-9f9f-d7badf35b506)
![Screenshot from 2024-09-23 23-44-56](https://github.com/user-attachments/assets/ee4a7dc4-1346-492a-8424-78c470bb5340)
![Screenshot from 2024-09-23 23-55-28](https://github.com/user-attachments/assets/3f78823e-529e-4e61-9177-f53bf12932fd)
![Screenshot from 2024-09-24 00-00-16](https://github.com/user-attachments/assets/8ab32f8e-53e8-4eb8-888b-0388a0ba12a0)
