### PR TITLE
Fix favourite stops

### DIFF
--- a/views/pages/home.tpl
+++ b/views/pages/home.tpl
@@ -212,8 +212,8 @@
                                     <table>
                                         <thead>
                                             <tr>
-                                                <th>Stop Number</th>
-                                                <th>Stop Name</th>
+                                                <th>Stop</th>
+                                                <th>Routes</th>
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -228,9 +228,11 @@
                                                     % value = favourite.value
                                                     <tr>
                                                         <td>
-                                                            <a href="{{ get_url(value.system, 'stops', value) }}">{{ value.number }}</a>
+                                                            % include('components/stop', stop=value)
                                                         </td>
-                                                        <td>{{ value.name }}</td>
+                                                        <td>
+                                                            % include('components/route_list', routes=value.routes)
+                                                        </td>
                                                     </tr>
                                                 % end
                                             % end


### PR DESCRIPTION
I'm not sure if I somehow accidentally reverted this or just missed it entirely, but the favourite stops list on the homepage wasn't using the new stop component that was introduced with agencies - it still had separate columns for number and name. For systems without numbers this was showing the internal ID.

I've fixed this to now use the stop component with the optional number badge, for both consistency and better design when there's no number. Since doing this also freed up some extra space in the table, I've also added the stop's routes as a column.

In the past I know there's been requests to have these favourite stops show one or two upcoming departures as a quick way to see what's coming without having to go to the stop page itself. I agree this would be quite useful, but because of the small width even on desktop, there isn't much space to show that info. I'll probably tinker with that idea more in the future but for now I'll just keep the stop name/code and routes.

![Screenshot from 2025-01-30 22-20-24](https://github.com/user-attachments/assets/fa80cd8c-8d1b-4be6-90c6-95682c47db60)
