### PR TITLE
Map settings toggle on desktop

### DIFF
--- a/server.py
+++ b/server.py
@@ -21,7 +21,7 @@ from repositories import *
 from services import *
 
 # Increase the version to force CSS reload
-VERSION = 50
+VERSION = 51
 
 random = Random()
 

--- a/style/devices/desktop.css
+++ b/style/devices/desktop.css
@@ -16,6 +16,7 @@ body {
 body.full-map #page {
     padding: 10px 20px 10px 20px;
     width: fit-content;
+    min-width: 250px;
 }
 
 input[type="text"] {

--- a/style/devices/mobile.css
+++ b/style/devices/mobile.css
@@ -10,6 +10,10 @@ body.full-map {
     overflow: hidden;
 }
 
+body.full-map #main {
+    overflow: hidden;
+}
+
 body.full-map #page {
     padding: 10px 20px 10px 20px;
 }
@@ -178,10 +182,6 @@ table th {
 
 #search-results .result .description {
     font-size: 11pt;
-}
-
-#settings.collapsed {
-    display: none !important;
 }
 
 #side-bar {

--- a/style/devices/tablet.css
+++ b/style/devices/tablet.css
@@ -10,6 +10,10 @@ body.full-map {
     overflow: hidden;
 }
 
+body.full-map #main {
+    overflow: hidden;
+}
+
 body.full-map #page {
     padding: 10px 20px 10px 20px;
 }
@@ -158,10 +162,6 @@ table {
 
 #search-results .result .description {
     font-size: 12pt;
-}
-
-#settings.collapsed {
-    display: none !important;
 }
 
 #side-bar {

--- a/style/main.css
+++ b/style/main.css
@@ -23,6 +23,8 @@ body.full-map #page {
     z-index: 20;
     border-radius: 10px;
     margin: 10px 20px;
+    overflow: auto;
+    max-height: calc(100% - 120px);
 }
 
 body.full-map #page-header {
@@ -216,7 +218,6 @@ table tr.header td {
     border-width: 1px;
     border-style: solid;
 }
-
 
 #map .ol-zoom {
     top: unset;
@@ -427,6 +428,10 @@ table tr.header td {
     flex: 1;
     display: flex;
     flex-direction: column;
+}
+
+#settings.collapsed {
+    display: none !important;
 }
 
 #side-bar {
@@ -1438,6 +1443,10 @@ table tr.header td {
 .toggle-button {
     --image-color: var(--toggle-button-color);
     --image-size: 30px;
+}
+
+.toggle-button:hover {
+    cursor: pointer;
 }
 
 .tooltip-anchor {

--- a/views/components/settings_toggle.tpl
+++ b/views/components/settings_toggle.tpl
@@ -1,4 +1,4 @@
-<div class="non-desktop toggle-button" onclick="toggleSettings()">
+<div class="toggle-button" onclick="toggleSettings()">
     % include('components/svg', name='settings')
 </div>
 <script>


### PR DESCRIPTION
Added ability to toggle the settings menu open and closed on desktop, like you currently can on mobile/tablet. Like those, it currently defaults to closed when the page is first loaded, and can be opened if needed. Based on user feedback, we could choose down the road to store the state so when the user returns to the page it'll be either open or closed.

To keep things fairly consistent, a min width of 250px is added on desktop, so the toggle doesn't move between open/closed states. If the settings ever become wider than 250 however we may need to adjust this. Min width is used rather than a fixed width because the page element on some other map screens may be wider (eg the map page for a specific route).

![Screenshot from 2025-02-09 10-24-46](https://github.com/user-attachments/assets/8f828b8d-4840-4f6d-9f2f-aa3cac58870a)

I also fixed a minor bug in which the settings menu could get cut off at the bottom of the screen if there isn't enough space for it. The page view will now be cut off at the bottom (with space underneath for the zoom/toggle buttons) and scrolls its inner content. This is mainly only an issue on very small screens right now, but could become more relevant if we add new settings or filters (eg the ability to filter by route could make it very tall in some systems). This fix applies to all screen sizes.

![Screenshot from 2025-02-09 10-30-18](https://github.com/user-attachments/assets/e868e56f-8f69-40d0-8379-3a54958a99d8)

![Screenshot from 2025-02-09 10-24-24](https://github.com/user-attachments/assets/1baf2985-debd-4f31-bd1f-11d7a0e2e2ca)
