### PR TITLE
Change bus icons from map page

### DIFF
--- a/server.py
+++ b/server.py
@@ -21,7 +21,7 @@ from repositories import *
 from services import *
 
 # Increase the version to force CSS reload
-VERSION = 49
+VERSION = 50
 
 random = Random()
 
@@ -266,7 +266,7 @@ class Server(Bottle):
             system=system,
             agency=agency,
             enable_refresh=enable_refresh,
-            include_maps=include_maps,
+            include_maps=include_maps or full_map,
             full_map=full_map,
             regions=self.region_repository.find_all(),
             systems=self.system_repository.find_all(),
@@ -427,7 +427,6 @@ class Server(Bottle):
             path=['map'],
             system=system,
             agency=agency,
-            include_maps=len(visible_positions) > 0,
             full_map=len(visible_positions) > 0,
             positions=sorted(positions, key=lambda p: p.lat),
             auto_refresh=auto_refresh,
@@ -554,7 +553,6 @@ class Server(Bottle):
             title=f'Bus {bus}',
             system=system,
             agency=agency,
-            include_maps=bool(position),
             full_map=bool(position),
             bus=bus,
             position=position,
@@ -690,7 +688,6 @@ class Server(Bottle):
             system=system,
             agency=agency,
             enable_refresh=False,
-            include_maps=len(routes) > 0,
             full_map=len(routes) > 0,
             routes=routes,
             show_route_numbers=show_route_numbers
@@ -759,7 +756,6 @@ class Server(Bottle):
             title=str(route),
             system=system,
             agency=agency,
-            include_maps=len(route.trips) > 0,
             full_map=len(route.trips) > 0,
             route=route,
             positions=self.position_repository.find_all(system, route=route),
@@ -924,7 +920,6 @@ class Server(Bottle):
             title=f'Block {block.id}',
             system=system,
             agency=agency,
-            include_maps=True,
             full_map=True,
             block=block,
             positions=self.position_repository.find_all(system, block=block)
@@ -1015,7 +1010,6 @@ class Server(Bottle):
             title=f'Trip {trip.id}',
             system=system,
             agency=agency,
-            include_maps=True,
             full_map=True,
             trip=trip,
             positions=self.position_repository.find_all(system, trip=trip)
@@ -1180,7 +1174,6 @@ class Server(Bottle):
             title=str(stop),
             system=system,
             agency=agency,
-            include_maps=True,
             full_map=True,
             stop=stop,
             favourite=Favourite('stop', stop),

--- a/style/devices/desktop.css
+++ b/style/devices/desktop.css
@@ -13,8 +13,9 @@ body {
     grid-template-rows: auto 1fr;
 }
 
-body.full-map #page-header {
-    align-self: flex-start;
+body.full-map #page {
+    padding: 10px 20px 10px 20px;
+    width: fit-content;
 }
 
 input[type="text"] {

--- a/style/devices/mobile.css
+++ b/style/devices/mobile.css
@@ -10,16 +10,16 @@ body.full-map {
     overflow: hidden;
 }
 
+body.full-map #page {
+    padding: 10px 20px 10px 20px;
+}
+
 body.full-map #side-bar {
     overflow: hidden;
 }
 
 body.full-map #system-menu {
     overflow: auto;
-}
-
-body.full-map #page-header {
-    width: 100%;
 }
 
 button {

--- a/style/devices/tablet.css
+++ b/style/devices/tablet.css
@@ -10,8 +10,8 @@ body.full-map {
     overflow: hidden;
 }
 
-body.full-map #page-header {
-    width: 100%;
+body.full-map #page {
+    padding: 10px 20px 10px 20px;
 }
 
 button {

--- a/style/main.css
+++ b/style/main.css
@@ -18,14 +18,15 @@ body, ol, ul, p, h1, h2, h3, h4, form {
     margin: 0px;
 }
 
-body.full-map #page-header {
+body.full-map #page {
     position: relative;
     z-index: 20;
-    border-bottom-width: 0px;
-    padding: 10px;
     border-radius: 10px;
-    top: -10px;
-    left: -10px;
+    margin: 10px 20px;
+}
+
+body.full-map #page-header {
+    border-bottom-width: 0px;
 }
 
 body.full-map .tab-button-bar {

--- a/style/main.css
+++ b/style/main.css
@@ -164,6 +164,20 @@ table tr.header td {
     height: 36px;
 }
 
+#loading-container {
+    position: absolute;
+    z-index: 0;
+    left: 0px;
+    top: 0px;
+    right: 0px;
+    bottom: 0px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
+}
+
 #loading-line {
     background-color: var(--loading-foreground);
     position: absolute;
