### PR TITLE
Add West Coast system

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Available at https://bctracker.ca
 - Squamish
 - Sunshine Coast
 - Victoria
+- West Coast
 - West Kootenay
 - Whistler
 - Williams Lake

--- a/models/system.py
+++ b/models/system.py
@@ -25,8 +25,6 @@ class System:
         'remote_id',
         'enabled',
         'timezone',
-        'preposition',
-        'regional',
         'colour_routes',
         'gtfs_downloaded',
         'gtfs_loaded',
@@ -93,8 +91,6 @@ class System:
         self.remote_id = kwargs.get('remote_id')
         self.enabled = kwargs.get('enabled', True) and agency.enabled
         self.timezone = pytz.timezone(kwargs.get('timezone', 'America/Vancouver'))
-        self.preposition = kwargs.get('preposition', 'for')
-        self.regional = kwargs.get('regional', False)
         self.colour_routes = kwargs.get('colour_routes')
         
         self.gtfs_downloaded = None

--- a/server.py
+++ b/server.py
@@ -21,7 +21,7 @@ from repositories import *
 from services import *
 
 # Increase the version to force CSS reload
-VERSION = 51
+VERSION = 52
 
 random = Random()
 

--- a/static/systems.json
+++ b/static/systems.json
@@ -7,19 +7,15 @@
             },
             "comox": {
                 "name": "Comox Valley",
-                "remote_id": 45,
-                "preposition": "for the"
+                "remote_id": 45
             },
             "cowichan-valley": {
                 "name": "Cowichan Valley",
-                "remote_id": 10,
-                "preposition": "for the"
+                "remote_id": 10
             },
             "mount-waddington": {
                 "name": "Mount Waddington",
-                "remote_id": 17,
-                "preposition": "for the",
-                "regional": true
+                "remote_id": 17
             },
             "nanaimo": {
                 "name": "Nanaimo",
@@ -31,19 +27,22 @@
             },
             "salt-spring": {
                 "name": "Salt Spring Island",
-                "remote_id": 39,
-                "colour_routes": "000000"
+                "remote_id": 39
             },
             "victoria": {
                 "name": "Victoria",
                 "remote_id": 48
+            },
+            "west-coast": {
+                "name": "West Coast",
+                "remote_id": 51,
+                "colour_routes": "000000"
             }
         },
         "southern-coast": {
             "fraser-valley": {
                 "name": "Fraser Valley",
-                "remote_id": 13,
-                "preposition": "for the"
+                "remote_id": 13
             },
             "pemberton": {
                 "name": "Pemberton",
@@ -62,7 +61,6 @@
             "sunshine-coast": {
                 "name": "Sunshine Coast",
                 "remote_id": 18,
-                "preposition": "for the",
                 "colour_routes": "000000"
             },
             "whistler": {
@@ -74,8 +72,6 @@
             "ashcroft-clinton": {
                 "name": "Ashcroft-Clinton",
                 "remote_id": 38,
-                "preposition":"for the",
-                "regional": true,
                 "colour_routes": "000000"
             },
             "clearwater": {
@@ -86,15 +82,12 @@
             "creston-valley": {
                 "name": "Creston Valley",
                 "remote_id": 16,
-                "preposition": "for the",
                 "timezone": "America/Creston"
             },
             "east-kootenay": {
                 "name": "East Kootenay",
                 "remote_id": 21,
                 "timezone": "America/Edmonton",
-                "preposition": "for the",
-                "regional": true,
                 "colour_routes": "000000"
             },
             "kamloops": {
@@ -113,9 +106,7 @@
             },
             "north-okanagan": {
                 "name": "North Okanagan",
-                "remote_id": 14,
-                "preposition": "for the",
-                "regional": true
+                "remote_id": 14
             },
             "revelstoke": {
                 "name": "Revelstoke",
@@ -124,16 +115,11 @@
             },
             "south-okanagan": {
                 "name": "South Okanagan",
-                "remote_id": 15,
-                "preposition": "for the",
-                "regional": true
+                "remote_id": 15
             },
             "west-kootenay": {
                 "name": "West Kootenay",
-                "remote_id": 20,
-                "preposition": "for the",
-                "regional": true,
-                "colour_routes": "000000"
+                "remote_id": 20
             }
         },
         "northern-bc": {
@@ -155,8 +141,6 @@
             "kitimat": {
                 "name": "Kitimat-Stikine",
                 "remote_id": 26,
-                "preposition": "for the",
-                "regional": true,
                 "colour_routes": "000000"
             },
             "prince-george": {
@@ -180,8 +164,7 @@
             },
             "williams-lake": {
                 "name": "Williams Lake",
-                "remote_id": 33,
-                "colour_routes": "000000"
+                "remote_id": 33
             }
         }
     },

--- a/style/main.css
+++ b/style/main.css
@@ -542,8 +542,13 @@ table tr.header td {
     cursor: pointer;
 }
 
-.banner .title {
-    font-weight: bold;
+.banner .content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.banner h1 {
     font-size: 16pt;
 }
 

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -43,11 +43,10 @@
         
         % if system:
             <meta property="og:title" content="{{ system }} | {{ title }}">
-            <meta property="og:description" content="Transit schedules and bus tracking for {{ system }}, BC" />
         % else:
             <meta property="og:title" content="BCTracker | {{ title }}">
-            <meta property="og:description" content="Transit schedules and bus tracking for BC, Canada" />
         % end
+        <meta property="og:description" content="Transit schedules and bus tracking" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="{{ get_url(system, *path) }}" />
         <meta property="og:image" content="{{ get_url(system, 'img', 'meta-logo.png') }}" />
@@ -448,12 +447,19 @@
         </div>
         <div id="main">
             <div id="banners">
-                % if system is not None and (system.id == 'cowichan-valley'):
+                % if system is not None and system.id == 'cowichan-valley':
                     <div class="banner">
                         <div class="content">
-                            <span class="title">Due to ongoing job action, service in the Cowichan Valley area is currently suspended.</span>
-                            <br />
-                            <span class="description">For more information and updates please visit the <a target="_blank" href="https://www.bctransit.com/cowichan-valley/news">BC Transit News Page</a>.</span>
+                            <h1>Due to ongoing job action, service in the Cowichan Valley area is currently suspended.</h1>
+                            <p>For more information and updates please visit the <a target="_blank" href="https://www.bctransit.com/cowichan-valley/news">BC Transit News Page</a>.</p>
+                        </div>
+                    </div>
+                % end
+                % from models.date import Date
+                % if system is not None and system.id == 'west-coast' and today < Date(2025, 3, 1, system.timezone):
+                    <div class="banner">
+                        <div class="content">
+                            <h1>BC Transit will begin operating between Tofino and Ucluelet on March 1st, 2025</h1>
                         </div>
                     </div>
                 % end
@@ -526,7 +532,7 @@
             </div>
             <div id="search-placeholder">
                 % if system:
-                    Search for buses, routes, stops, and blocks in {{ system }}
+                    Search for {{ system }} buses, routes, stops, and blocks
                 % else:
                     Search for buses in all systems
                 % end

--- a/views/pages/block/history.tpl
+++ b/views/pages/block/history.tpl
@@ -120,7 +120,7 @@
     % include('components/top_button')
 % else:
     <div class="placeholder">
-        <h3>{{ system }} does not currently support realtime</h3>
-        <p>You can browse the schedule data for {{ system }} using the links above, or choose a different system.</p>
+        <h3>{{ system }} realtime information is not supported</h3>
+        <p>You can browse schedule data using the links above, or choose a different system.</p>
     </div>
 % end

--- a/views/pages/blocks/date.tpl
+++ b/views/pages/blocks/date.tpl
@@ -83,7 +83,7 @@
                     % else:
                         <div class="placeholder">
                             % if system.gtfs_loaded:
-                                <h3>No blocks found for {{ system }} on {{ date.format_long() }}</h3>
+                                <h3>No {{ system }} blocks found on {{ date.format_long() }}</h3>
                                 <p>There are a few reasons why that might be the case:</p>
                                 <ol>
                                     <li>It may be a day of the week that does not normally have service</li>
@@ -92,7 +92,7 @@
                                 </ol>
                                 <p>Please check again later!</p>
                             % else:
-                                <h3>Block information for {{ system }} is unavailable</h3>
+                                <h3>{{ system }} block information is unavailable</h3>
                                 <p>System data is currently loading and will be available soon.</p>
                             % end
                         </div>

--- a/views/pages/blocks/overview.tpl
+++ b/views/pages/blocks/overview.tpl
@@ -143,7 +143,7 @@
         % include('components/top_button')
     % else:
         <div class="placeholder">
-            <h3>Block information for {{ system }} is unavailable</h3>
+            <h3>{{ system }} block information is unavailable</h3>
             % if system.gtfs_loaded:
                 <p>Please check again later!</p>
             % else:

--- a/views/pages/blocks/schedule.tpl
+++ b/views/pages/blocks/schedule.tpl
@@ -93,7 +93,7 @@
         % include('components/top_button')
     % else:
         <div class="placeholder">
-            <h3>Block information for {{ system }} is unavailable</h3>
+            <h3>{{ system }} block information is unavailable</h3>
             % if system.gtfs_loaded:
                 <p>Please check again later!</p>
             % else:

--- a/views/pages/fleet.tpl
+++ b/views/pages/fleet.tpl
@@ -30,7 +30,7 @@
             % if system:
                 <p>
                     Please note that this list includes vehicles from every system.
-                    To see only buses that have operated in {{ system }}, visit the <a href="{{ get_url(system, 'history') }}">history</a> page.
+                    To see only {{ system }} buses, visit the <a href="{{ get_url(system, 'history') }}">history</a> page.
                 </p>
             % end
         </div>

--- a/views/pages/history/first_seen.tpl
+++ b/views/pages/history/first_seen.tpl
@@ -85,13 +85,13 @@
             <h3>No vehicle history found</h3>
             <p>Something has probably gone terribly wrong if you're seeing this.</p>
         % elif not system.realtime_enabled:
-            <h3>{{ system }} does not currently support realtime</h3>
-            <p>You can browse the schedule data for {{ system }} using the links above, or choose a different system.</p>
+            <h3>{{ system }} realtime information is not supported</h3>
+            <p>You can browse schedule data using the links above, or choose a different system.</p>
             <div class="non-desktop">
                 % include('components/systems')
             </div>
         % else:
-            <h3>No buses have been recorded in {{ system }}</h3>
+            <h3>No {{ system }} buses have been recorded</h3>
             <p>Please check again later!</p>
         % end
     </div>

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -240,16 +240,16 @@
                                 <p>Something has probably gone terribly wrong if you're seeing this.</p>
                             % end
                         % elif not system.realtime_enabled:
-                            <h3>{{ system }} does not currently support realtime</h3>
-                            <p>You can browse the schedule data for {{ system }} using the links above, or choose a different system.</p>
+                            <h3>{{ system }} realtime information is not supported</h3>
+                            <p>You can browse schedule data using the links above, or choose a different system.</p>
                             <div class="non-desktop">
                                 % include('components/systems')
                             </div>
                         % elif days:
-                            <h3>No buses have been recorded in {{ system }} for the selected date range</h3>
+                            <h3>No {{ system }} buses have been recorded for the selected date range</h3>
                             <p>Please choose a different date range or check again later!</p>
                         % else:
-                            <h3>No buses have been recorded in {{ system }}</h3>
+                            <h3>No {{ system }} buses have been recorded</h3>
                             <p>Please check again later!</p>
                         % end
                     </div>

--- a/views/pages/history/transfers.tpl
+++ b/views/pages/history/transfers.tpl
@@ -159,8 +159,8 @@
                             <h3>No transfers found</h3>
                             <p>Something has probably gone terribly wrong if you're seeing this.</p>
                         % elif not system.realtime_enabled:
-                            <h3>{{ system }} does not currently support realtime</h3>
-                            <p>You can browse the schedule data for {{ system }} using the links above, or choose a different system.</p>
+                            <h3>{{ system }} realtime information is not supported</h3>
+                            <p>You can browse schedule data using the links above, or choose a different system.</p>
                             <div class="non-desktop">
                                 % include('components/systems')
                             </div>

--- a/views/pages/home.tpl
+++ b/views/pages/home.tpl
@@ -7,12 +7,12 @@
     <h1>Welcome to BCTracker!</h1>
     % if system:
         % if agency.realtime_enabled:
-            <h2>Transit Schedules and Bus Tracking {{ system.preposition }} {{ system }}{{ ' Region' if system.regional else '' }}</h2>
+            <h2>{{ system }} Transit Schedules and Bus Tracking</h2>
         % else:
-            <h2>Transit Schedules {{ system.preposition }} {{ system }}{{ ' Region' if system.regional else '' }}</h2>
+            <h2>{{ system }} Transit Schedules</h2>
         % end
     % else:
-        <h2>Transit Schedules and Bus Tracking for British Columbia</h2>
+        <h2>British Columbia Transit Schedules and Bus Tracking</h2>
     % end
 </div>
 

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -739,19 +739,19 @@
                         <p>You can see all active buses, including ones not in service, by selecting the <b>Show NIS Buses</b> checkbox.</p>
                     % end
                 % elif not system.realtime_enabled:
-                    <h3>{{ system }} does not support realtime</h3>
-                    <p>You can browse the schedule data for {{ system }} using the links above, or choose a different system.</p>
+                    <h3>{{ system }} realtime information is not supported</h3>
+                    <p>You can browse schedule data using the links above, or choose a different system.</p>
                     <div class="non-desktop">
                         % include('components/systems')
                     </div>
                 % elif not system.realtime_loaded:
-                    <h3>Realtime information for {{ system }} is unavailable</h3>
+                    <h3>{{ system }} realtime information is unavailable</h3>
                     <p>System data is currently loading and will be available soon.</p>
                 % elif not show_nis:
-                    <h3>There are no buses in service in {{ system }} right now</h3>
+                    <h3>There are no {{ system }} buses in service right now</h3>
                     <p>You can see all active buses, including ones not in service, by selecting the <b>Show NIS Buses</b> checkbox.</p>
                 % else:
-                    <h3>There are no buses out in {{ system }} right now</h3>
+                    <h3>There are no {{ system }} buses out right now</h3>
                     <p>Please check again later!</p>
                 % end
             </div>

--- a/views/pages/realtime/all.tpl
+++ b/views/pages/realtime/all.tpl
@@ -93,19 +93,19 @@
                 <p>You can see all active buses, including ones not in service, by selecting the <b>Show NIS Buses</b> checkbox.</p>
             % end
         % elif not system.realtime_enabled:
-            <h3>{{ system }} does not support realtime</h3>
-            <p>You can browse the schedule data for {{ system }} using the links above, or choose a different system.</p>
+            <h3>{{ system }} realtime information is not supported</h3>
+            <p>You can browse schedule data for using the links above, or choose a different system.</p>
             <div class="non-desktop">
                 % include('components/systems')
             </div>
         % elif not system.realtime_loaded:
-            <h3>Realtime information for {{ system }} is unavailable</h3>
+            <h3>{{ system }} realtime information is unavailable</h3>
             <p>System data is currently loading and will be available soon.</p>
         % elif not show_nis:
-            <h3>There are no buses in service in {{ system }} right now</h3>
+            <h3>There are no {{ system }} buses in service right now</h3>
             <p>You can see all active buses, including ones not in service, by selecting the <b>Show NIS Buses</b> checkbox.</p>
         % else:
-            <h3>There are no buses out in {{ system }} right now</h3>
+            <h3>There are no {{ system }} buses out right now</h3>
             <p>Please check again later!</p>
         % end
     </div>

--- a/views/pages/realtime/models.tpl
+++ b/views/pages/realtime/models.tpl
@@ -190,19 +190,19 @@
                 <p>You can see all active buses, including ones not in service, by selecting the <b>Show NIS Buses</b> checkbox.</p>
             % end
         % elif not system.realtime_enabled:
-            <h3>{{ system }} does not support realtime</h3>
-            <p>You can browse the schedule data for {{ system }} using the links above, or choose a different system.</p>
+            <h3>{{ system }} realtime information is not supported</h3>
+            <p>You can browse schedule data for using the links above, or choose a different system.</p>
             <div class="non-desktop">
                 % include('components/systems')
             </div>
         % elif not system.realtime_loaded:
-            <h3>Realtime information for {{ system }} is unavailable</h3>
+            <h3>{{ system }} realtime information is unavailable</h3>
             <p>System data is currently loading and will be available soon.</p>
         % elif not show_nis:
-            <h3>There are no buses in service in {{ system }} right now</h3>
+            <h3>There are no {{ system }} buses in service right now</h3>
             <p>You can see all active buses, including ones not in service, by selecting the <b>Show NIS Buses</b> checkbox.</p>
         % else:
-            <h3>There are no buses out in {{ system }} right now</h3>
+            <h3>There are no {{ system }} buses out right now</h3>
             <p>Please check again later!</p>
         % end
     </div>

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -197,19 +197,19 @@
             </p>
             <p>Please choose a system.</p>
         % elif not system.realtime_enabled:
-            <h3>{{ system }} does not support realtime</h3>
-            <p>You can browse the schedule data for {{ system }} using the links above, or choose a different system.</p>
+            <h3>{{ system }} realtime information is not supported</h3>
+            <p>You can browse schedule data for using the links above, or choose a different system.</p>
             <div class="non-desktop">
                 % include('components/systems')
             </div>
         % elif not system.realtime_loaded:
-            <h3>Realtime information for {{ system }} is unavailable</h3>
+            <h3>{{ system }} realtime information is unavailable</h3>
             <p>System data is currently loading and will be available soon.</p>
         % elif not show_nis:
-            <h3>There are no buses in service in {{ system }} right now</h3>
+            <h3>There are no {{ system }} buses in service right now</h3>
             <p>You can see all active buses, including ones not in service, by selecting the <b>Show NIS Buses</b> checkbox.</p>
         % else:
-            <h3>There are no buses out in {{ system }} right now</h3>
+            <h3>There are no {{ system }} buses out right now</h3>
             <p>Please check again later!</p>
         % end
     </div>

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -125,19 +125,19 @@
                 <p>You can see all active buses, including ones not in service, by selecting the <b>Show NIS Buses</b> checkbox.</p>
             % end
         % elif not system.realtime_enabled:
-            <h3>{{ system }} does not support realtime</h3>
-            <p>You can browse the schedule data for {{ system }} using the links above, or choose a different system.</p>
+            <h3>{{ system }} realtime information is not supported</h3>
+            <p>You can browse schedule data for using the links above, or choose a different system.</p>
             <div class="non-desktop">
                 % include('components/systems')
             </div>
         % elif not system.realtime_loaded:
-            <h3>Realtime information for {{ system }} is unavailable</h3>
+            <h3>{{ system }} realtime information is unavailable</h3>
             <p>System data is currently loading and will be available soon.</p>
         % elif not show_nis:
-            <h3>There are no buses in service in {{ system }} right now</h3>
+            <h3>There are no {{ system }} buses in service right now</h3>
             <p>You can see all active buses, including ones not in service, by selecting the <b>Show NIS Buses</b> checkbox.</p>
         % else:
-            <h3>There are no buses out in {{ system }} right now</h3>
+            <h3>There are no {{ system }} buses out right now</h3>
             <p>Please check again later!</p>
         % end
     </div>

--- a/views/pages/routes/list.tpl
+++ b/views/pages/routes/list.tpl
@@ -37,7 +37,7 @@
         </table>
     % else:
         <div class="placeholder">
-            <h3>Route information for {{ system }} is unavailable</h3>
+            <h3>{{ system }} route information is unavailable</h3>
             % if system.gtfs_loaded:
                 <p>Please check again later!</p>
             % else:

--- a/views/pages/routes/map.tpl
+++ b/views/pages/routes/map.tpl
@@ -184,7 +184,7 @@
             <h3>Route information is unavailable</h3>
             <p>Please check again later!</p>
         % else:
-            <h3>Route information for {{ system }} is unavailable</h3>
+            <h3>{{ system }} route information is unavailable</h3>
             % if system.gtfs_loaded:
                 <p>Please check again later!</p>
             % else:

--- a/views/pages/stops.tpl
+++ b/views/pages/stops.tpl
@@ -159,7 +159,7 @@
                                     <p>Please try selecting different routes!</p>
                                 % end
                             % else:
-                                <h3>Stop information for {{ system }} is unavailable</h3>
+                                <h3>{{ system }} stop information is unavailable</h3>
                                 % if system.gtfs_loaded:
                                     <p>Please check again later!</p>
                                 % else:

--- a/views/pages/trip/history.tpl
+++ b/views/pages/trip/history.tpl
@@ -121,7 +121,7 @@
     % include('components/top_button')
 % else:
     <div class="placeholder">
-        <h3>{{ system }} does not currently support realtime</h3>
-        <p>You can browse the schedule data for {{ system }} using the links above, or choose a different system.</p>
+        <h3>{{ system }} realtime information is not supported</h3>
+        <p>You can browse schedule data using the links above, or choose a different system.</p>
     </div>
 % end


### PR DESCRIPTION
- Added `west-coast` system to list
  - By itself adding a new system is so easy!
- Minor updates to banner HTML/CSS for consistency - no changes to UI itself
- Removed preposition/regional logic from systems; syntax is now generally "(system) etc etc" instead of "etc etc in/on/for (system)"
- Removed a couple route colouring keys in systems list which are no longer needed

**IMPORTANT:** Before deploying, we'll need to update DNS and nginx to support the new `west-coast.bctracker.ca` subdomain