### PR TITLE
Add month headers

### DIFF
--- a/models/date.py
+++ b/models/date.py
@@ -129,6 +129,16 @@ class Date:
             return self.datetime.strftime("%b %-d")
         return self.datetime.strftime("%b %-d, %Y")
     
+    def format_month(self):
+        '''Returns a string of this date formatted as MMMM YYYY'''
+        return self.datetime.strftime("%B %Y")
+    
+    def format_day(self):
+        '''Returns a string of this date formatted as DD{ordinal}'''
+        day = self.day
+        ordinal = "th" if 4 <= day % 100 <= 20 else {1:"st",2:"nd",3:"rd"}.get(day % 10, "th")
+        return f'{day}{ordinal}'
+    
     def format_since(self):
         '''Returns a string of the number of days, months, and years since this date'''
         if self.is_today:

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -122,6 +122,8 @@ class TestWeekday:
     def test_default(self):
         date = Date.today()
         now = datetime.now(timezone)
+        if now.hour < 4:
+            now = now - timedelta(days=1)
         weekday = Weekday(now.weekday())
         
         assert date.weekday == weekday
@@ -405,6 +407,8 @@ class TestFormatLong:
     
     def test_current_year(self):
         now = datetime.now(timezone)
+        if now.hour < 4:
+            now = now - timedelta(days=1)
         date = Date(now.year, 1, 1, timezone)
         
         assert date.format_long() == 'January 1'
@@ -417,6 +421,8 @@ class TestFormatShort:
     
     def test_current_year(self):
         now = datetime.now(timezone)
+        if now.hour < 4:
+            now = now - timedelta(days=1)
         date = Date(now.year, 1, 1, timezone)
         
         assert date.format_short() == 'Jan 1'
@@ -529,6 +535,8 @@ class TestFormatSince:
     
     def test_near_year(self):
         now = datetime.now(timezone)
+        if now.hour < 4:
+            now = now - timedelta(days=1)
         year_ago = Date(now.year - 1, now.month, now.day, timezone)
         # Need to calculate days based on number of days in month one year ago
         # Extra logic is needed to account for different number of days in different months

--- a/views/pages/block/history.tpl
+++ b/views/pages/block/history.tpl
@@ -63,16 +63,23 @@
                                     <th>Date</th>
                                     <th>Bus</th>
                                     <th class="desktop-only">Model</th>
-                                    <th class="non-mobile">First Seen</th>
-                                    <th>Last Seen</th>
+                                    <th class="no-wrap non-mobile">First Seen</th>
+                                    <th class="no-wrap">Last Seen</th>
                                 </tr>
                             </thead>
                             <tbody>
+                                % last_date = None
                                 % for record in records:
                                     % bus = record.bus
+                                    % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
+                                        <tr class="header">
+                                            <td colspan="5">{{ record.date.format_month() }}</td>
+                                            <tr class="display-none"></tr>
+                                        </tr>
+                                    % end
+                                    % last_date = record.date
                                     <tr>
-                                        <td class="desktop-only">{{ record.date.format_long() }}</td>
-                                        <td class="non-desktop">{{ record.date.format_short() }}</td>
+                                        <td>{{ record.date.format_day() }}</td>
                                         <td>
                                             <div class="column">
                                                 <div class="row">

--- a/views/pages/bus/history.tpl
+++ b/views/pages/bus/history.tpl
@@ -95,18 +95,25 @@
                                     <th class="desktop-only">Routes</th>
                                     <th class="desktop-only">Start Time</th>
                                     <th class="desktop-only">End Time</th>
-                                    <th class="non-mobile">First Seen</th>
+                                    <th class="no-wrap non-mobile">First Seen</th>
                                     <th class="no-wrap">Last Seen</th>
                                 </tr>
                             </thead>
                             <tbody>
+                                % last_date = None
                                 % for record in records:
+                                    % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
+                                        <tr class="header">
+                                            <td colspan="8">{{ record.date.format_month() }}</td>
+                                            <tr class="display-none"></tr>
+                                        </tr>
+                                    % end
+                                    % last_date = record.date
                                     <tr>
-                                        <td class="desktop-only">{{ record.date.format_long() }}</td>
-                                        <td class="non-desktop">
+                                        <td>
                                             <div class="column">
-                                                {{ record.date.format_short() }}
-                                                <span class="smaller-font">{{ record.system }}</span>
+                                                {{ record.date.format_day() }}
+                                                <span class="non-desktop smaller-font">{{ record.system }}</span>
                                             </div>
                                         </td>
                                         <td class="desktop-only">{{ record.system }}</td>

--- a/views/pages/bus/overview.tpl
+++ b/views/pages/bus/overview.tpl
@@ -366,18 +366,25 @@
                                 <th class="desktop-only">Routes</th>
                                 <th class="desktop-only">Start Time</th>
                                 <th class="desktop-only">End Time</th>