@@ -222,20 +236,6 @@ table tr.header td {
 
 #map .ol-overlay-container:hover {
     z-index: 10;
-}
-
-#map-loading {
-    position: absolute;
-    z-index: 0;
-    left: 0px;
-    top: 0px;
-    right: 0px;
-    bottom: 0px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 20px;
 }
 
 #map-toggle {

--- a/style/themes/bc-hydro.css
+++ b/style/themes/bc-hydro.css
@@ -38,11 +38,11 @@ body {
     color: #000000;
 }
 
-body.full-map #page-header {
+body.full-map #page {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .option {
+body.full-map #page .option {
     --hover-background: #FFFFFF;
 }
 

--- a/style/themes/bc-transit-classic.css
+++ b/style/themes/bc-transit-classic.css
@@ -38,11 +38,11 @@ body {
     color: #000000;
 }
 
-body.full-map #page-header {
+body.full-map #page {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .option {
+body.full-map #page .option {
     --hover-background: #FFFFFF;
 }
 

--- a/style/themes/bc-transit.dark.css
+++ b/style/themes/bc-transit.dark.css
@@ -40,11 +40,11 @@ body {
     color: #FFFFFF;
 }
 
-body.full-map #page-header {
+body.full-map #page {
     background-color: rgba(30, 30, 30, 0.7);
 }
 
-body.full-map #page-header .option {
+body.full-map #page .option {
     --hover-background: #2F2F2F;
 }
 

--- a/style/themes/bc-transit.light.css
+++ b/style/themes/bc-transit.light.css
@@ -38,11 +38,11 @@ body {
     color: #000000;
 }
 
-body.full-map #page-header {
+body.full-map #page {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .option {
+body.full-map #page .option {
     --hover-background: #FFFFFF;
 }
 

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -38,11 +38,11 @@ body {
     color: #000000;
 }
 
-body.full-map #page-header {
+body.full-map #page {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .option {
+body.full-map #page .option {
     --hover-background: #FFFFFF;
 }
 

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -40,11 +40,11 @@ body {
     color: #000000;
 }
 
-body.full-map #page-header {
+body.full-map #page {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .option {
+body.full-map #page .option {
     --hover-background: #FFFFFF;
 }
 

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -40,11 +40,11 @@ body {
     color: #000000;
 }
 
-body.full-map #page-header {
+body.full-map #page {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .option {
+body.full-map #page .option {
     --hover-background: #FFFFFF;
 }
 

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -40,11 +40,11 @@ body {
     color: #FFFFFF;
 }
 
-body.full-map #page-header {
+body.full-map #page {
     background-color: rgba(30, 30, 30, 0.7);
 }
 
-body.full-map #page-header .option {
+body.full-map #page .option {
     --hover-background: #2F2F2F;
 }
 

--- a/style/themes/pride.dark.css
+++ b/style/themes/pride.dark.css
@@ -37,11 +37,11 @@ body {
     color: #FFFFFF;
 }
 
-body.full-map #page-header {
+body.full-map #page {
     background-color: rgba(30, 30, 30, 0.7);
 }
 
-body.full-map #page-header .option {
+body.full-map #page .option {
     --hover-background: #2F2F2F;
 }
 

--- a/style/themes/pride.light.css
+++ b/style/themes/pride.light.css
@@ -36,11 +36,11 @@ body {
     color: #000000;
 }
 
