### PR TITLE
Round adherence seconds

### DIFF
--- a/models/adherence.py
+++ b/models/adherence.py
@@ -28,10 +28,10 @@ class Adherence:
             return None
         previous_departure = departure.find_previous()
         try:
-            expected_scheduled_mins = departure.time.get_minutes()
+            expected_scheduled_mins = departure.time.get_minutes(round_seconds=True)
             
             if previous_departure:
-                previous_departure_mins = previous_departure.time.get_minutes()
+                previous_departure_mins = previous_departure.time.get_minutes(round_seconds=True)
                 time_difference = expected_scheduled_mins - previous_departure_mins
                 
                 # in the case where we know a previous stop, and its a long gap, do linear interpolation
@@ -39,7 +39,7 @@ class Adherence:
                     expected_scheduled_mins = previous_departure_mins + linear_interpolate(lat, lon, previous_departure.stop, stop, time_difference)
             if not timestamp:
                 timestamp = Timestamp.now(trip.system.timezone)
-            value = expected_scheduled_mins - timestamp.time.get_minutes()
+            value = expected_scheduled_mins - timestamp.time.get_minutes(round_seconds=True)
             layover = stop and trip.first_stop and stop == trip.first_stop and value > 0
             return cls(value, layover)
         except AttributeError:

--- a/models/time.py
+++ b/models/time.py
@@ -161,11 +161,14 @@ class Time:
             second = None
         return Time(hour, time.minute, second, self.timezone)
     
-    def get_minutes(self):
+    def get_minutes(self, round_seconds=False):
         '''Returns the total number of minutes in this time'''
         if self.is_unknown:
             return 0
-        return (self.hour * 60) + self.minute
+        minutes = (self.hour * 60) + self.minute
+        if round_seconds and self.second is not None and self.second >= 30:
+            minutes += 1
+        return minutes
     
     def format_db(self):
         '''Returns a string of this time formatted as HH:MM:SS'''


### PR DESCRIPTION
A request from user feedback - since we changed adherence to use the bus' timestamp instead of the current time, it can sometimes be slightly inaccurate if the last update was towards the end of the minute, since we always round down. It makes more sense to round to the nearest minute, ie round up if we're >= 30 seconds. This can be done for both the bus timestamp and the departure time - though the departures for BCT are always rounded to the minute, it'll help with Translink or other agencies if we ever add realtime for those.