### PR TITLE
Allow viewing map even when no buses available

### DIFF
--- a/js/area.js
+++ b/js/area.js
@@ -1,10 +1,10 @@
 
 class Area {
-    constructor() {
-        this.minLat = null;
-        this.maxLat = null;
-        this.minLon = null;
-        this.maxLon = null;
+    constructor(minLat = null, maxLat = null, minLon = null, maxLon = null) {
+        this.minLat = minLat === null ? null : parseFloat(minLat);
+        this.maxLat = maxLat === null ? null : parseFloat(maxLat);
+        this.minLon = minLon === null ? null : parseFloat(minLon);
+        this.maxLon = maxLon === null ? null : parseFloat(maxLon);
     }
     
     get isValid() {

--- a/models/area.py
+++ b/models/area.py
@@ -1,0 +1,32 @@
+
+class Area:
+    '''A geographic area defined by min/max latitudes and longitudes'''
+    
+    __slots__ = (
+        'min_lat',
+        'max_lat',
+        'min_lon',
+        'max_lon'
+    )
+    
+    @classmethod
+    def from_db(cls, row):
+        '''Returns an area initialized from the given database row'''
+        area = cls(**row)
+        if area.min_lat is None and area.max_lat is None and area.min_lon is None and area.max_lon is None:
+            return None
+        return area
+    
+    @classmethod
+    def calculate(cls, lats, lons):
+        '''Returns the area of the given lats and lons'''
+        return cls(min(lats), max(lats), min(lons), max(lons))
+    
+    def __init__(self, min_lat, max_lat, min_lon, max_lon):
+        self.min_lat = min_lat
+        self.max_lat = max_lat
+        self.min_lon = min_lon
+        self.max_lon = max_lon
+    
+    def __eq__(self, other):
+        return self.min_lat == other.min_lat and self.max_lat == other.max_lat and self.min_lon == other.min_lon and self.max_lon == other.max_lon

--- a/repositories/sql/stop.py
+++ b/repositories/sql/stop.py
@@ -96,7 +96,13 @@ class SQLStopRepository(StopRepository):
                 'MAX(stop.lon)': 'max_lon'
             },
             filters={
-                'stop.system_id': system_id
+                'stop.system_id': system_id,
+                'stop.lat': {
+                    '!=': 0
+                },
+                'stop.lon': {
+                    '!=': 0
+                }
             },
             initializer=Area.from_db
         )

--- a/repositories/sql/stop.py
+++ b/repositories/sql/stop.py
@@ -1,6 +1,7 @@
 
 from database import Database
 
+from models.area import Area
 from models.stop import Stop
 
 from repositories import StopRepository
@@ -83,6 +84,26 @@ class SQLStopRepository(StopRepository):
             limit=limit,
             initializer=Stop.from_db
         )
+    
+    def find_area(self, system):
+        system_id = getattr(system, 'id', system)
+        areas = self.database.select(
+            table='stop',
+            columns={
+                'MIN(stop.lat)': 'min_lat',
+                'MAX(stop.lat)': 'max_lat',
+                'MIN(stop.lon)': 'min_lon',
+                'MAX(stop.lon)': 'max_lon'
+            },
+            filters={
+                'stop.system_id': system_id
+            },
+            initializer=Area.from_db
+        )
+        try:
+            return areas[0]
+        except IndexError:
+            return None
     
     def delete_all(self, system):
         '''Deletes all stops for the given system from the database'''

--- a/repositories/stop.py
+++ b/repositories/stop.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from abc import ABC, abstractmethod
 
 if TYPE_CHECKING:
+    from models.area import Area
     from models.stop import Stop
 
 class StopRepository(ABC):
@@ -18,6 +19,10 @@ class StopRepository(ABC):
     
     @abstractmethod
     def find_all(self, system, limit=None, lat=None, lon=None, size=0.01) -> list[Stop]:
+        raise NotImplementedError()
+    
+    @abstractmethod
+    def find_area(self, system) -> Area:
         raise NotImplementedError()
     
     @abstractmethod

--- a/server.py
+++ b/server.py
@@ -424,20 +424,20 @@ class Server(Bottle):
         show_route_lines = self.query_cookie('show_route_lines', 'false') != 'false'
         show_stops = self.query_cookie('show_stops', 'true') != 'false'
         show_nis = self.query_cookie('show_nis', 'true') != 'false'
-        visible_positions = positions if show_nis else [p for p in positions if p.trip]
+        stop_area = self.stop_repository.find_area(system)
         return self.page(
             name='map',
             title='Map',
             path=['map'],
             system=system,
             agency=agency,
-            full_map=len(visible_positions) > 0,
+            full_map=True,
             positions=sorted(positions, key=lambda p: p.lat),
             auto_refresh=auto_refresh,
             show_route_lines=show_route_lines,
             show_stops=show_stops,
             show_nis=show_nis,
-            visible_positions=visible_positions
+            stop_area=stop_area
         )
     
     def realtime_all(self, system, agency):

--- a/style/main.css
+++ b/style/main.css
@@ -25,6 +25,7 @@ body.full-map #page {
     margin: 10px 20px;
     overflow: auto;
     max-height: calc(100% - 120px);
+    gap: 5px;
 }
 
 body.full-map #page-header {

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -273,12 +273,11 @@
         <div id="navigation-bar">
             <a class="navigation-item title non-desktop" href="{{ get_url(system) }}">BCTracker</a>
             
+            <a class="navigation-item non-mobile" href="{{ get_url(system, 'map') }}">Map</a>
             % if not system or system.realtime_enabled:
-                <a class="navigation-item non-mobile" href="{{ get_url(system, 'map') }}">Map</a>
                 <a class="navigation-item non-mobile" href="{{ get_url(system, 'realtime') }}">Realtime</a>
                 <a class="navigation-item desktop-only" href="{{ get_url(system, 'history') }}">History</a>
             % else:
-                <div class="navigation-item non-mobile disabled">Map</div>
                 <div class="navigation-item non-mobile disabled">Realtime</div>
                 <div class="navigation-item desktop-only disabled">History</div>
             % end
@@ -328,11 +327,11 @@
             </div>
         </div>
         <div id="navigation-menu" class="non-desktop display-none">
+            <a class="menu-button mobile-only" href="{{ get_url(system, 'map') }}">
+                % include('components/svg', name='map')
+                <span>Map</span>
+            </a>
             % if not system or system.realtime_enabled:
-                <a class="menu-button mobile-only" href="{{ get_url(system, 'map') }}">
-                    % include('components/svg', name='map')
-                    <span>Map</span>
-                </a>
                 <a class="menu-button mobile-only" href="{{ get_url(system, 'realtime') }}">
                     % include('components/svg', name='realtime')
                     <span>Realtime</span>