-body.full-map #page-header {
+body.full-map #page {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .option {
+body.full-map #page .option {
     --hover-background: #FFFFFF;
 }
 

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -29,11 +29,11 @@ body {
     color: #000000;
 }
 
-body.full-map #page-header {
+body.full-map #page {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .option {
+body.full-map #page .option {
     --hover-background: #FFFFFF;
 }
 

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -38,11 +38,11 @@ body {
     color: #000000;
 }
 
-body.full-map #page-header {
+body.full-map #page {
     background-color: rgba(255, 255, 255, 0.7);
 }
 
-body.full-map #page-header .option {
+body.full-map #page .option {
     --hover-background: #FFFFFF;
 }
 

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -452,6 +452,7 @@
             </div>
             % if full_map:
                 <div id="map" class="full-screen"></div>
+                % include('components/loading')
                 % include('components/map_toggle')
             % end
             <div id="page">{{ !base }}</div>

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -450,6 +450,10 @@
             <div id="banners">
                 
             </div>
+            % if full_map:
+                <div id="map" class="full-screen"></div>
+                % include('components/map_toggle')
+            % end
             <div id="page">{{ !base }}</div>
         </div>
         <div id="search" class="display-none" tabindex="0">

--- a/views/components/loading.tpl
+++ b/views/components/loading.tpl
@@ -1,11 +1,15 @@
-<div id="loading">
-    <div id="loading-line"></div>
-    <div id="loading-stop">
-        % include('components/svg', name='stop')
+<div id="loading-container" class="display-none">
+    <div id="loading">
+        <div id="loading-line"></div>
+        <div id="loading-stop">
+            % include('components/svg', name='stop')
+        </div>
     </div>
+    <h2>Loading...</h2>
     <script>
         const loadingStopElement = document.getElementById("loading-stop");
         let loadingStopPosition = -36;
