### PR TITLE
MacOS and installation improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__/
 .vscode
 .idea
 .pytest_cache
+.python-version
+.DS_Store

--- a/server.py
+++ b/server.py
@@ -186,7 +186,7 @@ class Server(Bottle):
                     self.gtfs_service.load(system, args.reload, args.updatedb)
                     if not self.gtfs_service.validate(system):
                         self.gtfs_service.load(system, True)
-                    self.gtfs_service.update_cache_in_background(system)
+                    self.gtfs_service.update_cache(system)
                     self.realtime_service.update(system)
                 except Exception as e:
                     print(f'Error loading data for {system}: {e}')
@@ -1476,7 +1476,7 @@ class Server(Bottle):
                     self.gtfs_service.load(system)
                     if not self.gtfs_service.validate(system):
                         self.gtfs_service.load(system, True)
-                    self.gtfs_service.update_cache_in_background(system)
+                    self.gtfs_service.update_cache(system)
                     self.realtime_service.update(system)
                 except Exception as e:
                     print(f'Error loading data for {system}: {e}')
@@ -1509,7 +1509,7 @@ class Server(Bottle):
             return 'Invalid system'
         try:
             self.gtfs_service.load(system, True)
-            self.gtfs_service.update_cache_in_background(system)
+            self.gtfs_service.update_cache(system)
             self.realtime_service.update(system)
             self.realtime_service.update_records()
             if not system.gtfs_downloaded or not self.realtime_service.validate(system):

--- a/services/default/cron.py
+++ b/services/default/cron.py
@@ -67,7 +67,7 @@ class DefaultCronService(CronService):
                     date = Date.today(system.timezone)
                     if date.weekday == Weekday.MON or not self.gtfs_service.validate(system):
                         self.gtfs_service.load(system, True)
-                        self.gtfs_service.update_cache_in_background(system)
+                        self.gtfs_service.update_cache(system)
                 except Exception as e:
                     print(f'Error loading GTFS data for {system}: {e}')
         if self.running:
@@ -90,7 +90,7 @@ class DefaultCronService(CronService):
                     if system.reload_backoff.check():
                         system.reload_backoff.increase_target()
                         self.gtfs_service.load(system, True)
-                        self.gtfs_service.update_cache_in_background(system)
+                        self.gtfs_service.update_cache(system)
                     self.realtime_service.update(system)
                 except Exception as e:
                     print(f'Error loading data for {system}: {e}')

--- a/services/default/gtfs.py
+++ b/services/default/gtfs.py
@@ -143,10 +143,13 @@ class DefaultGTFSService(GTFSService):
             return Date.today(system.timezone) < max(end_dates) - timedelta(days=7)
         return True
     
-    def update_cache_in_background(self, system):
-        '''Updates cached data for the given system in a background thread'''
-        thread = Thread(target=system.update_cache)
-        thread.start()
+    def update_cache(self, system):
+        '''Updates cached data for the given system'''
+        if self.settings.update_cache_in_background:
+            thread = Thread(target=system.update_cache)
+            thread.start()
+        else:
+            system.update_cache()
 
 def read_csv(system, name, initializer):
     '''Opens a CSV file and applies an initializer to each row'''

--- a/services/gtfs.py
+++ b/services/gtfs.py
@@ -12,5 +12,5 @@ class GTFSService(ABC):
         raise NotImplementedError()
     
     @abstractmethod
-    def update_cache_in_background(self, system):
+    def update_cache(self, system):
         raise NotImplementedError()

--- a/settings.py
+++ b/settings.py
@@ -12,7 +12,8 @@ class Settings:
         'enable_analytics',
         'enable_gtfs_backups',
         'enable_realtime_backups',
-        'enable_database_backups'
+        'enable_database_backups',
+        'update_cache_in_background'
     )
     
     def __init__(self):
@@ -34,6 +35,7 @@ class Settings:
         self.enable_gtfs_backups = True
         self.enable_realtime_backups = True
         self.enable_database_backups = True
+        self.update_cache_in_background = True
     
     def setup(self, config):
         self.cron_id = config.get('cron_id', 'bctracker-muncher')
@@ -50,3 +52,4 @@ class Settings:
         self.enable_gtfs_backups = config.get('enable_gtfs_backups', 'true') == 'true'
         self.enable_realtime_backups = config.get('enable_realtime_backups', 'true') == 'true'
         self.enable_database_backups = config.get('enable_database_backups', 'true') == 'true'
+        self.update_cache_in_background = config.get('update_cache_in_background', 'true') == 'true'

--- a/setup.sh
+++ b/setup.sh
@@ -6,9 +6,10 @@ pip install requests
 pip install Bottle
 pip install cherrypy
 pip install wsgi-request-logger
-pip install protobuf
+pip install protobuf==3.20
 pip install google
 pip install python-crontab
+pip install pytz
 
 # Create directories
 mkdir -p archives/gtfs


### PR DESCRIPTION
- Added `update_cache_in_background` setting
  - When disabled, updates the cache immediately
  - Defaults to enabled
  - Down the road we may want to take a look at how multithreading on Mac can be improved in general
- Updated setup script
  - Now installs `pytz`
  - Locks `protobuf` in at version 3.20 (required for the current protobuf code compiled for the project)
- Updated gitignore
  - Now ignores `.DS_Store` on Macs
  - Now ignores `.python-version` for python environment managing