@@ -342,10 +341,6 @@
                     <span>History</span>
                 </a>
             % else:
-                <div class="menu-button mobile-only disabled">
-                    % include('components/svg', name='map')
-                    <span>Map</span>
-                </div>
                 <div class="menu-button mobile-only disabled">
                     % include('components/svg', name='realtime')
                     <span>Realtime</span>

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -18,6 +18,16 @@
     </div>
 </div>
 
+<div id="no-buses-message" class="{{ 'display-none' if positions else '' }}">
+    % if system and not system.realtime_enabled:
+        <i>{{ system }} realtime information is not supported</i>
+    % elif system:
+        <i>There are no {{ system }} buses out right now</i>
+    % else:
+        <i>There are no buses out right now</i>
+    % end
+</div>
+
 % if not system or system.realtime_enabled:
     <div id="settings" class="container collapsed">
         <div class="section">
@@ -139,6 +149,12 @@
         busMarkers = [];
         
         const area = new Area();
+        
+        if (positions.length === 0) {
+            document.getElementById("no-buses-message").classList.remove("display-none");
+        } else {
+            document.getElementById("no-buses-message").classList.add("display-none");
+        }
         
         for (const position of positions) {
             if (position.shape_id !== null && position.shape_id !== undefined) {

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -3,16 +3,22 @@
 
 % rebase('base')
 
+% include('components/svg_script', name='fish')
+% include('components/svg_script', name='no-people')
+% include('components/svg_script', name='one-person')
+% include('components/svg_script', name='two-people')
+% include('components/svg_script', name='three-people')
+
 <div id="page-header">
     <div class="row">
         <h1 class="flex-1">Map</h1>
-        % if visible_positions:
+        % if not system or system.realtime_enabled:
             % include('components/settings_toggle')
         % end
     </div>
 </div>
 
-% if visible_positions:
+% if not system or system.realtime_enabled:
     <div id="settings" class="container collapsed">
         <div class="section">
             <div class="header">
@@ -79,392 +85,454 @@
     </div>
 % end
 
-% if visible_positions:
-    % include('components/svg_script', name='fish')
-    % include('components/svg_script', name='no-people')
-    % include('components/svg_script', name='one-person')
-    % include('components/svg_script', name='two-people')
-    % include('components/svg_script', name='three-people')
-    
+% if stop_area:
     <script>
-        map.on('moveend', function(event) {
+        const initialArea = new Area("{{ stop_area.min_lat }}", "{{ stop_area.max_lat }}", "{{ stop_area.min_lon }}", "{{ stop_area.max_lon }}");
+        const initialTopPadding = window.screen.width > 1000 ? 100 : 200;
+        const initialLeftPadding = window.screen.width > 1000 ? 400 : 100;
+        map.getView().fit(ol.proj.transformExtent(initialArea.box, ol.proj.get("EPSG:4326"), ol.proj.get("EPSG:3857")), {
+            padding: [initialTopPadding, 100, 100, initialLeftPadding]
+        });
+    </script>
+% end
+
+<script>
+    let positions = JSON.parse('{{! json.dumps([p.get_json() for p in positions]) }}');
+    let currentShapeIDs = [];
+    let routeLayers = {};
+    let automaticRefresh = "{{ auto_refresh }}" !== "False";
+    let showRouteLines = "{{ show_route_lines }}" !== "False";
+    let showStops = "{{ show_stops }}" !== "False";
+    let showNISBuses = "{{ show_nis }}" !== "False";
+    let busMarkerStyle = "{{ bus_marker_style or 'default' }}";
+    let hoverPosition = null;
+    
+    let busMarkers = [];
+    
+    const shapes = {};
+    
+    const cachedStops = {};
+    const stopMarkers = {};
+    let currentStopKeys = new Set();
+    
+    document.body.onload = function() {
+        map.updateSize();
+    }
+    
+    updateMap(true);
+    if (showRouteLines) {
+        updateRouteData();
+    }
+    
+    map.on('moveend', function(event) {
+        const zoom = map.getView().getZoom();
+        const extent = map.getView().calculateExtent(map.getSize());
+        const box = ol.proj.transformExtent(extent, 'EPSG:3857', 'EPSG:4326');
+        updateStops(zoom, box);
+    });
+    
+    function updateMap(resetCoordinates) {
+        currentShapeIDs = [];
+        for (const marker of busMarkers) {
+            map.removeOverlay(marker);
+        }
+        busMarkers = [];
+        
+        const area = new Area();
+        
+        for (const position of positions) {
+            if (position.shape_id !== null && position.shape_id !== undefined) {
+                const shapeID = position.system_id + "_" + position.shape_id;
+                if (!(currentShapeIDs.includes(shapeID))) {
+                    currentShapeIDs.push(shapeID);
+                }
+            }
+            
+            const adherence = position.adherence;
+            
+            const element = document.createElement("div");
+            element.id = "bus-marker-" + position.bus_number;
+            element.className = "marker";
+            if (position.shape_id === null || position.shape_id === undefined) {
+                element.classList.add("nis-bus");
+                if (!showNISBuses) {
+                    element.classList.add("display-none");
+                }
+            }
+            if (position.bearing !== undefined) {
+                const sideWidthValue = busMarkerStyle == "mini" ? 8 : 16;
+                const bottomWidthValue = busMarkerStyle == "mini" ? 18 : 26;
+                const length = Math.floor(position.speed / 10);
+                const bearing = document.createElement("div");
+                bearing.className = "bearing";
+                if (busMarkerStyle === "adherence") {
+                    bearing.classList.add('adherence');
+                    if (adherence !== undefined && adherence !== null) {
+                        bearing.classList.add(adherence.status_class)
+                    }
+                } else if (busMarkerStyle === "occupancy") {
+                    bearing.classList.add("occupancy");
+                    bearing.classList.add(position.occupancy_status_class);
+                } else {
+                    bearing.style.borderBottomColor = "#" + position.colour;
+                }
+                bearing.style.marginTop = (-8 - length) + "px";
+                bearing.style.borderLeftWidth = sideWidthValue + "px";
+                bearing.style.borderRightWidth = sideWidthValue + "px";
+                bearing.style.borderBottomWidth = (bottomWidthValue + length) + "px";
+                bearing.style.transform = "rotate(" + position.bearing + "deg)";
+                element.appendChild(bearing)
+            }
+            
+            let icon;
+            if (position.bus_number < 0) {
+                icon = document.createElement("div");
+            } else {
+                icon = document.createElement("a");
+                icon.href = getUrl(systemID, "bus/" + position.bus_url_id);
+                icon.innerHTML = "<div class='link'></div>"
+            }
+            icon.className = "icon";
+            icon.onmouseenter = function() {
+                setHoverPosition(position);
+            }
+            icon.onmouseleave = function() {
+                setHoverPosition(null);
+            }
+            element.appendChild(icon);
+            
+            if (busMarkerStyle === "route") {
+                icon.classList.add("bus_route");
+                if (position.lat === 0 && position.lon === 0) {
+                    icon.innerHTML += getSVG("fish");
+                } else {
+                    icon.innerHTML += position.route_number;
+                }
+                icon.style.backgroundColor = "#" + position.colour;
+            } else if (busMarkerStyle === "mini") {
+                element.classList.add("small");
+                icon.classList.add("mini");
+                icon.style.backgroundColor = "#" + position.colour;
+            } else if (busMarkerStyle === "adherence") {
+                icon.classList.add("adherence");
+                if (adherence === undefined || adherence === null) {
+                    if (position.lat === 0 && position.lon === 0) {
+                        icon.innerHTML += getSVG("fish");
+                    } else if (position.route_number === "NIS") {
+                        icon.innerHTML += "NIS";
+                    } else {
+                        icon.innerHTML += "N/A"
+                    }
+                } else {
+                    if (position.lat === 0 && position.lon === 0) {
+                        icon.innerHTML += getSVG("fish");
+                    } else {
+                        icon.innerHTML += adherence.value;
+                    }
+                    icon.classList.add(adherence.status_class);
+                    const adherenceValue = parseInt(adherence.value);
+                    if (adherenceValue >= 100 || adherenceValue <= -100) {
+                        icon.classList.add("smaller-font");
+                    }
+                }
+            } else if (busMarkerStyle === "occupancy") {
+                icon.classList.add("occupancy");
+                icon.classList.add(position.occupancy_status_class);
+                if (position.lat === 0 && position.lon === 0) {
+                    icon.innerHTML += getSVG("fish");
+                } else {
+                    icon.innerHTML += getSVG(position.occupancy_icon);
+                }
+            } else {
+                if (position.lat === 0 && position.lon === 0) {
+                    icon.innerHTML += getSVG("fish");
+                } else {
+                    icon.innerHTML += getSVG(position.bus_icon);
+                }
+                icon.style.backgroundColor = "#" + position.colour;
+            }
+            
+            const details = document.createElement("div");
+            details.className = "details";
+            element.appendChild(details);
+            
+            const title = document.createElement("div");
+            title.className = "title";
+            title.innerHTML = position.bus_display;
+            if (position.adornment != null) {
+                title.innerHTML += " <span class='adornment'>" + position.adornment + "</span>";
+            }
+            details.appendChild(title);
+            
+            const content = document.createElement("div");
+            content.className = "content hover-only";
+            details.appendChild(content);
+            
+            const model = document.createElement("div");
+            model.className = "lighter-text";
+            model.innerHTML = position.bus_order;
+            content.appendChild(model);
+            
+            const headsign = document.createElement("div");
+            if (position.headsign === "Not In Service") {
+                headsign.innerHTML = position.headsign;
+            } else {
+                headsign.className = "headsign";
+            
+                const routeLine = document.createElement("div");
+                routeLine.className = "route-line";
+                routeLine.style.backgroundColor = "#" + position.colour;
+                
+                headsign.innerHTML = routeLine.outerHTML + position.headsign;
+            }
+            content.appendChild(headsign);
+        
+            const footer = document.createElement("div");
+            footer.className = "lighter-text";
+            content.appendChild(footer);
+            
+            const systemElement = document.createElement("span");
+            systemElement.innerHTML = position.system;
+            footer.appendChild(systemElement);
+            
+            if (position.timestamp) {
+                if (systemElement) {
+                    const separator = document.createElement("span")
+                    separator.innerHTML = " • ";
+                    footer.appendChild(separator);
+                }
+                const timestamp = document.createElement("span");
+                footer.appendChild(timestamp);
+                updateTimestampFunctions.push(function(currentTime) {
+                    const difference = getDifference(currentTime, (position.timestamp * 1000) + timestampOffset);
+                    timestamp.innerHTML = difference;
+                });
+            }
+            
+            const iconsRow = document.createElement("div");
+            iconsRow.className = "row center gap-5";
+            content.appendChild(iconsRow);
+            
+            if (adherence !== null && adherence !== undefined) {
+                const adherenceElement = document.createElement("div");
+                adherenceElement.classList.add("adherence-indicator", adherence.status_class);
+                adherenceElement.innerHTML = adherence.value;
+                iconsRow.appendChild(adherenceElement);
+            }
+            
+            const occupancyIcon = document.createElement("div");
+            occupancyIcon.className = "occupancy-icon";
+            occupancyIcon.classList.add(position.occupancy_status_class);
+            occupancyIcon.innerHTML = getSVG(position.occupancy_icon);
+            iconsRow.appendChild(occupancyIcon);
+            
+            const agencyLogo = document.createElement("img");
+            agencyLogo.className = "agency-logo";
+            agencyLogo.src = "/img/icons/" + position.agency_id + ".png";
+            agencyLogo.onerror = function() {
+                agencyLogo.style.visibility = 'hidden';
+            };
+            iconsRow.appendChild(agencyLogo);
+            
+            if (position.lat != 0 && position.lon != 0) {
+                area.combine(position.lat, position.lon);
+            }
+            
+            const marker = new ol.Overlay({
+                position: ol.proj.fromLonLat([position.lon, position.lat]),
+                positioning: 'center-center',
+                element: element,
+                stopEvent: false,
+            });
+            map.addOverlay(marker);
+            busMarkers.push(marker);
+        }
+        
+        if (resetCoordinates && area.isValid) {
+            if (area.isPoint) {
+                map.getView().setCenter(ol.proj.fromLonLat(area.point));
+                map.getView().setZoom(15);
+            } else {
+                const topPadding = window.screen.width > 1000 ? 100 : 200;
+                const leftPadding = window.screen.width > 1000 ? 400 : 100;
+                map.getView().fit(ol.proj.transformExtent(area.box, ol.proj.get("EPSG:4326"), ol.proj.get("EPSG:3857")), {
+                    padding: [topPadding, 100, 100, leftPadding]
+                });
+            }
+        }
+        
+        for (const shapeID in shapes) {
+            if (currentShapeIDs.includes(shapeID)) {
+                shapes[shapeID].setVisible(showRouteLines);
+            } else {
+                shapes[shapeID].setVisible(false);
+            }
+        }
+    }
+    
+    function toggleAutomaticRefresh() {
+        automaticRefresh = !automaticRefresh;
+        const checkbox = document.getElementById("auto-refresh-checkbox");
+        checkbox.classList.toggle("selected");
+        setCookie("auto_refresh", automaticRefresh ? "true" : "false");
+        
+        if (automaticRefresh) {
+            updatePositionData();
+        }
+    }
+    
+    function toggleRouteLines() {
+        showRouteLines = !showRouteLines;
+        const checkbox = document.getElementById("show-route-lines-checkbox");
+        checkbox.classList.toggle("selected");
+        setCookie("show_route_lines", showRouteLines ? "true" : "false");
+        
+        for (const shapeID of currentShapeIDs) {
+            if (shapeID in shapes) {
+                shapes[shapeID].setVisible(showRouteLines);
+            }
+        }
+        if (showRouteLines) {
+            updateRouteData();
+        }
+    }
+    
+    function toggleStops() {
+        showStops = !showStops;
+        const checkbox = document.getElementById("show-stops-checkbox");
+        checkbox.classList.toggle("selected");
+        setCookie("show_stops", showStops ? "true" : "false");
+        
+        if (showStops) {
             const zoom = map.getView().getZoom();
             const extent = map.getView().calculateExtent(map.getSize());
             const box = ol.proj.transformExtent(extent, 'EPSG:3857', 'EPSG:4326');
             updateStops(zoom, box);
-        });
-        
-        let positions = JSON.parse('{{! json.dumps([p.get_json() for p in positions]) }}');
-        let currentShapeIDs = [];
-        let routeLayers = {};
-        let automaticRefresh = "{{ auto_refresh }}" !== "False";
-        let showRouteLines = "{{ show_route_lines }}" !== "False";
-        let showStops = "{{ show_stops }}" !== "False";
-        let showNISBuses = "{{ show_nis }}" !== "False";
-        let busMarkerStyle = "{{ bus_marker_style or 'default' }}";
-        let hoverPosition = null;
-        
-        let busMarkers = [];
-        
-        const shapes = {};
-        
-        const cachedStops = {};
-        const stopMarkers = {};
-        let currentStopKeys = new Set();
-        
-        document.body.onload = function() {
-            map.updateSize();
-        }
-        
-        updateMap(true);
-        if (showRouteLines) {
-            updateRouteData();
-        }
-        
-        function updateMap(resetCoordinates) {
-            currentShapeIDs = [];
-            for (const marker of busMarkers) {
-                map.removeOverlay(marker);
-            }
-            busMarkers = [];
-            
-            const area = new Area();
-            
-            for (const position of positions) {
-                if (position.shape_id !== null && position.shape_id !== undefined) {
-                    const shapeID = position.system_id + "_" + position.shape_id;
-                    if (!(currentShapeIDs.includes(shapeID))) {
-                        currentShapeIDs.push(shapeID);
-                    }
-                }
-                
-                const adherence = position.adherence;
-                
-                const element = document.createElement("div");
-                element.id = "bus-marker-" + position.bus_number;
-                element.className = "marker";
-                if (position.shape_id === null || position.shape_id === undefined) {
-                    element.classList.add("nis-bus");
-                    if (!showNISBuses) {
-                        element.classList.add("display-none");
-                    }
-                }
-                if (position.bearing !== undefined) {
-                    const sideWidthValue = busMarkerStyle == "mini" ? 8 : 16;
-                    const bottomWidthValue = busMarkerStyle == "mini" ? 18 : 26;
-                    const length = Math.floor(position.speed / 10);
-                    const bearing = document.createElement("div");
-                    bearing.className = "bearing";
-                    if (busMarkerStyle === "adherence") {
-                        bearing.classList.add('adherence');
-                        if (adherence !== undefined && adherence !== null) {
-                            bearing.classList.add(adherence.status_class)
-                        }
-                    } else if (busMarkerStyle === "occupancy") {
-                        bearing.classList.add("occupancy");
-                        bearing.classList.add(position.occupancy_status_class);
-                    } else {
-                        bearing.style.borderBottomColor = "#" + position.colour;
-                    }
-                    bearing.style.marginTop = (-8 - length) + "px";
-                    bearing.style.borderLeftWidth = sideWidthValue + "px";
-                    bearing.style.borderRightWidth = sideWidthValue + "px";
-                    bearing.style.borderBottomWidth = (bottomWidthValue + length) + "px";
-                    bearing.style.transform = "rotate(" + position.bearing + "deg)";
-                    element.appendChild(bearing)
-                }
-                
-                let icon;
-                if (position.bus_number < 0) {
-                    icon = document.createElement("div");
-                } else {
-                    icon = document.createElement("a");
-                    icon.href = getUrl(systemID, "bus/" + position.bus_url_id);
-                    icon.innerHTML = "<div class='link'></div>"
-                }
-                icon.className = "icon";
-                icon.onmouseenter = function() {
-                    setHoverPosition(position);
-                }
-                icon.onmouseleave = function() {
-                    setHoverPosition(null);
-                }
-                element.appendChild(icon);
-                
-                if (busMarkerStyle === "route") {
-                    icon.classList.add("bus_route");
-                    if (position.lat === 0 && position.lon === 0) {
-                        icon.innerHTML += getSVG("fish");
-                    } else {
-                        icon.innerHTML += position.route_number;
-                    }
-                    icon.style.backgroundColor = "#" + position.colour;
-                } else if (busMarkerStyle === "mini") {
-                    element.classList.add("small");
-                    icon.classList.add("mini");
-                    icon.style.backgroundColor = "#" + position.colour;
-                } else if (busMarkerStyle === "adherence") {
-                    icon.classList.add("adherence");
-                    if (adherence === undefined || adherence === null) {
-                        if (position.lat === 0 && position.lon === 0) {
-                            icon.innerHTML += getSVG("fish");
-                        } else if (position.route_number === "NIS") {
-                            icon.innerHTML += "NIS";
-                        } else {
-                            icon.innerHTML += "N/A"
-                        }
-                    } else {
-                        if (position.lat === 0 && position.lon === 0) {
-                            icon.innerHTML += getSVG("fish");
-                        } else {
-                            icon.innerHTML += adherence.value;
-                        }
-                        icon.classList.add(adherence.status_class);
-                        const adherenceValue = parseInt(adherence.value);
-                        if (adherenceValue >= 100 || adherenceValue <= -100) {
-                            icon.classList.add("smaller-font");
-                        }
-                    }
-                } else if (busMarkerStyle === "occupancy") {
-                    icon.classList.add("occupancy");
-                    icon.classList.add(position.occupancy_status_class);
-                    if (position.lat === 0 && position.lon === 0) {
-                        icon.innerHTML += getSVG("fish");
-                    } else {
-                        icon.innerHTML += getSVG(position.occupancy_icon);
-                    }
-                } else {
-                    if (position.lat === 0 && position.lon === 0) {
-                        icon.innerHTML += getSVG("fish");
-                    } else {
-                        icon.innerHTML += getSVG(position.bus_icon);
-                    }
-                    icon.style.backgroundColor = "#" + position.colour;
-                }
-                
-                const details = document.createElement("div");
-                details.className = "details";
-                element.appendChild(details);
-                
-                const title = document.createElement("div");
-                title.className = "title";
-                title.innerHTML = position.bus_display;
-                if (position.adornment != null) {
-                    title.innerHTML += " <span class='adornment'>" + position.adornment + "</span>";
-                }
-                details.appendChild(title);
-                
-                const content = document.createElement("div");
-                content.className = "content hover-only";
-                details.appendChild(content);
-                
-                const model = document.createElement("div");
-                model.className = "lighter-text";
-                model.innerHTML = position.bus_order;
-                content.appendChild(model);
-                
-                const headsign = document.createElement("div");
-                if (position.headsign === "Not In Service") {
-                    headsign.innerHTML = position.headsign;
-                } else {
-                    headsign.className = "headsign";
-                
-                    const routeLine = document.createElement("div");
-                    routeLine.className = "route-line";
-                    routeLine.style.backgroundColor = "#" + position.colour;
-                    
-                    headsign.innerHTML = routeLine.outerHTML + position.headsign;
-                }
-                content.appendChild(headsign);
-            
-                const footer = document.createElement("div");
-                footer.className = "lighter-text";
-                content.appendChild(footer);
-                
-                const systemElement = document.createElement("span");
-                systemElement.innerHTML = position.system;
-                footer.appendChild(systemElement);
-                
-                if (position.timestamp) {
-                    if (systemElement) {
-                        const separator = document.createElement("span")
-                        separator.innerHTML = " • ";
-                        footer.appendChild(separator);
-                    }
-                    const timestamp = document.createElement("span");
-                    footer.appendChild(timestamp);
-                    updateTimestampFunctions.push(function(currentTime) {
-                        const difference = getDifference(currentTime, (position.timestamp * 1000) + timestampOffset);
-                        timestamp.innerHTML = difference;
-                    });
-                }
-                
-                const iconsRow = document.createElement("div");
-                iconsRow.className = "row center gap-5";
-                content.appendChild(iconsRow);
-                
-                if (adherence !== null && adherence !== undefined) {
-                    const adherenceElement = document.createElement("div");
-                    adherenceElement.classList.add("adherence-indicator", adherence.status_class);
-                    adherenceElement.innerHTML = adherence.value;
-                    iconsRow.appendChild(adherenceElement);
-                }
-                
-                const occupancyIcon = document.createElement("div");
-                occupancyIcon.className = "occupancy-icon";
-                occupancyIcon.classList.add(position.occupancy_status_class);
-                occupancyIcon.innerHTML = getSVG(position.occupancy_icon);
-                iconsRow.appendChild(occupancyIcon);
-                
-                const agencyLogo = document.createElement("img");
-                agencyLogo.className = "agency-logo";
-                agencyLogo.src = "/img/icons/" + position.agency_id + ".png";
-                agencyLogo.onerror = function() {
-                    agencyLogo.style.visibility = 'hidden';
-                };
-                iconsRow.appendChild(agencyLogo);
-                
-                if (position.lat != 0 && position.lon != 0) {
-                    area.combine(position.lat, position.lon);
-                }
-                
-                const marker = new ol.Overlay({
-                    position: ol.proj.fromLonLat([position.lon, position.lat]),
-                    positioning: 'center-center',
-                    element: element,
-                    stopEvent: false,
-                });
-                map.addOverlay(marker);
-                busMarkers.push(marker);
-            }
-            
-            if (resetCoordinates && area.isValid) {
-                if (area.isPoint) {
-                    map.getView().setCenter(ol.proj.fromLonLat(area.point));
-                    map.getView().setZoom(15);
-                } else {
-                    const topPadding = window.screen.width > 1000 ? 100 : 200;
-                    const leftPadding = window.screen.width > 1000 ? 400 : 100;
-                    map.getView().fit(ol.proj.transformExtent(area.box, ol.proj.get("EPSG:4326"), ol.proj.get("EPSG:3857")), {
-                        padding: [topPadding, 100, 100, leftPadding]
-                    });
-                }
-            }
-            
-            for (const shapeID in shapes) {
-                if (currentShapeIDs.includes(shapeID)) {
-                    shapes[shapeID].setVisible(showRouteLines);
-                } else {
-                    shapes[shapeID].setVisible(false);
-                }
+        } else {
+            for (key in stopMarkers) {
+                removeStopMarkers(key);
             }
         }
+    }
+    
+    function toggleNISBuses() {
+        showNISBuses = !showNISBuses;
+        const checkbox = document.getElementById("show-nis-checkbox");
+        checkbox.classList.toggle("selected");
+        setCookie("show_nis", showNISBuses ? "true" : "false");
         
-        function toggleAutomaticRefresh() {
-            automaticRefresh = !automaticRefresh;
-            const checkbox = document.getElementById("auto-refresh-checkbox");
-            checkbox.classList.toggle("selected");
-            setCookie("auto_refresh", automaticRefresh ? "true" : "false");
-            
-            if (automaticRefresh) {
-                updatePositionData();
-            }
-        }
-        
-        function toggleRouteLines() {
-            showRouteLines = !showRouteLines;
-            const checkbox = document.getElementById("show-route-lines-checkbox");
-            checkbox.classList.toggle("selected");
-            setCookie("show_route_lines", showRouteLines ? "true" : "false");
-            
-            for (const shapeID of currentShapeIDs) {
-                if (shapeID in shapes) {
-                    shapes[shapeID].setVisible(showRouteLines);
-                }
-            }
-            if (showRouteLines) {
-                updateRouteData();
-            }
-        }
-        
-        function toggleStops() {
-            showStops = !showStops;
-            const checkbox = document.getElementById("show-stops-checkbox");
-            checkbox.classList.toggle("selected");
-            setCookie("show_stops", showStops ? "true" : "false");
-            
-            if (showStops) {
-                const zoom = map.getView().getZoom();
-                const extent = map.getView().calculateExtent(map.getSize());
-                const box = ol.proj.transformExtent(extent, 'EPSG:3857', 'EPSG:4326');
-                updateStops(zoom, box);
+        for (const element of document.getElementsByClassName("nis-bus")) {
+            if (showNISBuses) {
+                element.classList.remove("display-none");
             } else {
-                for (key in stopMarkers) {
-                    removeStopMarkers(key);
-                }
+                element.classList.add("display-none");
             }
         }
-        
-        function toggleNISBuses() {
-            showNISBuses = !showNISBuses;
-            const checkbox = document.getElementById("show-nis-checkbox");
-            checkbox.classList.toggle("selected");
-            setCookie("show_nis", showNISBuses ? "true" : "false");
-            
-            for (const element of document.getElementsByClassName("nis-bus")) {
-                if (showNISBuses) {
-                    element.classList.remove("display-none");
-                } else {
-                    element.classList.add("display-none");
+    }
+    
+    function setBusMarkerStyle(style) {
+        document.getElementById("bus-marker-style-" + busMarkerStyle).classList.remove("selected");
+        busMarkerStyle = style;
+        document.getElementById("bus-marker-style-" + style).classList.add("selected");
+        setCookie("bus_marker_style", style);
+        updateMap(false);
+    }
+    
+    function updatePositionData() {
+        const request = new XMLHttpRequest();
+        request.open("GET", "{{ get_url(system, 'api', 'positions') }}", true);
+        request.responseType = "json";
+        request.onload = function() {
+            if (request.status === 200) {
+                const lastUpdated = request.response.last_updated;
+                const element = document.getElementById("last-updated");
+                if (element !== null && element !== undefined && element.innerHTML.trim() !== "Updated " + lastUpdated) {
+                    element.innerHTML = "Updated " + lastUpdated;
+                    positions = request.response.positions;
+                    updateMap(false);
+                    if (showRouteLines) {
+                        updateRouteData()
+                    }
                 }
             }
-        }
-        
-        function setBusMarkerStyle(style) {
-            document.getElementById("bus-marker-style-" + busMarkerStyle).classList.remove("selected");
-            busMarkerStyle = style;
-            document.getElementById("bus-marker-style-" + style).classList.add("selected");
-            setCookie("bus_marker_style", style);
-            updateMap(false);
-        }
-        
-        function updatePositionData() {
+        };
+        request.send();
+    }
+    
+    function updateRouteData() {
+        for (const position of positions) {
+            if (position.shape_id === null || position.shape_id === undefined) {
+                continue;
+            }
+            const shapeID = position.system_id + "_" + position.shape_id
+            if (shapeID in shapes) {
+                continue;
+            }
             const request = new XMLHttpRequest();
-            request.open("GET", "{{ get_url(system, 'api', 'positions') }}", true);
+            request.open("GET", getUrl(position.system_id, "api/shape/" + position.shape_id), true);
             request.responseType = "json";
             request.onload = function() {
                 if (request.status === 200) {
-                    const lastUpdated = request.response.last_updated;
-                    const element = document.getElementById("last-updated");
-                    if (element !== null && element !== undefined && element.innerHTML.trim() !== "Updated " + lastUpdated) {
-                        element.innerHTML = "Updated " + lastUpdated;
-                        positions = request.response.positions;
-                        updateMap(false);
-                        if (showRouteLines) {
-                            updateRouteData()
-                        }
+                    if (shapeID in shapes) {
+                        shapes[shapeID].setVisible(showRouteLines);
+                    } else {
+                        const layer = new ol.layer.Vector({
+                            className: "ol-layer route-layer",
+                            source: new ol.source.Vector({
+                                features: [
+                                    new ol.Feature({
+                                        geometry: new ol.geom.LineString(request.response.points.map(function (point) {
+                                            return ol.proj.fromLonLat([point.lon, point.lat])
+                                        })),
+                                        name: shapeID
+                                    })
+                                ],
+                                wrapX: false
+                            }),
+                            style: new ol.style.Style({
+                                stroke: new ol.style.Stroke({
+                                    color: "#" + position.colour,
+                                    width: 4,
+                                    lineCap: "butt"
+                                })
+                            }),
+                            visible: showRouteLines,
+                            zIndex: 1
+                        });
+                        shapes[shapeID] = layer;
+                        map.addLayer(layer);
                     }
                 }
             };
             request.send();
         }
-        
-        function updateRouteData() {
-            for (const position of positions) {
-                if (position.shape_id === null || position.shape_id === undefined) {
-                    continue;
-                }
-                const shapeID = position.system_id + "_" + position.shape_id
-                if (shapeID in shapes) {
-                    continue;
-                }
+    }
+    
+    function setHoverPosition(position) {
+        if (showRouteLines) {
+            return
+        }
+        if (hoverPosition !== null) {
+            const shapeID = hoverPosition.system_id + "_" + hoverPosition.shape_id
+            if (shapeID in shapes) {
+                shapes[shapeID].setVisible(false);
+            }
+        }
+        if (position !== null) {
+            if (position.shape_id === null || position.shape_id === undefined) {
+                return;
+            }
+            const shapeID = position.system_id + "_" + position.shape_id
+            if (shapeID in shapes) {
+                shapes[shapeID].setVisible(true);
+            } else {
                 const request = new XMLHttpRequest();
                 request.open("GET", getUrl(position.system_id, "api/shape/" + position.shape_id), true);
                 request.responseType = "json";
                 request.onload = function() {
                     if (request.status === 200) {
                         if (shapeID in shapes) {
-                            shapes[shapeID].setVisible(showRouteLines);
+                            shapes[shapeID].setVisible(shapeID, hoverPosition == position);
                         } else {
                             const layer = new ol.layer.Vector({
                                 className: "ol-layer route-layer",
@@ -486,9 +554,9 @@
                                         lineCap: "butt"
                                     })
                                 }),
-                                visible: showRouteLines,
+                                visible: hoverPosition == position,
                                 zIndex: 1
-                            });
+                            })
                             shapes[shapeID] = layer;
                             map.addLayer(layer);
                         }
@@ -497,205 +565,150 @@
                 request.send();
             }
         }
-        
-        function setHoverPosition(position) {
-            if (showRouteLines) {
-                return
-            }
-            if (hoverPosition !== null) {
-                const shapeID = hoverPosition.system_id + "_" + hoverPosition.shape_id
-                if (shapeID in shapes) {
-                    shapes[shapeID].setVisible(false);
-                }
-            }
-            if (position !== null) {
-                if (position.shape_id === null || position.shape_id === undefined) {
-                    return;
-                }
-                const shapeID = position.system_id + "_" + position.shape_id
-                if (shapeID in shapes) {
-                    shapes[shapeID].setVisible(true);
-                } else {
-                    const request = new XMLHttpRequest();
-                    request.open("GET", getUrl(position.system_id, "api/shape/" + position.shape_id), true);
-                    request.responseType = "json";
-                    request.onload = function() {
-                        if (request.status === 200) {
-                            if (shapeID in shapes) {
-                                shapes[shapeID].setVisible(shapeID, hoverPosition == position);
-                            } else {
-                                const layer = new ol.layer.Vector({
-                                    className: "ol-layer route-layer",
-                                    source: new ol.source.Vector({
-                                        features: [
-                                            new ol.Feature({
-                                                geometry: new ol.geom.LineString(request.response.points.map(function (point) {
-                                                    return ol.proj.fromLonLat([point.lon, point.lat])
-                                                })),
-                                                name: shapeID
-                                            })
-                                        ],
-                                        wrapX: false
-                                    }),
-                                    style: new ol.style.Style({
-                                        stroke: new ol.style.Stroke({
-                                            color: "#" + position.colour,
-                                            width: 4,
-                                            lineCap: "butt"
-                                        })
-                                    }),
-                                    visible: hoverPosition == position,
-                                    zIndex: 1
-                                })
-                                shapes[shapeID] = layer;
-                                map.addLayer(layer);
-                            }
-                        }
-                    };
-                    request.send();
-                }
-            }
-            hoverPosition = position;
+        hoverPosition = position;
+    }
+    
+    function updateStops(zoom, box) {
+        if (!showStops) {
+            return
         }
-        
-        function updateStops(zoom, box) {
-            if (!showStops) {
-                return
+        const minZoom = window.screen.width > 1000 ? 14.5 : 14;
+        if (zoom >= minZoom) {
+            const minLat = box[1];
+            const maxLat = box[3];
+            const latPadding = (maxLat - minLat) / 2;
+            
+            const minLon = box[0];
+            const maxLon = box[2];
+            const lonPadding = (maxLon - minLon) / 2;
+            
+            const size = 0.01;
+            
+            const firstLat = Math.round((minLat - latPadding - size) * 100) / 100;
+            const firstLon = Math.round((minLon - lonPadding - size) * 100) / 100;
+            const lastLat = Math.round((maxLat + latPadding + size) * 100) / 100;
+            const lastLon = Math.round((maxLon + lonPadding + size) * 100) / 100;
+            
+            let newStopKeys = new Set();
+            for (let lat = firstLat; lat <= lastLat; lat += size) {
+                for (let lon = firstLon; lon <= lastLon; lon += size) {
+                    const roundedLat = Math.round(lat * 100) / 100;
+                    const roundedLon = Math.round(lon * 100) / 100;
+                    const key = roundedLat + ":" + roundedLon;
+                    newStopKeys.add(key);
+                    loadStops(key, roundedLat, roundedLon, size);
+                }
             }
-            const minZoom = window.screen.width > 1000 ? 14.5 : 14;
-            if (zoom >= minZoom) {
-                const minLat = box[1];
-                const maxLat = box[3];
-                const latPadding = (maxLat - minLat) / 2;
-                
-                const minLon = box[0];
-                const maxLon = box[2];
-                const lonPadding = (maxLon - minLon) / 2;
-                
-                const size = 0.01;
-                
-                const firstLat = Math.round((minLat - latPadding - size) * 100) / 100;
-                const firstLon = Math.round((minLon - lonPadding - size) * 100) / 100;
-                const lastLat = Math.round((maxLat + latPadding + size) * 100) / 100;
-                const lastLon = Math.round((maxLon + lonPadding + size) * 100) / 100;
-                
-                let newStopKeys = new Set();
-                for (let lat = firstLat; lat <= lastLat; lat += size) {
-                    for (let lon = firstLon; lon <= lastLon; lon += size) {
-                        const roundedLat = Math.round(lat * 100) / 100;
-                        const roundedLon = Math.round(lon * 100) / 100;
-                        const key = roundedLat + ":" + roundedLon;
-                        newStopKeys.add(key);
-                        loadStops(key, roundedLat, roundedLon, size);
-                    }
+            for (const key of currentStopKeys.difference(newStopKeys)) {
+                removeStopMarkers(key);
+            }
+            currentStopKeys = newStopKeys;
+        } else {
+            for (const key in stopMarkers) {
+                removeStopMarkers(key);
+            }
+        }
+    }
+    
+    function removeStopMarkers(key) {
+        if (key in stopMarkers) {
+            for (const marker of stopMarkers[key]) {
+                map.removeOverlay(marker);
+            }
+            stopMarkers[key] = [];
+        }
+    }
+    
+    function loadStops(key, lat, lon, size) {
+        if (key in cachedStops) {
+            updateStopMarkers(key);
+        } else {
+            const url = getUrl(systemID, "api/stops", {
+                "lat": lat,
+                "lon": lon,
+                "size": size
+            });
+            const request = new XMLHttpRequest();
+            request.open("GET", url, true);
+            request.responseType = "json";
+            request.onload = function() {
+                if (request.status === 200) {
+                    cachedStops[key] = request.response.stops;
+                    updateStopMarkers(key);
                 }
-                for (const key of currentStopKeys.difference(newStopKeys)) {
-                    removeStopMarkers(key);
-                }
-                currentStopKeys = newStopKeys;
+            };
+            request.send();
+        }
+    }
+    
+    function updateStopMarkers(key) {
+        if (key in stopMarkers && stopMarkers[key].length > 0) {
+            return
+        }
+        let markers = [];
+        for (const stop of cachedStops[key]) {
+            const element = document.createElement("div");
+            element.className = "marker small";
+            
+            const icon = document.createElement("a");
+            icon.className = "icon";
+            icon.href = getUrl(stop.system_id, "stops/" + stop.url_id);
+            icon.innerHTML = "<div class='link'></div>" + getSVG("stop");
+            if (stop.routes.length > 0) {
+                icon.style.backgroundColor = "#" + stop.routes[0].colour;
             } else {
-                for (const key in stopMarkers) {
-                    removeStopMarkers(key);
-                }
+                icon.style.backgroundColor = "#666666";
             }
+            
+            const details = document.createElement("div");
+            details.className = "details hover-only";
+            
+            if (stop.number !== null && stop.number !== undefined) {
+                const title = document.createElement("div");
+                title.className = "title";
+                title.innerHTML = stop.number;
+                details.appendChild(title);
+            }
+            
+            const content = document.createElement("div");
+            content.className = "content";
+            content.innerHTML = stop.name
+            
+            const routeList = document.createElement("div");
+            routeList.className = "route-list";
+            for (const route of stop.routes) {
+                routeList.innerHTML += "<span class='route' style='background-color: #" + route.colour + ";'>" + route.number + "</span>";
+            }
+            content.appendChild(routeList);
+            
+            const agencyLogo = document.createElement("img");
+            agencyLogo.className = "agency-logo";
+            agencyLogo.src = "/img/icons/" + stop.agency_id + ".png";
+            agencyLogo.onerror = function() {
+                agencyLogo.style.visibility = 'hidden';
+            };
+            content.innerHTML += "<div class='row gap-5'>" + agencyLogo.outerHTML + stop.system_name + "</div>";
+            
+            details.appendChild(content);
+            
+            element.appendChild(icon);
+            element.appendChild(details);
+            
+            const marker = new ol.Overlay({
+                position: ol.proj.fromLonLat([stop.lon, stop.lat]),
+                positioning: "center-center",
+                element: element,
+                stopEvent: false
+            })
+            map.addOverlay(marker);
+            markers.push(marker);
         }
-        
-        function removeStopMarkers(key) {
-            if (key in stopMarkers) {
-                for (const marker of stopMarkers[key]) {
-                    map.removeOverlay(marker);
-                }
-                stopMarkers[key] = [];
-            }
-        }
-        
-        function loadStops(key, lat, lon, size) {
-            if (key in cachedStops) {
-                updateStopMarkers(key);
-            } else {
-                const url = getUrl(systemID, "api/stops", {
-                    "lat": lat,
-                    "lon": lon,
-                    "size": size
-                });
-                const request = new XMLHttpRequest();
-                request.open("GET", url, true);
-                request.responseType = "json";
-                request.onload = function() {
-                    if (request.status === 200) {
-                        cachedStops[key] = request.response.stops;
-                        updateStopMarkers(key);
-                    }
-                };
-                request.send();
-            }
-        }
-        
-        function updateStopMarkers(key) {
-            if (key in stopMarkers && stopMarkers[key].length > 0) {
-                return
-            }
-            let markers = [];
-            for (const stop of cachedStops[key]) {
-                const element = document.createElement("div");
-                element.className = "marker small";
-                
-                const icon = document.createElement("a");
-                icon.className = "icon";
-                icon.href = getUrl(stop.system_id, "stops/" + stop.url_id);
-                icon.innerHTML = "<div class='link'></div>" + getSVG("stop");
-                if (stop.routes.length > 0) {
-                    icon.style.backgroundColor = "#" + stop.routes[0].colour;
-                } else {
-                    icon.style.backgroundColor = "#666666";
-                }
-                
-                const details = document.createElement("div");
-                details.className = "details hover-only";
-                
-                if (stop.number !== null && stop.number !== undefined) {
-                    const title = document.createElement("div");
-                    title.className = "title";
-                    title.innerHTML = stop.number;
-                    details.appendChild(title);
-                }
-                
-                const content = document.createElement("div");
-                content.className = "content";
-                content.innerHTML = stop.name
-                
-                const routeList = document.createElement("div");
-                routeList.className = "route-list";
-                for (const route of stop.routes) {
-                    routeList.innerHTML += "<span class='route' style='background-color: #" + route.colour + ";'>" + route.number + "</span>";
-                }
-                content.appendChild(routeList);
-                
-                const agencyLogo = document.createElement("img");
-                agencyLogo.className = "agency-logo";
-                agencyLogo.src = "/img/icons/" + stop.agency_id + ".png";
-                agencyLogo.onerror = function() {
-                    agencyLogo.style.visibility = 'hidden';
-                };
-                content.innerHTML += "<div class='row gap-5'>" + agencyLogo.outerHTML + stop.system_name + "</div>";
-                
-                details.appendChild(content);
-                
-                element.appendChild(icon);
-                element.appendChild(details);
-                
-                const marker = new ol.Overlay({
-                    position: ol.proj.fromLonLat([stop.lon, stop.lat]),
-                    positioning: "center-center",
-                    element: element,
-                    stopEvent: false
-                })
-                map.addOverlay(marker);
-                markers.push(marker);
-            }
-            stopMarkers[key] = markers;
-        }
-        
+        stopMarkers[key] = markers;
+    }
+</script>
+
+% if not system or system.realtime_enabled:
+    <script>
         setTimeout(function() {
             if (automaticRefresh) {
                 updatePositionData();
@@ -707,54 +720,4 @@
             }, 1000 * 60);
         }, 1000 * (timeToNextUpdate + 15));
     </script>
-% else:
-    <div class="container">
-        <div class="section">
-            <div class="options-container">
-                <div class="option" onclick="toggleNISBusesEmpty()">
-                    <div id="show-nis-checkbox" class="checkbox {{ 'selected' if show_nis else '' }}">
-                        % include('components/svg', name='check')
-                    </div>
-                    <div>Show NIS Buses</div>
-                </div>
-            </div>
-            <script>
-                function toggleNISBusesEmpty() {
-                    window.location = "{{ get_url(system, 'map', show_nis='false' if show_nis else 'true') }}"
-                }
-            </script>
-        </div>
-        <div class="section">
-            <div class="placeholder">
-                % if not system:
-                    % if show_nis:
-                        <h3>There are no buses out right now</h3>
-                        <p>
-                            None of our current agencies operate late night service, so this should be the case overnight.
-                            If you look out your window and the sun is shining, there may be an issue getting up-to-date info.
-                        </p>
-                        <p>Please check again later!</p>
-                    % else:
-                        <h3>There are no buses in service right now</h3>
-                        <p>You can see all active buses, including ones not in service, by selecting the <b>Show NIS Buses</b> checkbox.</p>
-                    % end
-                % elif not system.realtime_enabled:
-                    <h3>{{ system }} does not support realtime</h3>
-                    <p>You can browse the schedule data for {{ system }} using the links above, or choose a different system.</p>
-                    <div class="non-desktop">
-                        % include('components/systems')
-                    </div>
-                % elif not system.realtime_loaded:
-                    <h3>Realtime information for {{ system }} is unavailable</h3>
-                    <p>System data is currently loading and will be available soon.</p>
-                % elif not show_nis:
-                    <h3>There are no buses in service in {{ system }} right now</h3>
-                    <p>You can see all active buses, including ones not in service, by selecting the <b>Show NIS Buses</b> checkbox.</p>
-                % else:
-                    <h3>There are no buses out in {{ system }} right now</h3>
-                    <p>Please check again later!</p>
-                % end
-            </div>
-        </div>
-    </div>
 % end


### PR DESCRIPTION
Right now the map page can only be viewed if there are realtime bus positions to show. Now that we show stops on the map page, users may want to be able to see those stops even when there's no buses out. This change allows the map to be viewed always, even if there are no buses. On systems with no realtime info, the map page is now enabled; however the settings on the map page are not shown as they are currently all related to realtime.

- Added `Area` model in Python, matching our JavaScript model of the same concept - has min and max lat/lon values to define a box area
- Added `find_area` function to the stop repository - returns an area containing all stops (optionally filtered by system)
- Map page now fetches stop area on load, and initially sets the map view to that area
  - If there are positions to be shown, the map is then adjusted to fit those, so no change to existing behaviour
- Map page is now simplified to always have map JS logic instead of conditionally including it if positions are available
  - This looks like a big complex change in the diff but it's just indentation level changing now that there's no longer an `if` wrapping it all
  - A couple `if`s do remain for checking if the system doesn't support realtime, in which case the settings aren't shown and we don't run the auto-update functionality

Initial view for a system with no realtime at all:
![Screenshot from 2025-02-15 20-16-01](https://github.com/user-attachments/assets/63e3b442-2fb2-4d5e-95b4-07be316ecc2e)

Initial view for a system with realtime but no buses out at the moment:
![Screenshot from 2025-02-15 20-16-24](https://github.com/user-attachments/assets/aeb172e9-a585-457e-9885-fa5096999649)