-                                <th class="non-mobile">First Seen</th>
+                                <th class="no-wrap non-mobile">First Seen</th>
                                 <th class="no-wrap">Last Seen</th>
                             </tr>
                         </thead>
                         <tbody>
+                            % last_date = None
                             % for record in records:
+                                % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
+                                    <tr class="header">
+                                        <td colspan="8">{{ record.date.format_month() }}</td>
+                                        <tr class="display-none"></tr>
+                                    </tr>
+                                % end
+                                % last_date = record.date
                                 <tr>
-                                    <td class="desktop-only">{{ record.date.format_long() }}</td>
-                                    <td class="non-desktop">
+                                    <td>
                                         <div class="column">
-                                            {{ record.date.format_short() }}
-                                            <span class="smaller-font">{{ record.system }}</span>
+                                            {{ record.date.format_day() }}
+                                            <span class="non-desktop smaller-font">{{ record.system }}</span>
                                         </div>
                                     </td>
                                     <td class="desktop-only">{{ record.system }}</td>

--- a/views/pages/history/first_seen.tpl
+++ b/views/pages/history/first_seen.tpl
@@ -14,7 +14,7 @@
     <table>
         <thead>
             <tr>
-                <th>First Seen</th>
+                <th>Date</th>
                 <th>Bus</th>
                 <th class="desktop-only">Model</th>
                 % if not system:
@@ -29,13 +29,17 @@
             % for overview in overviews:
                 % record = overview.first_record
                 % bus = record.bus
-                % same_date = not last_date or record.date == last_date
+                % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
+                    <tr class="header">
+                        <td colspan="6">{{ record.date.format_month() }}</td>
+                        <tr class="display-none"></tr>
+                    </tr>
+                % end
                 % last_date = record.date
-                <tr class="{{'' if same_date else 'divider'}}">
-                    <td class="desktop-only">{{ record.date.format_long() }}</td>
-                    <td class="non-desktop">
+                <tr>
+                    <td>
                         <div class="column">
-                            {{ record.date.format_short() }}
+                            {{ record.date.format_day() }}
                             % if not system:
                                 <span class="mobile-only smaller-font">{{ record.system }}</span>
                             % end

--- a/views/pages/history/transfers.tpl
+++ b/views/pages/history/transfers.tpl
@@ -115,11 +115,15 @@
                             % last_date = None
                             % for transfer in transfers:
                                 % bus = transfer.bus
-                                % same_date = not last_date or transfer.date == last_date
+                                % if not last_date or transfer.date.year != last_date.year or transfer.date.month != last_date.month:
+                                    <tr class="header">
+                                        <td colspan="6">{{ transfer.date.format_month() }}</td>
+                                        <tr class="display-none"></tr>
+                                    </tr>
+                                % end
                                 % last_date = transfer.date
-                                <tr class="{{'' if same_date else 'divider'}}">
-                                    <td class="desktop-only">{{ transfer.date.format_long() }}</td>
-                                    <td class="non-desktop">{{ transfer.date.format_short() }}</td>
+                                <tr>
+                                    <td>{{ transfer.date.format_day() }}</td>
                                     <td>
                                         <div class="column">
                                             % include('components/bus')

--- a/views/pages/trip/history.tpl
+++ b/views/pages/trip/history.tpl
@@ -64,16 +64,23 @@
                                     <th>Date</th>
                                     <th>Bus</th>
                                     <th class="desktop-only">Model</th>
-                                    <th class="non-mobile">First Seen</th>
-                                    <th>Last Seen</th>
+                                    <th class="no-wrap non-mobile">First Seen</th>
+                                    <th class="no-wrap">Last Seen</th>
                                 </tr>
                             </thead>
                             <tbody>
+                                % last_date = None
                                 % for record in records:
                                     % bus = record.bus
+                                    % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
+                                        <tr class="header">
+                                            <td colspan="5">{{ record.date.format_month() }}</td>
+                                            <tr class="display-none"></tr>
+                                        </tr>
+                                    % end
+                                    % last_date = record.date
                                     <tr>
-                                        <td class="desktop-only">{{ record.date.format_long() }}</td>
-                                        <td class="non-desktop">{{ record.date.format_short() }}</td>
+                                        <td>{{ record.date.format_day() }}</td>
                                         <td>
                                             <div class="column">
                                                 <div class="row">


### PR DESCRIPTION
- Added new formatting functions to `Date` model
  - `format_month` returns the month and year
  - `format_day` returns the day and appropriate ordinal (eg 1st, 11th)
- Added header rows with the month and year to tables where a date is the primary column
  - The old dates are simplified to just the day (also means we no longer have separate values for mobile and desktop (mobile previously used short month names to conserve space))
  - This is done for:
    - History > First Seen
    - History > Transfers
    - Bus > Overview
    - Bus > History
    - Block > History
    - Trip > History
  - First seen and transfers no longer have dividers between individual dates
- Minor standardization updates
  - Made use of `no-wrap` consistent for some headers
  - Renamed `First Seen` column to `Date` on First Seen page