+        let loadingInterval = null;
         
         function moveLoadingStop() {
             if (loadingStopPosition === -36) {
@@ -16,10 +20,18 @@
             loadingStopElement.style.left = loadingStopPosition + "px";
         }
         
-        const loadingInterval = setInterval(moveLoadingStop, 10);
+        function startLoading() {
+            stopLoading();
+            document.getElementById("loading-container").classList.remove("display-none");
+            loadingInterval = setInterval(moveLoadingStop, 10);
+        }
         
-        function stopLoadingInterval() {
-            clearInterval(loadingInterval);
+        function stopLoading() {
+            document.getElementById("loading-container").classList.add("display-none");
+            if (loadingInterval !== null) {
+                clearInterval(loadingInterval);
+                loadingInterval = null;
+            }
         }
     </script>
 </div>

--- a/views/components/map.tpl
+++ b/views/components/map.tpl
@@ -3,7 +3,9 @@
 
 % is_preview = get('is_preview', True)
 
-<div id="map" class="{{ 'preview' if is_preview else 'full-screen' }}"></div>
+% if is_preview:
+    <div id="map" class="preview"></div>
+% end
 
 % include('components/svg_script', name='fish')
 % include('components/svg_script', name='no-people')
@@ -158,7 +160,7 @@
                     if (position.lat === 0 && position.lon === 0) {
                         icon.innerHTML += getSVG("fish");
                     } else {
-                        icon.innerHTML += "N/A";
+                        icon.innerHTML += "NIS";
                     }
                 } else {
                     if (position.lat === 0 && position.lon === 0) {

--- a/views/components/map.tpl
+++ b/views/components/map.tpl
@@ -159,8 +159,10 @@
                 if (adherence === undefined || adherence === null) {
                     if (position.lat === 0 && position.lon === 0) {
                         icon.innerHTML += getSVG("fish");
-                    } else {
+                    } else if (position.route_number === "NIS") {
                         icon.innerHTML += "NIS";
+                    } else {
+                        icon.innerHTML += "N/A"
                     }
                 } else {
                     if (position.lat === 0 && position.lon === 0) {

--- a/views/components/map_toggle.tpl
+++ b/views/components/map_toggle.tpl
@@ -8,7 +8,7 @@
         document.getElementById("search").classList.add("display-none");
         document.getElementById("side-bar").classList.toggle("display-none");
         document.getElementById("banners").classList.toggle("display-none");
-        document.getElementById("page-header").classList.toggle("display-none");
+        document.getElementById("page").classList.toggle("display-none");
         map.updateSize();
     }
 </script>

--- a/views/pages/block/map.tpl
+++ b/views/pages/block/map.tpl
@@ -16,5 +16,3 @@
 % departures = block.find_departures()
 
 % include('components/map', is_preview=False, map_trips=trips, map_departures=departures, map_positions=positions)
-
-% include('components/map_toggle')

--- a/views/pages/bus/map.tpl
+++ b/views/pages/bus/map.tpl
@@ -26,8 +26,6 @@
     % else:
         % include('components/map', is_preview=False, map_position=position)
     % end
-    
-    % include('components/map_toggle')
 % else:
     <div class="placeholder">
         <h3>Not in service</h3>

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -214,8 +214,10 @@
                     if (adherence === undefined || adherence === null) {
                         if (position.lat === 0 && position.lon === 0) {
                             icon.innerHTML += getSVG("fish");
-                        } else {
+                        } else if (position.route_number === "NIS") {
                             icon.innerHTML += "NIS";
+                        } else {
+                            icon.innerHTML += "N/A"
                         }
                     } else {
                         if (position.lat === 0 && position.lon === 0) {

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -10,33 +10,70 @@
             % include('components/settings_toggle')
         % end
     </div>
-    % if visible_positions:
-        <div id="settings" class="options-container collapsed">
-            <div class="option" onclick="toggleAutomaticRefresh()">
-                <div id="auto-refresh-checkbox" class="checkbox {{ 'selected' if auto_refresh else '' }}">
-                    % include('components/svg', name='check')
-                </div>
-                <span>Automatically Refresh</span>
-            </div>
-            <div class="option" onclick="toggleRouteLines()">
-                <div id="show-route-lines-checkbox" class="checkbox {{ 'selected' if show_route_lines else '' }}">
-                    % include('components/svg', name='check')
-                </div>
-                <span>Show Route Lines</span>
-            </div>
-            <div class="option" onclick="toggleNISBuses()">
-                <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
-                    % include('components/svg', name='check')
-                </div>
-                <span>Show NIS Buses</span>
-            </div>
-        </div>
-    % end
 </div>
 
 % if visible_positions:
-    <div id="map" class="full-screen"></div>
-    
+    <div id="settings" class="container collapsed">
+        <div class="section">
+            <div class="header">
+                <h3>Options</h3>
+            </div>
+            <div class="content">
+                <div class="options-container">
+                    <div class="option" onclick="toggleAutomaticRefresh()">
+                        <div id="auto-refresh-checkbox" class="checkbox {{ 'selected' if auto_refresh else '' }}">
+                            % include('components/svg', name='check')
+                        </div>
+                        <span>Automatically Refresh</span>
+                    </div>
+                    <div class="option" onclick="toggleRouteLines()">
+                        <div id="show-route-lines-checkbox" class="checkbox {{ 'selected' if show_route_lines else '' }}">
+                            % include('components/svg', name='check')
+                        </div>
+                        <span>Show Route Lines</span>
+                    </div>
+                    <div class="option" onclick="toggleNISBuses()">
+                        <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
+                            % include('components/svg', name='check')
+                        </div>
+                        <span>Show NIS Buses</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="section">
+            <div class="header">
+                <h3>Icon Style</h3>
+            </div>
+            <div class="content">
+                <div class="options-container">
+                    <div class="option" onclick="setBusMarkerStyle('default')">
+                        <div id="bus-marker-style-default" class="radio-button {{ 'selected' if not bus_marker_style or bus_marker_style == 'default' else '' }}"></div>
+                        <div>Bus Type</div>
+                    </div>
+                    <div class="option" onclick="setBusMarkerStyle('mini')">
+                        <div id="bus-marker-style-mini" class="radio-button {{ 'selected' if bus_marker_style == 'mini' else '' }}"></div>
+                        <div>Mini</div>
+                    </div>
+                    <div class="option" onclick="setBusMarkerStyle('route')">
+                        <div id="bus-marker-style-route" class="radio-button {{ 'selected' if bus_marker_style == 'route' else '' }}"></div>
+                        <div>Route Number</div>
+                    </div>
+                    <div class="option" onclick="setBusMarkerStyle('adherence')">
+                        <div id="bus-marker-style-adherence" class="radio-button {{ 'selected' if bus_marker_style == 'adherence' else '' }}"></div>
+                        <div>Schedule Adherence</div>
+                    </div>
+                    <div class="option" onclick="setBusMarkerStyle('occupancy')">
+                        <div id="bus-marker-style-occupancy" class="radio-button {{ 'selected' if bus_marker_style == 'occupancy' else '' }}"></div>
+                        <div>Occupancy</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+% end
+
+% if visible_positions:
     % include('components/svg_script', name='fish')
     % include('components/svg_script', name='no-people')
     % include('components/svg_script', name='one-person')
@@ -76,8 +113,8 @@
         let automaticRefresh = "{{ auto_refresh }}" !== "False";
         let showRouteLines = "{{ show_route_lines }}" !== "False";
         let showNISBuses = "{{ show_nis }}" !== "False";
+        let busMarkerStyle = "{{ bus_marker_style }}";
         let hoverPosition = null;
-        const busMarkerStyle = "{{ bus_marker_style }}";
         
         const shapes = {};
         
@@ -178,7 +215,7 @@
                         if (position.lat === 0 && position.lon === 0) {
                             icon.innerHTML += getSVG("fish");
                         } else {
-                            icon.innerHTML += "N/A";
+                            icon.innerHTML += "NIS";
                         }
                     } else {
                         if (position.lat === 0 && position.lon === 0) {
@@ -368,6 +405,14 @@
             }
         }
         
+        function setBusMarkerStyle(style) {
+            document.getElementById("bus-marker-style-" + busMarkerStyle).classList.remove("selected");
+            busMarkerStyle = style;
+            document.getElementById("bus-marker-style-" + style).classList.add("selected");
+            setCookie("bus_marker_style", style);
+            updateMap(false);
+        }
+        
         function updatePositionData() {
             const request = new XMLHttpRequest();
             request.open("GET", "{{get_url(system, 'api', 'map.json')}}", true);
@@ -505,8 +550,6 @@
             }, 1000 * 60);
         }, 1000 * (timeToNextUpdate + 15));
     </script>
-
-    % include('components/map_toggle')
 % else:
     <div class="container">
         <div class="section">

--- a/views/pages/personalize.tpl
+++ b/views/pages/personalize.tpl
@@ -139,7 +139,7 @@
                 <div class="options-container">
                     <div class="option" onclick="setBusMarkerStyle('default')">
                         <div class="radio-button {{ 'selected' if not bus_marker_style or bus_marker_style == 'default' else '' }}"></div>
-                        <div>Default</div>
+                        <div>Bus Type</div>
                     </div>
                     <div class="option" onclick="setBusMarkerStyle('mini')">
                         <div class="radio-button {{ 'selected' if bus_marker_style == 'mini' else '' }}"></div>

--- a/views/pages/route/map.tpl
+++ b/views/pages/route/map.tpl
@@ -19,8 +19,6 @@
     % departures = route.find_departures()
     
     % include('components/map', is_preview=False, map_trips=trips, map_departures=departures, map_positions=positions)
-
-    % include('components/map_toggle')
 % else:
     <div class="placeholder">
         % if system.gtfs_loaded:

--- a/views/pages/routes/map.tpl
+++ b/views/pages/routes/map.tpl
@@ -29,13 +29,14 @@
 </div>
 
 % if routes:
-    <div id="map" class="full-screen display-none"></div>
     <div id="map-loading">
         % include('components/loading')
         <h2>Loading...</h2>
     </div>
     
     <script>
+        document.getElementById("map").classList.add("display-none");
+        
         const map = new ol.Map({
             target: 'map',
             layers: [
@@ -207,8 +208,6 @@
             request.send();
         }
     </script>
-
-    % include('components/map_toggle')
 % else:
     <div class="placeholder">
         % if not system:

--- a/views/pages/routes/map.tpl
+++ b/views/pages/routes/map.tpl
@@ -15,25 +15,18 @@
             <a href="{{ get_url(system, 'routes') }}" class="tab-button">List</a>
             <span class="tab-button current">Map</span>
         </div>
-        % if routes:
-            <div id="settings" class="options-container collapsed">
-                <div class="option" onclick="toggleRouteNumbers()">
-                    <div id="route-numbers-checkbox" class="checkbox {{ 'selected' if show_route_numbers else '' }}">
-                        % include('components/svg', name='check')
-                    </div>
-                    <span>Show Route Numbers</span>
-                </div>
-            </div>
-        % end
     </div>
 </div>
 
 % if routes:
-    <div id="map-loading">
-        % include('components/loading')
-        <h2>Loading...</h2>
+    <div id="settings" class="options-container collapsed">
+        <div class="option" onclick="toggleRouteNumbers()">
+            <div id="route-numbers-checkbox" class="checkbox {{ 'selected' if show_route_numbers else '' }}">
+                % include('components/svg', name='check')
+            </div>
+            <span>Show Route Numbers</span>
+        </div>
     </div>
-    
     <script>
         document.getElementById("map").classList.add("display-none");
         
@@ -181,6 +174,7 @@
         }
         
         document.body.onload = function() {
+            startLoading();
             const request = new XMLHttpRequest();
             request.open("GET", "{{ get_url(system, 'api', 'routes') }}", true);
             request.responseType = "json";
@@ -201,8 +195,7 @@
                             });
                         }
                     }
