### PR TITLE
Show cache info on admin page

### DIFF
--- a/models/system.py
+++ b/models/system.py
@@ -238,6 +238,15 @@ class System:
             for route_id, trips in route_trips.items():
                 if route_id not in self.route_caches:
                     self.route_caches[route_id] = RouteCache(self, trips)
+            for trip_id in self.trips.keys():
+                if trip_id not in self.trip_caches:
+                    self.trip_caches[trip_id] = TripCache([])
+            for stop_id in self.stops.keys():
+                if stop_id not in self.stop_caches:
+                    self.stop_caches[stop_id] = StopCache(self, [])
+            for route_id in self.routes.keys():
+                if route_id not in self.route_caches:
+                    self.route_caches[route_id] = RouteCache(self, [])
         except Exception as e:
             print(f'Failed to update cached data for {self}: {e}')
     

--- a/views/pages/admin.tpl
+++ b/views/pages/admin.tpl
@@ -42,6 +42,7 @@
                             <tr>
                                 <th>System</th>
                                 <th class="non-mobile">Enabled</th>
+                                <th class="non-mobile">Cache</th>
                                 <th>GTFS</th>
                                 <th>Realtime</th>
                             </tr>
@@ -55,6 +56,8 @@
                                     </tr>
                                     <tr class="display-none"></tr>
                                     % for region_system in sorted(region_systems):
+                                        % total = len(region_system.routes) + len(region_system.stops) + len(region_system.trips)
+                                        % progress = len(region_system.route_caches) + len(region_system.stop_caches) + len(region_system.trip_caches)
                                         <tr>
                                             <td>
                                                 <div class="row">
@@ -63,6 +66,9 @@
                                                         {{ region_system }}
                                                         <div class="mobile-only smaller-font {{ 'positive' if region_system.enabled else 'negative' }}">
                                                             {{ 'Enabled' if region_system.enabled else 'Disabled' }}
+                                                        </div>
+                                                        <div class="mobile-only smaller-font {{ 'positive' if total and progress == total else 'negative' }}">
+                                                            {{ progress }} / {{ total }}
                                                         </div>
                                                     </div>
                                                 </div>
@@ -73,6 +79,9 @@
                                                 % else:
                                                     % include('components/svg', name='close-circle')
                                                 % end
+                                            </td>
+                                            <td class="non-mobile {{ 'positive' if total and progress == total else 'negative' }}">
+                                                {{ progress }} / {{ total }}
                                             </td>
                                             <td>
                                                 % if region_system.gtfs_enabled:


### PR DESCRIPTION
The systems table on the admin page now has a `Cache` column showing the total number of trips, stops, and routes, and how many of those entities have been added to the in-memory cache so far. This allows us to see progress as systems are loaded.

Since caches are only created initially for entities with data, some stuff currently doesn't have a cache object created immediately - for example a stop without any departures. This leads to the caches appearing incomplete until the page for that entity is loaded manually and the cache is generated if it doesn't exist yet. To avoid this and make sure all caches are accounted for by the end of the loading period, I've added in loops to create empty caches for any missing trip/stop/route IDs.

<img width="603" alt="Screenshot 2025-04-17 at 23 31 15" src="https://github.com/user-attachments/assets/e460e6db-505a-4760-a195-0c40ff71d93c" />
<img width="330" alt="Screenshot 2025-04-17 at 23 37 07" src="https://github.com/user-attachments/assets/485c5654-710e-4f62-b701-9fbb1ff7b750" />