-                    stopLoadingInterval();
-                    document.getElementById("map-loading").remove();
+                    stopLoading();
                 }
             };
             request.send();

--- a/views/pages/stop/map.tpl
+++ b/views/pages/stop/map.tpl
@@ -17,5 +17,3 @@
 % departures = stop.find_adjacent_departures()
 
 % include('components/map', is_preview=False, map_trips=trips, map_departures=departures, map_stop=stop, zoom_trips=False, zoom_departures=False)
-
-% include('components/map_toggle')

--- a/views/pages/trip/map.tpl
+++ b/views/pages/trip/map.tpl
@@ -16,5 +16,3 @@
 % departures = trip.find_departures()
 
 % include('components/map', is_preview=False, map_trip=trip, map_departures=departures, map_positions=positions)
-
-% include('components/map_toggle')


### PR DESCRIPTION
- Redesigned map page menu
  - Existing settings are now under "Options" heading
  - Added "Icon Style" section with radio buttons for the various styles
  - Selecting new styles updates the cookie for future use, and updates the existing icons on the map
  - On mobile/tablet, both sections are still hidden by default and toggled with the controls icon
- Refactored full map page logic
  - Previously, the map was contained within the `page` div, and the `page-header` div was shown in the top left with the transparent background
  - Now, the map is contained in the base file at the same level as the `page`, and the page in its entirety is now shown in the top left
  - Basically we can now put things in the page like normal on full map screens and it will appear in the box, instead of having to stick everything in the "header"
  - There's some slight changes to spacing (more of a gap below the title, slight changes to the margins/padding of the box itself) but overall the appearance is unchanged
- A few other changes and improvements
  - When `full_map` is set to `True` when creating the map, `include_maps` is now also true by default, instead of having to set it as well
  - Renamed the "Default" icon style to "Bus Type"
  - When style is set to "Adherence", NIS buses now show NIS instead of N/A
  - The loading indicator has been moved to the base file as well, so we can potentially use it with maps other than the routes map. This is left as future work to do separately

![Screenshot from 2025-01-30 21-27-02](https://github.com/user-attachments/assets/9b3ec590-4cc7-49f1-8854-7f7cb016bf24)
