### PR TITLE
Redesign status bar

### DIFF
--- a/server.py
+++ b/server.py
@@ -21,7 +21,7 @@ from repositories import *
 from services import *
 
 # Increase the version to force CSS reload
-VERSION = 53
+VERSION = 54
 
 random = Random()
 
@@ -237,7 +237,7 @@ class Server(Bottle):
         
         time_format = self.query_cookie('time_format')
         bus_marker_style = self.query_cookie('bus_marker_style')
-        hide_systems = self.query_cookie('hide_systems') == 'yes'
+        hide_systems = self.query_cookie('hide_systems') != 'no'
         if system:
             last_updated = system.last_updated
             today = Date.today(system.timezone)

--- a/style/devices/desktop.css
+++ b/style/devices/desktop.css
@@ -4,13 +4,12 @@ a:hover {
 }
 
 body {
-    display: grid;
+    display: flex;
+    flex-direction: column;
     justify-items: stretch;
     align-items: stretch;
     height: 100%;
     overflow: hidden;
-    grid-template-columns: auto 1fr auto;
-    grid-template-rows: auto 1fr;
 }
 
 body.full-map #page {
@@ -34,8 +33,10 @@ table th {
     white-space: nowrap;
 }
 
-#last-updated {
-    font-size: 11pt;
+#content {
+    display: flex;
+    flex-direction: row;
+    overflow: hidden;
 }
 
 #main {
@@ -54,8 +55,15 @@ table th {
 
 #navigation-bar {
     font-size: 14pt;
-    grid-column-start: span 2;
     padding-right: 20px;
+}
+
+#navigation-bar .navigation-button:hover {
+    background-color: var(--navigation-bar-hover);
+}
+
+#navigation-bar .navigation-button.disabled:hover {
+    background-color: unset;
 }
 
 #navigation-menu-toggle {
@@ -67,7 +75,16 @@ table th {
 }
 
 #refresh-button {
+    padding: 2px;
     --image-size: 28px;
+}
+
+#refresh-button:hover {
+    background-color: var(--status-bar-hover);
+}
+
+#refresh-button.disabled:hover {
+    background-color: unset;
 }
 
 #search {
@@ -113,61 +130,51 @@ table th {
     font-size: 11pt;
 }
 
-#side-bar {
-    overflow: hidden;
-    border-right-width: 1px;
-    border-right-style: solid;
-}
-
-#side-bar .spacer {
-    flex: 1;
-}
-
-#side-bar-toggle {
-    padding: 6px;
-    border-radius: 10px;
-    width: 20px;
-    height: 20px;
-    cursor: pointer;
-    text-align: center;
-    --image-size: 20px;
-}
-
-#side-bar-toggle-container {
-    padding: 8px 15px;
+#status-bar {
     display: flex;
+    flex-direction: row;
     align-items: center;
-    font-size: 11pt;
     gap: 10px;
 }
 
-#status {
-    border-bottom-width: 1px;
-    border-bottom-style: solid;
+#status-bar .details {
+    align-self: stretch;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 10px;
 }
 
 #system {
-    font-size: 14pt;
+    align-self: stretch;
+    display: flex;
+    flex-direction: row;
+    gap: 5px;
+    align-items: center;
+    cursor: pointer;
+    padding: 10px 20px;
+}
+
+#system:hover {
+    background-color: var(--status-bar-hover);
 }
 
 #system-menu {
-    flex: 1;
-    grid-template-columns: auto;
+    display: flex;
+    flex-direction: column;
     overflow: auto;
-    padding-bottom: 15px;
-    border-bottom-width: 1px;
-    border-bottom-style: solid;
-    align-content: flex-start;
+    border-right-width: 1px;
+    border-right-style: solid;
+    font-size: 12pt;
 }
 
-#system-menu .header {
-    font-size: 13pt;
+#system-menu.collapse-desktop {
+    display: none !important;
 }
 
 #system-menu .system-button {
     text-decoration: none !important;
     padding: 5px 20px;
-    font-size: 12pt;
     text-wrap: nowrap;
 }
 
@@ -180,17 +187,8 @@ table th {
     display: none;
 }
 
-#title {
-    font-family: var(--sans-serif-font);
-    font-size: 22pt;
-    font-weight: bold;
-    display: flex;
-    align-items: center;
-    padding: 5px 20px;
-    text-decoration: none;
-    line-height: 1em;
-    gap: 10px;
-    --image-size: 24px;
+#title:hover {
+    background-color: var(--navigation-bar-hover);
 }
 
 .banner a {
@@ -216,26 +214,6 @@ table th {
 
 .option:hover {
     background-color: var(--hover-background);
-}
-
-.side-bar-open .side-bar-closed-only {
-    display: none !important;
-}
-
-.side-bar-closed .side-bar-open-only {
-    display: none !important;
-}
-
-.side-bar-closed #page {
-    padding-left: 15px;
-}
-
-.side-bar-closed #title {
-    justify-content: center;
-}
-
-.side-bar-closed #side-bar {
-    border-right-width: 0px;
 }
 
 .sidebar table {

--- a/style/devices/mobile.css
+++ b/style/devices/mobile.css
@@ -6,20 +6,8 @@ body {
     overflow: visible;
 }
 
-body.full-map {
-    overflow: hidden;
-}
-
-body.full-map #main {
-    overflow: hidden;
-}
-
 body.full-map #page {
     padding: 10px 20px 10px 20px;
-}
-
-body.full-map #side-bar {
-    overflow: hidden;
 }
 
 body.full-map #system-menu {
@@ -52,8 +40,13 @@ table th {
     font-size: 12pt;
 }
 
+#content {
+    display: flex;
+    flex-direction: column;
+}
+
 #last-updated {
-    font-size: 12pt;
+    text-align: center;
 }
 
 #loading {
@@ -61,8 +54,8 @@ table th {
 }
 
 #main {
+    order: 3;
     font-size: 12pt;
-    order: 6;
 }
 
 #map-controls {
@@ -77,55 +70,16 @@ table th {
     --image-size: 24px;
 }
 
-#navigation-bar {
-    order: 2;
-    padding: 0px 5px;
-}
-
-#navigation-bar .title {
-    font-size: 22pt;
-}
-
-#navigation-bar .navigation-icon {
+#navigation-bar .navigation-button {
     --image-size: 36px;
 }
 
-#navigation-bar .navigation-icon .label {
+#navigation-bar .navigation-button.compact .label {
     display: none;
 }
 
 #navigation-menu {
-    order: 3;
-    position: relative;
-    margin: 0px;
-    padding: 5px 0px;
-    display: grid;
     grid-template-columns: 1fr 1fr;
-    align-items: center;
-    font-family: var(--sans-serif-font);
-}
-
-#navigation-menu .menu-button {
-    display: flex;
-    flex-direction: row;
-    gap: 10px;
-    align-items: center;
-    padding: 15px 20px;
-    font-size: 16pt;
-    font-weight: normal;
-    --image-size: 24px;
-}
-
-#navigation-menu-toggle {
-    padding: 5px;
-    margin: 5px 10px 5px 0px;
-}
-
-#navigation-menu-toggle .line {
-    width: 32px;
-    height: 4px;
-    border-radius: 2px;
-    margin: 6px;
 }
 
 #page {
@@ -142,7 +96,7 @@ table th {
 }
 
 #search {
-    order: 4;
+    order: 2;
     border-bottom-width: 1px;
     border-bottom-style: solid;
 }
@@ -196,28 +150,33 @@ table th {
     font-size: 11pt;
 }
 
-#side-bar {
-    order: 5;
-}
-
-#side-bar-toggle-container {
-    display: none;
-}
-
-#status .details {
+#status-bar {
+    display: flex;
+    flex-direction: row;
     align-items: center;
-    text-align: center;
+    column-gap: 10px;
+    padding: 5px 20px;
+}
+
+#status-bar .details {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
 }
 
 #system {
-    font-size: 14pt;
+    text-align: center;
 }
 
 #system-menu {
+    order: 1;
+    display: grid;
     grid-template-columns: 1fr 1fr;
     align-items: center;
     border-bottom-width: 1px;
     border-bottom-style: solid;
+    font-size: 12pt;
 }
 
 #system-menu.collapse-non-desktop {
@@ -226,13 +185,11 @@ table th {
 
 #system-menu .header {
     grid-column-end: span 2;
-    font-size: 15pt;
     text-align: center;
 }
 
 #system-menu .system-button {
     padding: 5px 20px;
-    font-size: 14pt;
     font-weight: normal;
 }
 
@@ -241,12 +198,8 @@ table th {
 }
 
 #system-menu-toggle {
-    --image-size: 36px;
-}
-
-#title {
-    order: 1;
-    display: none;
+    grid-row: span 2;
+    --image-size: 32px;
 }
 
 .button {
@@ -293,6 +246,10 @@ table th {
 .page-container {
     flex-direction: column;
     gap: 20px;
+}
+
+.placeholder {
+    align-items: stretch;
 }
 
 .sheet .dates .month .name {

--- a/style/devices/tablet.css
+++ b/style/devices/tablet.css
@@ -6,14 +6,6 @@ body {
     overflow: visible;
 }
 
-body.full-map {
-    overflow: hidden;
-}
-
-body.full-map #main {
-    overflow: hidden;
-}
-
 body.full-map #page {
     padding: 10px 20px 10px 20px;
 }
@@ -36,17 +28,18 @@ table {
     font-size: 12pt;
 }
 
-table {
+table th {
     font-size: 13pt;
 }
 
-#last-updated {
-    font-size: 12pt;
+#content {
+    display: flex;
+    flex-direction: column;
 }
 
 #main {
+    order: 3;
     font-size: 13pt;
-    order: 6;
 }
 
 #map-controls {
@@ -54,60 +47,17 @@ table {
     bottom: 15px;
 }
 
-#navigation-bar {
-    order: 2;
-    padding: 0px 5px;
-}
-
-#navigation-bar .navigation-item {
+#navigation-bar .navigation-button {
     font-size: 16pt;
-}
-
-#navigation-bar .title {
-    font-size: 22pt;
-}
-
-#navigation-bar .navigation-icon {
     --image-size: 36px;
 }
 
-#navigation-bar .navigation-icon .label {
+#navigation-bar .navigation-button.compact .label {
     display: none;
 }
 
 #navigation-menu {
-    order: 3;
-    position: relative;
-    margin: 0px;
-    padding: 5px 0px;
-    display: grid;
     grid-template-columns: 1fr 1fr 1fr 1fr;
-    align-items: center;
-    font-family: var(--sans-serif-font);
-}
-
-#navigation-menu .menu-button {
-    display: flex;
-    flex-direction: row;
-    gap: 10px;
-    align-items: center;
-    padding: 15px 20px;
-    font-size: 16pt;
-    font-weight: normal;
-    text-align: center;
-    --image-size: 24px;
-}
-
-#navigation-menu-toggle {
-    padding: 5px;
-    margin: 5px 10px 5px 0px;
-}
-
-#navigation-menu-toggle .line {
-    width: 32px;
-    height: 4px;
-    border-radius: 2px;
-    margin: 6px;
 }
 
 #page {
@@ -115,11 +65,11 @@ table {
 }
 
 #refresh-button {
-    --image-size: 36px;
+    --image-size: 28px;
 }
 
 #search {
-    order: 4;
+    order: 2;
     border-bottom-width: 1px;
     border-bottom-style: solid;
 }
@@ -169,28 +119,33 @@ table {
     font-size: 12pt;
 }
 
-#side-bar {
-    order: 5;
-}
-
-#side-bar-toggle-container {
-    display: none;
-}
-
-#status .details {
+#status-bar {
+    display: flex;
+    flex-direction: row;
     align-items: center;
-    text-align: center;
+    gap: 10px;
+    padding: 5px 20px;
+}
+
+#status-bar .details {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 10px;
 }
 
 #system {
-    font-size: 14pt;
+    padding: 0px 10px;
 }
 
 #system-menu {
-    grid-template-columns: 1fr 1fr 1fr 1fr;
+    order: 1;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
     align-items: center;
     border-bottom-width: 1px;
     border-bottom-style: solid;
+    font-size: 12pt;
 }
 
 #system-menu.collapse-non-desktop {
@@ -198,28 +153,21 @@ table {
 }
 
 #system-menu .header {
-    grid-column-end: span 4;
-    font-size: 15pt;
+    grid-column-end: span 3;
     text-align: center;
 }
 
 #system-menu .system-button {
     padding: 5px 20px;
-    font-size: 14pt;
     font-weight: normal;
 }
 
 #system-menu .system-button.all-systems {
-    grid-column-end: span 4;
+    grid-column-end: span 3;
 }
 
 #system-menu-toggle {
-    --image-size: 36px;
-}
-
-#title {
-    order: 1;
-    display: none;
+    --image-size: 28px;
 }
 
 .button {
@@ -274,6 +222,10 @@ button.compact {
 .page-container {
     flex-direction: column;
     gap: 20px;
+}
+
+.placeholder {
+    align-items: stretch;
 }
 
 .smaller-font {

--- a/style/main.css
+++ b/style/main.css
@@ -37,6 +37,7 @@ body.full-map .tab-button-bar {
 }
 
 input {
+    appearance: none;
     -webkit-appearance: none;
 }
 
@@ -143,6 +144,14 @@ table tr.table-button {
 #banners {
     position: relative;
     z-index: 20;
+}
+
+#content {
+    flex: 1;
+}
+
+#last-updated {
+    font-size: 12pt;
 }
 
 #loading {
@@ -262,43 +271,79 @@ table tr.table-button {
 #navigation-bar {
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: stretch;
     font-family: var(--sans-serif-font);
+    background-color: var(--navigation-bar-background);
+    --image-color: var(--navigation-bar-foreground);
 }
 
-#navigation-bar .navigation-icon {
-    padding: 5px;
-    margin: 0px 2px;
-    border-radius: 100px;
+#navigation-bar .navigation-button {
     cursor: pointer;
+    padding: 10px 15px;
+    text-decoration: none !important;
+    font-weight: normal;
     display: flex;
     flex-direction: row;
     gap: 5px;
     align-items: center;
+    color: var(--navigation-bar-foreground);
     --image-size: 28px;
 }
 
-#navigation-bar .navigation-icon:hover {
-    text-decoration: none;
-}
-
-#navigation-bar .navigation-icon .label {
-    margin-right: 5px;
-}
-
-#navigation-bar .navigation-item {
-    padding: 15px;
-    text-decoration: none !important;
-    font-weight: normal;
-}
-
-#navigation-bar .navigation-item.disabled {
+#navigation-bar .navigation-button.disabled {
     cursor: default;
     opacity: 0.7;
 }
 
-#navigation-bar .title {
-    font-weight: bold;
+#navigation-bar .navigation-button.compact {
+    align-self: center;
+    padding: 5px;
+    border-radius: 100px;
+    margin: 0px 2px;
+}
+
+#navigation-bar .navigation-button.compact .label {
+    margin-right: 5px;
+}
+
+#navigation-menu {
+    position: relative;
+    margin: 0px;
+    padding: 5px 0px;
+    display: grid;
+    align-items: center;
+    font-family: var(--sans-serif-font);
+    background-color: var(--navigation-menu-background);
+    --image-color: var(--navigation-menu-foreground)
+}
+
+#navigation-menu .menu-button {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+    align-items: center;
+    padding: 15px 20px;
+    font-size: 16pt;
+    font-weight: normal;
+    color: var(--navigation-menu-foreground);
+    --image-size: 24px;
+}
+
+#navigation-menu .menu-button.disabled {
+    opacity: 0.7;
+}
+
+#navigation-menu-toggle {
+    padding: 5px;
+    margin: 5px 10px 5px 0px;
+}
+
+#navigation-menu-toggle .line {
+    width: 32px;
+    height: 4px;
+    border-radius: 2px;
+    margin: 6px;
+    background-color: var(--navigation-bar-foreground);
 }
 
 #nearby-status {
@@ -356,11 +401,8 @@ table tr.table-button {
 }
 
 #refresh-button {
-    border-radius: 50%;
-}
-
-#refresh-button:hover {
     cursor: pointer;
+    border-radius: 50%;
 }
 
 #refresh-button.disabled {
@@ -444,34 +486,20 @@ table tr.table-button {
     display: none !important;
 }
 
-#side-bar {
-    display: flex;
-    flex-direction: column;
+#status-bar {
     font-family: var(--sans-serif-font);
-}
-
-#status {
-    padding: 10px 20px;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    gap: 20px;
-}
-
-#status .details {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 0px;
+    background-color: var(--status-bar-background);
+    color: var(--status-bar-foreground);
+    --image-color: var(--status-bar-foreground);
 }
 
 #system {
     font-weight: bold;
+    font-size: 14pt;
 }
 
 #system-menu {
-    display: grid;
+    font-family: var(--sans-serif-font);
 }
 
 #system-menu .header {
@@ -486,11 +514,29 @@ table tr.table-button {
     align-items: center;
 }
 
+#system-menu .system-button.current {
+    font-weight: bold;
+    cursor: default;
+}
+
 #top-button {
     position: fixed;
     right: 40px;
     bottom: 20px;
     display: none;
+}
+
+#title {
+    font-size: 22pt;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    padding: 10px 20px;
+    text-decoration: none;
+    line-height: 1em;
+    gap: 10px;
+    color: var(--navigation-bar-foreground);
+    --image-size: 24px;
 }
 
 .adherence-indicator {

--- a/style/themes/bc-hydro.css
+++ b/style/themes/bc-hydro.css
@@ -200,6 +200,10 @@ table tr.table-button:hover {
     color: #666666;
 }
 
+#status-bar {
+    --tooltip-background: #026E6E;
+}
+
 #system-menu {
     background-color: #D8D8D8;
     border-color: #666666;

--- a/style/themes/bc-hydro.css
+++ b/style/themes/bc-hydro.css
@@ -17,6 +17,17 @@
 */
 
 :root {
+    --navigation-bar-background: #61C315;
+    --navigation-bar-hover: #347800;
+    --navigation-bar-foreground: #FFFFFF;
+    
+    --navigation-menu-background: #347800;
+    --navigation-menu-foreground: #FFFFFF;
+    
+    --status-bar-background: #249B9B;
+    --status-bar-hover: #026E6E;
+    --status-bar-foreground: #FFFFFF;
+    
     --loading-background: #FFFBEF;
     --loading-foreground: #61C315;
     
@@ -114,51 +125,7 @@ table tr.table-button:hover {
 }
 
 #navigation-bar {
-    background-color: #61C315;
     --tooltip-background: #347800;
-    --image-color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon:hover {
-    background-color: #347800;
-}
-
-#navigation-bar .navigation-icon.disabled:hover {
-    background-color: #61C315 !important;
-}
-
-#navigation-bar .navigation-item {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-item:hover {
-    background-color: #347800;
-}
-
-#navigation-bar .navigation-item.disabled:hover {
-    background-color: #61C315 !important;
-}
-
-#navigation-menu {
-    background-color: #347800;
-}
-
-#navigation-menu .menu-button {
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
-#navigation-menu .menu-button.disabled {
-    color: #ABABAB;
-    --image-color: #ABABAB;
-}
-
-#navigation-menu-toggle .line {
-    background-color: #FFFFFF;
 }
 
 #nearby-status.loading {
@@ -182,18 +149,6 @@ table tr.table-button:hover {
 #quick-navigation .item {
     background-color: #D8D8D8;
     border-color: #666666;
-}
-
-#refresh-button {
-    --image-color: #FFFFFF;
-}
-
-#refresh-button:hover {
-    background-color: #026E6E;
-}
-
-#refresh-button.disabled:hover {
-    background-color: #249B9B;
 }
 
 #search {
@@ -245,27 +200,9 @@ table tr.table-button:hover {
     color: #666666;
 }
 
-#side-bar {
-    border-right-color: #666666;
-}
-
-#side-bar-toggle {
-    background-color: #D8D8D8;
-}
-
-#side-bar-toggle:hover {
-    background-color: #CBCBCB;
-}
-
-#status {
-    background-color: #249B9B;
-    color: #FFFFFF;
-    border-bottom-color: #666666;
-}
-
 #system-menu {
     background-color: #D8D8D8;
-    border-bottom-color: #666666;
+    border-color: #666666;
 }
 
 #system-menu .header {
@@ -283,22 +220,6 @@ table tr.table-button:hover {
 
 #system-menu .system-button.current {
     background-color: #CBCBCB;
-    font-weight: bold;
-    cursor: default;
-}
-
-#system-menu-toggle {
-    --image-color: #FFFFFF;
-}
-
-#title {
-    background-color: #61C315;
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
-#title:hover {
-    background-color: #347800;
 }
 
 .banner {

--- a/style/themes/bc-transit-classic.css
+++ b/style/themes/bc-transit-classic.css
@@ -204,6 +204,10 @@ table tr.table-button:hover {
     color: #666666;
 }
 
+#status-bar {
+    --tooltip-background: #011E58;
+}
+
 #system-menu {
     background-color: #E6E6E6;
     border-color: #666666;

--- a/style/themes/bc-transit-classic.css
+++ b/style/themes/bc-transit-classic.css
@@ -17,6 +17,17 @@
 */
 
 :root {
+    --navigation-bar-background: #E20000;
+    --navigation-bar-hover: #840000;
+    --navigation-bar-foreground: #FFFFFF;
+    
+    --navigation-menu-background: #840000;
+    --navigation-menu-foreground: #FFFFFF;
+    
+    --status-bar-background: #023496;
+    --status-bar-hover: #011E58;
+    --status-bar-foreground: #FFFFFF;
+    
     --loading-background: #FFFFFF;
     --loading-foreground: #E20000;
     
@@ -118,51 +129,7 @@ table tr.table-button:hover {
 }
 
 #navigation-bar {
-    background-color: #E20000;
     --tooltip-background: #840000;
-    --image-color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon:hover {
-    background-color: #840000;
-}
-
-#navigation-bar .navigation-icon.disabled:hover {
-    background-color: #E20000 !important;
-}
-
-#navigation-bar .navigation-item {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-item:hover {
-    background-color: #840000;
-}
-
-#navigation-bar .navigation-item.disabled:hover {
-    background-color: #E20000 !important;
-}
-
-#navigation-menu {
-    background-color: #840000;
-    --image-color: #FFFFFF;
-}
-
-#navigation-menu .menu-button {
-    color: #FFFFFF;
-}
-
-#navigation-menu .menu-button.disabled {
-    color: #ABABAB;
-    --image-color: #ABABAB;
-}
-
-#navigation-menu-toggle .line {
-    background-color: #FFFFFF;
 }
 
 #nearby-status.loading {
@@ -186,18 +153,6 @@ table tr.table-button:hover {
 #quick-navigation .item {
     background-color: #E6E6E6;
     border-color: #666666;
-}
-
-#refresh-button {
-    --image-color: #FFFFFF;
-}
-
-#refresh-button:hover {
-    background-color: #011E58;
-}
-
-#refresh-button.disabled:hover {
-    background-color: #023496;
 }
 
 #search {
@@ -249,27 +204,9 @@ table tr.table-button:hover {
     color: #666666;
 }
 
-#side-bar {
-    border-right-color: #666666;
-}
-
-#side-bar-toggle {
-    background-color: #E6E6E6;
-}
-
-#side-bar-toggle:hover {
-    background-color: #CBCBCB;
-}
-
-#status {
-    background-color: #023496;
-    color: #FFFFFF;
-    border-bottom-color: #666666;
-}
-
 #system-menu {
     background-color: #E6E6E6;
-    border-bottom-color: #666666;
+    border-color: #666666;
 }
 
 #system-menu .header {
@@ -287,22 +224,6 @@ table tr.table-button:hover {
 
 #system-menu .system-button.current {
     background-color: #CBCBCB;
-    font-weight: bold;
-    cursor: default;
-}
-
-#system-menu-toggle {
-    --image-color: #FFFFFF;
-}
-
-#title {
-    background-color: #E20000;
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
-#title:hover {
-    background-color: #840000;
 }
 
 .banner {

--- a/style/themes/bc-transit.dark.css
+++ b/style/themes/bc-transit.dark.css
@@ -213,6 +213,10 @@ table tr.table-button:hover {
     color: #ABABAB;
 }
 
+#status-bar {
+    --tooltip-background: #053305;
+}
+
 #system-menu {
     background-color: #393939;
     border-color: #565656;

--- a/style/themes/bc-transit.dark.css
+++ b/style/themes/bc-transit.dark.css
@@ -19,6 +19,17 @@
 :root {
     color-scheme: dark;
     
+    --navigation-bar-background: #154E15;
+    --navigation-bar-hover: #053305;
+    --navigation-bar-foreground: #FFFFFF;
+    
+    --navigation-menu-background: #053305;
+    --navigation-menu-foreground: #FFFFFF;
+    
+    --status-bar-background: #276227;
+    --status-bar-hover: #053305;
+    --status-bar-foreground: #FFFFFF;
+    
     --loading-background: #2F2F2F;
     --loading-foreground: #154E15;
     
@@ -128,51 +139,7 @@ table tr.table-button:hover {
 }
 
 #navigation-bar {
-    background-color: #154E15;
     --tooltip-background: #053305;
-    --image-color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon:hover {
-    background-color: #053305;
-}
-
-#navigation-bar .navigation-icon.disabled:hover {
-    background-color: #154E15 !important;
-}
-
-#navigation-bar .navigation-item {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-item:hover {
-    background-color: #053305;
-}
-
-#navigation-bar .navigation-item.disabled:hover {
-    background-color: #154E15 !important;
-}
-
-#navigation-menu {
-    background-color: #053305;
-    --image-color: #FFFFFF;
-}
-
-#navigation-menu .menu-button {
-    color: #FFFFFF;
-}
-
-#navigation-menu .menu-button.disabled {
-    color: #ABABAB;
-    --image-color: #ABABAB;
-}
-
-#navigation-menu-toggle .line {
-    background-color: #FFFFFF;
 }
 
 #nearby-status.loading {
@@ -196,18 +163,6 @@ table tr.table-button:hover {
 #quick-navigation .item {
     background-color: #393939;
     border-color: #565656;
-}
-
-#refresh-button {
-    --image-color: #FFFFFF;
-}
-
-#refresh-button:hover {
-    background-color: #053305;
-}
-
-#refresh-button.disabled:hover {
-    background-color: #276227;
 }
 
 #search {
@@ -258,28 +213,9 @@ table tr.table-button:hover {
     color: #ABABAB;
 }
 
-#side-bar {
-    border-right-color: #565656;
-}
-
-#side-bar-toggle {
-    background-color: #393939;
-    --image-color: #FFFFFF;
-}
-
-#side-bar-toggle:hover {
-    background-color: #565656;
-}
-
-#status {
-    background-color: #276227;
-    color: #FFFFFF;
-    border-bottom-color: #565656;
-}
-
 #system-menu {
     background-color: #393939;
-    border-bottom-color: #565656;
+    border-color: #565656;
 }
 
 #system-menu .header {
@@ -297,22 +233,6 @@ table tr.table-button:hover {
 
 #system-menu .system-button.current {
     background-color: #2F2F2F;
-    font-weight: bold;
-    cursor: default;
-}
-
-#system-menu-toggle {
-    --image-color: #FFFFFF;
-}
-
-#title {
-    background-color: #154E15;
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
-#title:hover {
-    background-color: #053305;
 }
 
 .banner {

--- a/style/themes/bc-transit.light.css
+++ b/style/themes/bc-transit.light.css
@@ -204,6 +204,10 @@ table tr.table-button:hover {
     color: #666666;
 }
 
+#status-bar {
+    --tooltip-background: #094409;
+}
+
 #system-menu {
     background-color: #E6E6E6;
     border-color: #666666;

--- a/style/themes/bc-transit.light.css
+++ b/style/themes/bc-transit.light.css
@@ -17,6 +17,17 @@
 */
 
 :root {
+    --navigation-bar-background: #1A671A;
+    --navigation-bar-hover: #094409;
+    --navigation-bar-foreground: #FFFFFF;
+    
+    --navigation-menu-background: #094409;
+    --navigation-menu-foreground: #FFFFFF;
+    
+    --status-bar-background: #48A348;
+    --status-bar-hover: #094409;
+    --status-bar-foreground: #FFFFFF;
+    
     --loading-background: #FFFFFF;
     --loading-foreground: #48A348;
     
@@ -118,51 +129,7 @@ table tr.table-button:hover {
 }
 
 #navigation-bar {
-    background-color: #1A671A;
     --tooltip-background: #094409;
-    --image-color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon:hover {
-    background-color: #094409;
-}
-
-#navigation-bar .navigation-icon.disabled:hover {
-    background-color: #1A671A !important;
-}
-
-#navigation-bar .navigation-item {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-item:hover {
-    background-color: #094409;
-}
-
-#navigation-bar .navigation-item.disabled:hover {
-    background-color: #1A671A !important;
-}
-
-#navigation-menu {
-    background-color: #094409;
-}
-
-#navigation-menu .menu-button {
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
-#navigation-menu .menu-button.disabled {
-    color: #ABABAB;
-    --image-color: #ABABAB;
-}
-
-#navigation-menu-toggle .line {
-    background-color: #FFFFFF;
 }
 
 #nearby-status.loading {
@@ -186,18 +153,6 @@ table tr.table-button:hover {
 #quick-navigation .item {
     background-color: #E6E6E6;
     border-color: #666666;
-}
-
-#refresh-button {
-    --image-color: #FFFFFF;
-}
-
-#refresh-button:hover {
-    background-color: #094409;
-}
-
-#refresh-button.disabled:hover {
-    background-color: #48A348;
 }
 
 #search {
@@ -249,27 +204,9 @@ table tr.table-button:hover {
     color: #666666;
 }
 
-#side-bar {
-    border-right-color: #666666;
-}
-
-#side-bar-toggle {
-    background-color: #E6E6E6;
-}
-
-#side-bar-toggle:hover {
-    background-color: #CBCBCB;
-}
-
-#status {
-    background-color: #48A348;
-    color: #FFFFFF;
-    border-bottom-color: #666666;
-}
-
 #system-menu {
     background-color: #E6E6E6;
-    border-bottom-color: #666666;
+    border-color: #666666;
 }
 
 #system-menu .header {
@@ -287,22 +224,6 @@ table tr.table-button:hover {
 
 #system-menu .system-button.current {
     background-color: #CBCBCB;
-    font-weight: bold;
-    cursor: default;
-}
-
-#system-menu-toggle {
-    --image-color: #FFFFFF;
-}
-
-#title {
-    background-color: #1A671A;
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
-#title:hover {
-    background-color: #094409;
 }
 
 .banner {

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -17,6 +17,17 @@
 */
 
 :root {
+    --navigation-bar-background: #165ABE;
+    --navigation-bar-hover: #07080D;
+    --navigation-bar-foreground: #FFFFFF;
+    
+    --navigation-menu-background: #07080D;
+    --navigation-menu-foreground: #FFFFFF;
+    
+    --status-bar-background: #E39B35;
+    --status-bar-hover: #C07A16;
+    --status-bar-foreground: #FFFFFF;
+    
     --loading-background: #FFFFFF;
     --loading-foreground: #165ABE;
     
@@ -114,51 +125,7 @@ table tr.table-button:hover {
 }
 
 #navigation-bar {
-    background-color: #165ABE;
     --tooltip-background: #07080D;
-    --image-color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon:hover {
-    background-color: #0A4499;
-}
-
-#navigation-bar .navigation-icon.disabled:hover {
-    background-color: #165ABE !important;
-}
-
-#navigation-bar .navigation-item {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-item:hover {
-    background-color: #0A4499;
-}
-
-#navigation-bar .navigation-item.disabled:hover {
-    background-color: #165ABE !important;
-}
-
-#navigation-menu {
-    background-color: #07080D;
-}
-
-#navigation-menu .menu-button {
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
-#navigation-menu .menu-button.disabled {
-    color: #ABABAB;
-    --image-color: #ABABAB;
-}
-
-#navigation-menu-toggle .line {
-    background-color: #FFFFFF;
 }
 
 #nearby-status.loading {
@@ -182,18 +149,6 @@ table tr.table-button:hover {
 #quick-navigation .item {
     background-color: #E6E6E6;
     border-color: #000000;
-}
-
-#refresh-button {
-    --image-color: #FFFFFF;
-}
-
-#refresh-button:hover {
-    background-color: #C07A16;
-}
-
-#refresh-button.disabled:hover {
-    background-color: #E39B35;
 }
 
 #search {
@@ -245,27 +200,9 @@ table tr.table-button:hover {
     color: #666666;
 }
 
-#side-bar {
-    border-right-color: #000000;
-}
-
-#side-bar-toggle {
-    background-color: #E6E6E6;
-}
-
-#side-bar-toggle:hover {
-    background-color: #CBCBCB;
-}
-
-#status {
-    background-color: #E39B35;
-    color: #FFFFFF;
-    border-bottom-color: #000000;
-}
-
 #system-menu {
     background-color: #E6E6E6;
-    border-bottom-color: #000000;
+    border-color: #000000;
 }
 
 #system-menu .header {
@@ -283,22 +220,6 @@ table tr.table-button:hover {
 
 #system-menu .system-button.current {
     background-color: #CBCBCB;
-    font-weight: bold;
-    cursor: default;
-}
-
-#system-menu-toggle {
-    --image-color: #FFFFFF;
-}
-
-#title {
-    background-color: #165ABE;
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
-#title:hover {
-    background-color: #0A4499;
 }
 
 .banner {

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -200,6 +200,10 @@ table tr.table-button:hover {
     color: #666666;
 }
 
+#status-bar {
+    --tooltip-background: #C07A16;
+}
+
 #system-menu {
     background-color: #E6E6E6;
     border-color: #000000;

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -17,6 +17,17 @@
 */
 
 :root {
+    --navigation-bar-background: #AB0000;
+    --navigation-bar-hover: #7A0000;
+    --navigation-bar-foreground: #FFFFFF;
+    
+    --navigation-menu-background: #7A0000;
+    --navigation-menu-foreground: #FFFFFF;
+    
+    --status-bar-background: #D70000;
+    --status-bar-hover: #7A0000;
+    --status-bar-foreground: #FFFFFF;
+    
     --tooltip-background: #69BB65;
     
     --loading-background: #FFFFFF;
@@ -120,51 +131,7 @@ table tr.table-button:hover {
 }
 
 #navigation-bar {
-    background-color: #AB0000;
     --tooltip-background: #7A0000;
-    --image-color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon:hover {
-    background-color: #7A0000;
-}
-
-#navigation-bar .navigation-icon.disabled:hover {
-    background-color: #AB0000 !important;
-}
-
-#navigation-bar .navigation-item {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-item:hover {
-    background-color: #7A0000;
-}
-
-#navigation-bar .navigation-item.disabled:hover {
-    background-color: #AB0000 !important;
-}
-
-#navigation-menu {
-    background-color: #7A0000;
-    --image-color: #FFFFFF;
-}
-
-#navigation-menu .menu-button {
-    color: #FFFFFF;
-}
-
-#navigation-menu .menu-button.disabled {
-    color: #ABABAB;
-    --image-color: #ABABAB;
-}
-
-#navigation-menu-toggle .line {
-    background-color: #FFFFFF;
 }
 
 #nearby-status.loading {
@@ -188,18 +155,6 @@ table tr.table-button:hover {
 #quick-navigation .item {
     background-color: #E4F6E3;
     border-color: #69BB65;
-}
-
-#refresh-button {
-    --image-color: #FFFFFF;
-}
-
-#refresh-button:hover {
-    background-color: #7A0000;
-}
-
-#refresh-button.disabled:hover {
-    background-color: #D70000;
 }
 
 #search {
@@ -251,27 +206,9 @@ table tr.table-button:hover {
     color: #666666;
 }
 
-#side-bar {
-    border-right-color: #69BB65;
-}
-
-#side-bar-toggle {
-    background-color: #E4F6E3;
-}
-
-#side-bar-toggle:hover {
-    background-color: #C3E9C1;
-}
-
-#status {
-    background-color: #D70000;
-    color: #FFFFFF;
-    border-bottom-color: #69BB65;
-}
-
 #system-menu {
     background-color: #E4F6E3;
-    border-bottom-color: #69BB65;
+    border-color: #69BB65;
 }
 
 #system-menu .header {
@@ -289,22 +226,6 @@ table tr.table-button:hover {
 
 #system-menu .system-button.current {
     background-color: #C3E9C1;
-    font-weight: bold;
-    cursor: default;
-}
-
-#system-menu-toggle {
-    --image-color: #FFFFFF;
-}
-
-#title {
-    background-color: #AB0000;
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
-#title:hover {
-    background-color: #7A0000;
 }
 
 .banner {

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -206,6 +206,10 @@ table tr.table-button:hover {
     color: #666666;
 }
 
+#status-bar {
+    --tooltip-background: #7A0000;
+}
+
 #system-menu {
     background-color: #E4F6E3;
     border-color: #69BB65;

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -2,9 +2,9 @@
  * 
  * Primary Background: #FFFFFF
  * Secondary Background: #E6E6E6
- * Primary Header: #FFFFFF
- * Secondary Header: #FFFFFF
- * Menu: #094409
+ * Primary Header: #EEEEEE
+ * Secondary Header: #EEEEEE
+ * Menu: #DDDDDD
  * Borders: #DDDDDD
  * Selection: #CBCBCB
  * 
@@ -17,6 +17,17 @@
 */
 
 :root {
+    --navigation-bar-background: #EEEEEE;
+    --navigation-bar-hover: #DDDDDD;
+    --navigation-bar-foreground: #000000;
+    
+    --navigation-menu-background: #DDDDDD;
+    --navigation-menu-foreground: #000000;
+    
+    --status-bar-background: #EEEEEE;
+    --status-bar-hover: #DDDDDD;
+    --status-bar-foreground: #000000;
+    
     --tooltip-background: #888888;
     
     --loading-background: #FFFFFF;
@@ -111,53 +122,6 @@ table tr.table-button:hover {
     --map-control-icon: #365CCB;
 }
 
-#navigation-bar {
-    background-color: #EEEEEE;
-    --image-color: #000000;
-}
-
-#navigation-bar .navigation-icon {
-    color: #000000;
-}
-
-#navigation-bar .navigation-icon:hover {
-    background-color: #DDDDDD;
-}
-
-#navigation-bar .navigation-icon.disabled:hover {
-    background-color: #FFFFFF !important;
-}
-
-#navigation-bar .navigation-item {
-    color: #000000;
-}
-
-#navigation-bar .navigation-item:hover {
-    background-color: #DDDDDD;
-}
-
-#navigation-bar .navigation-item.disabled:hover {
-    background-color: #FFFFFF !important;
-}
-
-#navigation-menu {
-    background-color: #DDDDDD;
-    --image-color: #000000;
-}
-
-#navigation-menu .menu-button {
-    color: #000000;
-}
-
-#navigation-menu .menu-button.disabled {
-    color: #888888;
-    --image-color: #888888;
-}
-
-#navigation-menu-toggle .line {
-    background-color: #000000;
-}
-
 #nearby-status.loading {
     background-color: #EEEEEE;
     border-color: #DDDDDD;
@@ -179,18 +143,6 @@ table tr.table-button:hover {
 #quick-navigation .item {
     background-color: #EEEEEE;
     border-color: #DDDDDD;
-}
-
-#refresh-button {
-    --image-color: #666666;
-}
-
-#refresh-button:hover {
-    background-color: #DDDDDD;
-}
-
-#refresh-button.disabled:hover {
-    background-color: #FFFFFF;
 }
 
 #search {
@@ -239,27 +191,9 @@ table tr.table-button:hover {
     color: #888888;
 }
 
-#side-bar {
-    border-right-color: #EEEEEE;
-}
-
-#side-bar-toggle {
-    background-color: #EEEEEE;
-}
-
-#side-bar-toggle:hover {
-    background-color: #DDDDDD;
-}
-
-#status {
-    background-color: #FFFFFF;
-    color: #000000;
-    border-bottom-color: #EEEEEE;
-}
-
 #system-menu {
     background-color: #FFFFFF;
-    border-bottom-color: #EEEEEE;
+    border-color: #EEEEEE;
 }
 
 #system-menu .header {
@@ -275,22 +209,6 @@ table tr.table-button:hover {
 }
 
 #system-menu .system-button.current {
-    background-color: #DDDDDD;
-    font-weight: bold;
-    cursor: default;
-}
-
-#system-menu-toggle {
-    --image-color: #666666;
-}
-
-#title {
-    background-color: #EEEEEE;
-    color: #000000;
-    --image-color: #000000;
-}
-
-#title:hover {
     background-color: #DDDDDD;
 }
 

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -213,6 +213,10 @@ table tr.table-button:hover {
     color: #ABABAB;
 }
 
+#status-bar {
+    --tooltip-background: #B24C00;
+}
+
 #system-menu {
     background-color: #393939;
     border-color: #565656;

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -19,6 +19,17 @@
 :root {
     color-scheme: dark;
     
+    --navigation-bar-background: #FF6C00;
+    --navigation-bar-hover: #B24C00;
+    --navigation-bar-foreground: #FFFFFF;
+    
+    --navigation-menu-background: #B24C00;
+    --navigation-menu-foreground: #FFFFFF;
+    
+    --status-bar-background: #E56100;
+    --status-bar-hover: #B24C00;
+    --status-bar-foreground: #FFFFFF;
+    
     --loading-background: #2F2F2F;
     --loading-foreground: #FF6C00;
     
@@ -128,51 +139,7 @@ table tr.table-button:hover {
 }
 
 #navigation-bar {
-    background-color: #E56100;
     --tooltip-background: #B24C00;
-    --image-color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon:hover {
-    background-color: #B24C00;
-}
-
-#navigation-bar .navigation-icon.disabled:hover {
-    background-color: #E56100 !important;
-}
-
-#navigation-bar .navigation-item {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-item:hover {
-    background-color: #B24C00;
-}
-
-#navigation-bar .navigation-item.disabled:hover {
-    background-color: #E56100 !important;
-}
-
-#navigation-menu {
-    background-color: #B24C00;
-    --image-color: #FFFFFF;
-}
-
-#navigation-menu .menu-button {
-    color: #FFFFFF;
-}
-
-#navigation-menu .menu-button.disabled {
-    color: #ABABAB;
-    --image-color: #ABABAB;
-}
-
-#navigation-menu-toggle .line {
-    background-color: #FFFFFF;
 }
 
 #nearby-status.loading {
@@ -196,18 +163,6 @@ table tr.table-button:hover {
 #quick-navigation .item {
     background-color: #393939;
     border-color: #565656;
-}
-
-#refresh-button {
-    --image-color: #FFFFFF;
-}
-
-#refresh-button:hover {
-    background-color: #B24C00;
-}
-
-#refresh-button.disabled:hover {
-    background-color: #FF6C00;
 }
 
 #search {
@@ -258,28 +213,9 @@ table tr.table-button:hover {
     color: #ABABAB;
 }
 
-#side-bar {
-    border-right-color: #565656;
-}
-
-#side-bar-toggle {
-    background-color: #393939;
-    --image-color: #FFFFFF;
-}
-
-#side-bar-toggle:hover {
-    background-color: #565656;
-}
-
-#status {
-    background-color: #FF6C00;
-    color: #FFFFFF;
-    border-bottom-color: #565656;
-}
-
 #system-menu {
     background-color: #393939;
-    border-bottom-color: #565656;
+    border-color: #565656;
 }
 
 #system-menu .header {
@@ -297,22 +233,6 @@ table tr.table-button:hover {
 
 #system-menu .system-button.current {
     background-color: #2F2F2F;
-    font-weight: bold;
-    cursor: default;
-}
-
-#system-menu-toggle {
-    --image-color: #FFFFFF;
-}
-
-#title {
-    background-color: #E56100;
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
-#title:hover {
-    background-color: #B24C00;
 }
 
 .banner {

--- a/style/themes/pride.dark.css
+++ b/style/themes/pride.dark.css
@@ -202,6 +202,10 @@ table tr.table-button:hover {
     color: #ABABAB;
 }
 
+#status-bar {
+    --tooltip-background: #000000;
+}
+
 #system-menu {
     background-color: rgba(0, 0, 0, 0.6);
     border-color: rgba(255, 255, 255, 0.3);

--- a/style/themes/pride.dark.css
+++ b/style/themes/pride.dark.css
@@ -1,6 +1,18 @@
 
 :root {
     color-scheme: dark;
+    
+    --navigation-bar-background: rgba(0, 0, 0, 0.6);
+    --navigation-bar-hover: rgba(0, 0, 0, 0.2);
+    --navigation-bar-foreground: #FFFFFF;
+    
+    --navigation-menu-background: rgba(0, 0, 0, 0.6);
+    --navigation-menu-foreground: #FFFFFF;
+    
+    --status-bar-background: rgba(0, 0, 0, 0.6);
+    --status-bar-hover: rgba(0, 0, 0, 0.2);
+    --status-bar-foreground: #FFFFFF;
+    
     --tooltip-background: #000000;
     
     --loading-background: rgba(0, 0, 0, 0);
@@ -111,53 +123,12 @@ table tr.table-button:hover {
 }
 
 #navigation-bar {
-    background-color: rgba(0, 0, 0, 0.6);
     --tooltip-background: #000000;
-    --image-color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon:hover {
-    background-color: rgba(0, 0, 0, 0.2);
-}
-
-#navigation-bar .navigation-icon.disabled:hover {
-    background-color: rgba(0, 0, 0, 0) !important;
-}
-
-#navigation-bar .navigation-item {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-item:hover {
-    background-color: rgba(0, 0, 0, 0.2);
-}
-
-#navigation-bar .navigation-item.disabled:hover {
-    background-color: rgba(0, 0, 0, 0) !important;
 }
 
 #navigation-menu {
-    background-color: rgba(0, 0, 0, 0.6);
     border-top: 1px solid rgba(255, 255, 255, 0.3);
     border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-}
-
-#navigation-menu .menu-button {
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
-#navigation-menu .menu-button.disabled {
-    color: #ABABAB;
-    --image-color: #ABABAB;
-}
-
-#navigation-menu-toggle .line {
-    background-color: #FFFFFF;
 }
 
 #nearby-status.loading {
@@ -181,18 +152,6 @@ table tr.table-button:hover {
 #quick-navigation .item {
     background-color: rgba(0, 0, 0, 0.6);
     border-color: rgba(255, 255, 255, 0.3);
-}
-
-#refresh-button {
-    --image-color: #FFFFFF;
-}
-
-#refresh-button:hover {
-    background-color: rgba(0, 0, 0, 0.4);
-}
-
-#refresh-button.disabled:hover {
-    background-color: rgba(0, 0, 0, 0);
 }
 
 #search {
@@ -243,27 +202,9 @@ table tr.table-button:hover {
     color: #ABABAB;
 }
 
-#side-bar {
-    background-color: rgba(0, 0, 0, 0.6);
-    color: #FFFFFF;
-    border-right-color: rgba(255, 255, 255, 0.3);
-}
-
-#side-bar-toggle {
-    background-color: rgba(0, 0, 0, 0.4);
-    --image-color: #FFFFFF;
-}
-
-#side-bar-toggle:hover {
-    background-color: rgba(0, 0, 0, 0.6);
-}
-
-#status {
-    border-bottom-color: rgba(255, 255, 255, 0.3);
-}
-
 #system-menu {
-    border-bottom-color: rgba(255, 255, 255, 0.3);
+    background-color: rgba(0, 0, 0, 0.6);
+    border-color: rgba(255, 255, 255, 0.3);
 }
 
 #system-menu .header {
@@ -280,22 +221,6 @@ table tr.table-button:hover {
 
 #system-menu .system-button.current {
     background-color: rgba(0, 0, 0, 0.4);
-    font-weight: bold;
-    cursor: default;
-}
-
-#system-menu-toggle {
-    --image-color: #FFFFFF;
-}
-
-#title {
-    background-color: rgba(0, 0, 0, 0.6);
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
-#title:hover {
-    background-color: rgba(0, 0, 0, 0.8);
 }
 
 .banner {

--- a/style/themes/pride.light.css
+++ b/style/themes/pride.light.css
@@ -1,5 +1,16 @@
 
 :root {
+    --navigation-bar-background: rgba(0, 0, 0, 0.2);
+    --navigation-bar-hover: rgba(0, 0, 0, 0.6);
+    --navigation-bar-foreground: #FFFFFF;
+    
+    --navigation-menu-background: rgba(0, 0, 0, 0.2);
+    --navigation-menu-foreground: #FFFFFF;
+    
+    --status-bar-background: rgba(0, 0, 0, 0.2);
+    --status-bar-hover: rgba(0, 0, 0, 0.6);
+    --status-bar-foreground: #FFFFFF;
+    
     --tooltip-background: #000000;
     
     --loading-background: rgba(0, 0, 0, 0);
@@ -110,53 +121,12 @@ table tr.table-button:hover {
 }
 
 #navigation-bar {
-    background-color: rgba(0, 0, 0, 0.2);
     --tooltip-background: #000000;
-    --image-color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon:hover {
-    background-color: rgba(0, 0, 0, 0.2);
-}
-
-#navigation-bar .navigation-icon.disabled:hover {
-    background-color: rgba(0, 0, 0, 0) !important;
-}
-
-#navigation-bar .navigation-item {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-item:hover {
-    background-color: rgba(0, 0, 0, 0.2);
-}
-
-#navigation-bar .navigation-item.disabled:hover {
-    background-color: rgba(0, 0, 0, 0) !important;
 }
 
 #navigation-menu {
-    background-color: rgba(0, 0, 0, 0.2);
     border-top: 1px solid rgba(255, 255, 255, 0.3);
     border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-}
-
-#navigation-menu .menu-button {
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
-#navigation-menu .menu-button.disabled {
-    color: #ABABAB;
-    --image-color: #ABABAB;
-}
-
-#navigation-menu-toggle .line {
-    background-color: #FFFFFF;
 }
 
 #nearby-status.loading {
@@ -180,18 +150,6 @@ table tr.table-button:hover {
 #quick-navigation .item {
     background-color: rgba(255, 255, 255, 0.6);
     border-color: rgba(0, 0, 0, 0.5);
-}
-
-#refresh-button {
-    --image-color: #FFFFFF;
-}
-
-#refresh-button:hover {
-    background-color: rgba(0, 0, 0, 0.4);
-}
-
-#refresh-button.disabled:hover {
-    background-color: rgba(0, 0, 0, 0);
 }
 
 #search {
@@ -242,31 +200,14 @@ table tr.table-button:hover {
     color: #E6E6E6;
 }
 
-#side-bar {
-    background-color: rgba(0, 0, 0, 0.2);
-    color: #FFFFFF;
-    border-right-color: rgba(255, 255, 255, 0.3);
-}
-
-#side-bar-toggle {
-    background-color: rgba(0, 0, 0, 0.4);
-    --image-color: #FFFFFF;
-}
-
-#side-bar-toggle:hover {
-    background-color: rgba(0, 0, 0, 0.6);
-}
-
-#status {
-    border-bottom-color: rgba(255, 255, 255, 0.3);
-}
-
 #system-menu {
-    border-bottom-color: rgba(255, 255, 255, 0.3);
+    background-color: rgba(0, 0, 0, 0.2);
+    border-color: rgba(255, 255, 255, 0.3);
 }
 
 #system-menu .header {
-    background-color: rgba(0, 0, 0, 0.6);
+    background-color: rgba(0, 0, 0, 0.4);
+    color: #FFFFFF;
 }
 
 #system-menu .system-button {
@@ -278,22 +219,6 @@ table tr.table-button:hover {
 }
 
 #system-menu .system-button.current {
-    background-color: rgba(0, 0, 0, 0.4);
-    font-weight: bold;
-    cursor: default;
-}
-
-#system-menu-toggle {
-    --image-color: #FFFFFF;
-}
-
-#title {
-    background-color: rgba(0, 0, 0, 0.2);
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
-#title:hover {
     background-color: rgba(0, 0, 0, 0.4);
 }
 

--- a/style/themes/pride.light.css
+++ b/style/themes/pride.light.css
@@ -200,6 +200,10 @@ table tr.table-button:hover {
     color: #E6E6E6;
 }
 
+#status-bar {
+    --tooltip-background: #000000;
+}
+
 #system-menu {
     background-color: rgba(0, 0, 0, 0.2);
     border-color: rgba(255, 255, 255, 0.3);

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -256,11 +256,12 @@ table tr.table-button:hover {
     color: #666666;
 }
 
-#status {
+#status-bar {
     background-color: #333333;
     background-image: linear-gradient(#444444, #2D2D2D);
     text-shadow: 0 -1px 1px #000000;
     border-bottom-color: #000000;
+    --tooltip-background: #444444;
 }
 
 #system:hover {

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -4,6 +4,17 @@
 */
 
 :root {
+    --navigation-bar-background: #111111;
+    --navigation-bar-hover: #444444;
+    --navigation-bar-foreground: #FFFFFF;
+    
+    --navigation-menu-background: #EEEEEE;
+    --navigation-menu-foreground: #222222;
+    
+    --status-bar-background: #333333;
+    --status-bar-hover: #444444;
+    --status-bar-foreground: #FFFFFF;
+    
     --tooltip-background: #000000;
     
     --loading-background: #FFFFFF;
@@ -115,62 +126,30 @@ table tr.table-button:hover {
 }
 
 #navigation-bar {
-    background-color: #111111;
     background-image: linear-gradient(#3C3C3C, #111111);
     text-shadow: 0 -1px 1px #000000;
     --tooltip-background: #444444;
-    --image-color: #FFFFFF;
 }
 
-#navigation-bar .navigation-icon {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon:hover {
-    background-color: #444444;
-    background-image: linear-gradient(#555555, #383838);
-}
-
-#navigation-bar .navigation-icon.disabled:hover {
-    background-color: #111111 !important;
-    background-image: linear-gradient(#3C3C3C, #111111) !important;
-}
-
-#navigation-bar .navigation-item {
-    color: #FFFFFF;
+#navigation-bar .navigation-button {
     text-shadow: none;
 }
 
-#navigation-bar .navigation-item:hover {
-    background-color: #444444;
+#navigation-bar .navigation-button:hover {
     background-image: linear-gradient(#555555, #383838);
 }
 
-#navigation-bar .navigation-item.disabled:hover {
-    background-color: #111111 !important;
-    background-image: linear-gradient(#3C3C3C, #111111) !important;
+#navigation-bar .navigation-button.disabled:hover {
+    background-image: unset;
 }
 
 #navigation-menu {
-    background-color: #EEEEEE;
-    color: #222222;
     text-shadow: 0 1px 0 #FFFFFF;
     background-image: linear-gradient(#FFFFFF, #F1F1F1);
-    --image-color: #000000;
 }
 
 #navigation-menu .menu-button {
-    color: #000000;
     text-decoration: none;
-}
-
-#navigation-menu .menu-button.disabled {
-    color: #666666;
-    --image-color: #666666;
-}
-
-#navigation-menu-toggle .line {
-    background-color: #FFFFFF;
 }
 
 #nearby-status.loading {
@@ -201,15 +180,7 @@ table tr.table-button:hover {
 }
 
 #refresh-button:hover {
-    background-color: #000000;
-}
-
-#refresh-button.disabled {
-    background-color: transparent;
-}
-
-#refresh-button {
-    --image-color: #FFFFFF;
+    background-image: linear-gradient(#555555, #383838);
 }
 
 #search {
@@ -285,31 +256,20 @@ table tr.table-button:hover {
     color: #666666;
 }
 
-#side-bar {
-    border-right-color: #000000;
-}
-
-#side-bar-toggle {
-    background-color: #EEEEEE;
-    background-image: linear-gradient(#FFFFFF, #F1F1F1);
-}
-
-#side-bar-toggle:hover {
-    background: #DFDFDF;
-    background-image: linear-gradient(#F6F6F6, #E0E0E0);
-}
-
 #status {
     background-color: #333333;
     background-image: linear-gradient(#444444, #2D2D2D);
     text-shadow: 0 -1px 1px #000000;
-    color: #FFFFFF;
     border-bottom-color: #000000;
+}
+
+#system:hover {
+    background-image: linear-gradient(#555555, #383838);
 }
 
 #system-menu {
     background-color: #EEEEEE;
-    border-bottom-color: #000000;
+    border-color: #000000;
 }
 
 #system-menu .header {
@@ -340,20 +300,7 @@ table tr.table-button:hover {
     color: #FFFFFF;
 }
 
-#system-menu-toggle {
-    --image-color: #FFFFFF;
-}
-
-#title {
-    background-color: #111111;
-    background-image: linear-gradient(#3C3C3C, #111111);
-    text-shadow: none;
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
 #title:hover {
-    background-color: #444444;
     background-image: linear-gradient(#555555, #383838);
 }
 

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -17,6 +17,17 @@
 */
 
 :root {
+    --navigation-bar-background: #C7743B;
+    --navigation-bar-hover: #7E3704;
+    --navigation-bar-foreground: #FFFFFF;
+    
+    --navigation-menu-background: #7E3704;
+    --navigation-menu-foreground: #FFFFFF;
+    
+    --status-bar-background: #DC9B41;
+    --status-bar-hover: #985C0A;
+    --status-bar-foreground: #FFFFFF;
+    
     --loading-background: #FFFBEF;
     --loading-foreground: #C7743B;
     
@@ -114,51 +125,7 @@ table tr.table-button:hover {
 }
 
 #navigation-bar {
-    background-color: #C7743B;
     --tooltip-background: #7E3704;
-    --image-color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-icon:hover {
-    background-color: #7E3704;
-}
-
-#navigation-bar .navigation-icon.disabled:hover {
-    background-color: #C7743B !important;
-}
-
-#navigation-bar .navigation-item {
-    color: #FFFFFF;
-}
-
-#navigation-bar .navigation-item:hover {
-    background-color: #7E3704;
-}
-
-#navigation-bar .navigation-item.disabled:hover {
-    background-color: #C7743B !important;
-}
-
-#navigation-menu {
-    background-color: #7E3704;
-    --image-color: #FFFFFF;
-}
-
-#navigation-menu .menu-button {
-    color: #FFFFFF;
-}
-
-#navigation-menu .menu-button.disabled {
-    color: #ABABAB;
-    --image-color: #ABABAB;
-}
-
-#navigation-menu-toggle .line {
-    background-color: #FFFFFF;
 }
 
 #nearby-status.loading {
@@ -182,18 +149,6 @@ table tr.table-button:hover {
 #quick-navigation .item {
     background-color: #E6E6E6;
     border-color: #666666;
-}
-
-#refresh-button {
-    --image-color: #FFFFFF;
-}
-
-#refresh-button:hover {
-    background-color: #985C0A;
-}
-
-#refresh-button.disabled:hover {
-    background-color: #DC9B41;
 }
 
 #search {
@@ -245,27 +200,9 @@ table tr.table-button:hover {
     color: #666666;
 }
 
-#side-bar {
-    border-right-color: #666666;
-}
-
-#side-bar-toggle {
-    background-color: #E6E6E6;
-}
-
-#side-bar-toggle:hover {
-    background-color: #CBCBCB;
-}
-
-#status {
-    background-color: #DC9B41;
-    color: #FFFFFF;
-    border-bottom-color: #666666;
-}
-
 #system-menu {
     background-color: #E6E6E6;
-    border-bottom-color: #666666;
+    border-color: #666666;
 }
 
 #system-menu .header {
@@ -283,22 +220,6 @@ table tr.table-button:hover {
 
 #system-menu .system-button.current {
     background-color: #CBCBCB;
-    font-weight: bold;
-    cursor: default;
-}
-
-#system-menu-toggle {
-    --image-color: #FFFFFF;
-}
-
-#title {
-    background-color: #C7743B;
-    color: #FFFFFF;
-    --image-color: #FFFFFF;
-}
-
-#title:hover {
-    background-color: #7E3704;
 }
 
 .banner {

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -200,6 +200,10 @@ table tr.table-button:hover {
     color: #666666;
 }
 
+#status-bar {
+    --tooltip-background: #985C0A;
+}
+
 #system-menu {
     background-color: #E6E6E6;
     border-color: #666666;

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -162,10 +162,6 @@
                 document.getElementById("search").classList.add("display-none");
             }
             
-            function toggleSystemMenu() {
-                document.getElementById("system-menu").classList.toggle("collapse-non-desktop");
-            }
-            
             String.prototype.format = function() {
                 a = this;
                 for (k in arguments) {
@@ -266,33 +262,32 @@
         </script>
     </head>
     
-    <body class="{{ 'full-map' if full_map else '' }} {{ 'side-bar-closed' if hide_systems else 'side-bar-open' }}">
-        <a id="title" href="{{ get_url(system) }}">
-            % include('components/svg', name='bctracker/bctracker')
-            <div class="side-bar-open-only">BCTracker</div>
-        </a>
+    <body class="{{ 'full-map' if full_map else '' }}">
         <div id="navigation-bar">
-            <a class="navigation-item title non-desktop" href="{{ get_url(system) }}">BCTracker</a>
+            <a id="title" href="{{ get_url(system) }}">
+                % include('components/svg', name='bctracker/bctracker')
+                <div>BCTracker</div>
+            </a>
             
-            <a class="navigation-item non-mobile" href="{{ get_url(system, 'map') }}">Map</a>
+            <a class="navigation-button non-mobile" href="{{ get_url(system, 'map') }}">Map</a>
             % if not system or system.realtime_enabled:
-                <a class="navigation-item non-mobile" href="{{ get_url(system, 'realtime') }}">Realtime</a>
-                <a class="navigation-item desktop-only" href="{{ get_url(system, 'history') }}">History</a>
+                <a class="navigation-button non-mobile" href="{{ get_url(system, 'realtime') }}">Realtime</a>
+                <a class="navigation-button desktop-only" href="{{ get_url(system, 'history') }}">History</a>
             % else:
-                <div class="navigation-item non-mobile disabled">Realtime</div>
-                <div class="navigation-item desktop-only disabled">History</div>
+                <div class="navigation-button non-mobile disabled">Realtime</div>
+                <div class="navigation-button desktop-only disabled">History</div>
             % end
             
-            <a class="navigation-item desktop-only" href="{{ get_url(system, 'routes') }}">Routes</a>
-            <a class="navigation-item desktop-only" href="{{ get_url(system, 'stops') }}">Stops</a>
-            <a class="navigation-item desktop-only" href="{{ get_url(system, 'blocks') }}">Blocks</a>
+            <a class="navigation-button desktop-only" href="{{ get_url(system, 'routes') }}">Routes</a>
+            <a class="navigation-button desktop-only" href="{{ get_url(system, 'stops') }}">Stops</a>
+            <a class="navigation-button desktop-only" href="{{ get_url(system, 'blocks') }}">Blocks</a>
             
-            <a class="navigation-item desktop-only" href="{{ get_url(system, 'about') }}">About</a>
+            <a class="navigation-button desktop-only" href="{{ get_url(system, 'about') }}">About</a>
             
             <div class="flex-1"></div>
             
             % if show_random:
-                <a class="navigation-icon desktop-only tooltip-anchor" href="{{ get_url(system, 'random') }}">
+                <a class="navigation-button compact desktop-only tooltip-anchor" href="{{ get_url(system, 'random') }}">
                     % include('components/svg', name='random')
                     <div class="tooltip left">
                         <div class="title">Random Page</div>
@@ -300,21 +295,21 @@
                 </a>
             % end
             
-            <a class="navigation-icon desktop-only tooltip-anchor" href="{{ get_url(system, 'nearby') }}">
+            <a class="navigation-button compact desktop-only tooltip-anchor" href="{{ get_url(system, 'nearby') }}">
                 % include('components/svg', name='nearby')
                 <div class="tooltip left">
                     <div class="title">Nearby Stops</div>
                 </div>
             </a>
             
-            <a class="navigation-icon desktop-only tooltip-anchor" href="{{ get_url(system, 'personalize') }}">
+            <a class="navigation-button compact desktop-only tooltip-anchor" href="{{ get_url(system, 'personalize') }}">
                 % include('components/svg', name='personalize')
                 <div class="tooltip left">
                     <div class="title">Personalize</div>
                 </div>
             </a>
             
-            <div class="navigation-icon" onclick="toggleSearch()">
+            <div class="navigation-button compact" onclick="toggleSearch()">
                 <div>
                     % include('components/svg', name='action/search')
                 </div>
@@ -382,28 +377,28 @@
                 </a>
             % end
         </div>
-        <div id="side-bar">
-            <div id="status" class="side-bar-open-only">
-                <div id="system-menu-toggle" onclick="toggleSystemMenu()">
-                    % include('components/svg', name='system')
-                </div>
-                <div class="details">
-                    <div id="system">
-                        % if system:
-                            {{ system }}
-                        % else:
-                            All Transit Systems
-                        % end
-                    </div>
-                    % if last_updated:
-                        <div id="last-updated">Updated {{ last_updated.format_web(time_format) }}</div>
+        <div id="status-bar">
+            <div id="system-menu-toggle" onclick="toggleSystemMenuMobile()">
+                % include('components/svg', name='system')
+            </div>
+            <div class="details">
+                <div id="system" onclick="toggleSystemMenuDesktop()">
+                    % if system:
+                        {{ system }}
+                    % else:
+                        All Transit Systems
                     % end
                 </div>
-                <div id="refresh-button" class="disabled">
-                    % include('components/svg', name='action/refresh')
-                </div>
+                % if last_updated:
+                    <div id="last-updated">Updated {{ last_updated.format_web(time_format) }}</div>
+                % end
             </div>
-            <div id="system-menu" class="collapse-non-desktop side-bar-open-only">
+            <div id="refresh-button" class="disabled">
+                % include('components/svg', name='action/refresh')
+            </div>
+        </div>
+        <div id="content">
+            <div id="system-menu" class="collapse-non-desktop {{ 'collapse-desktop' if hide_systems else '' }}">
                 % if system:
                     <a href="{{ get_url(None, *path, **path_args) }}" class="system-button all-systems">All Transit Systems</a>
                 % else:
@@ -429,115 +424,103 @@
                     % end
                 % end
             </div>
-            <div class="flex-1 side-bar-closed-only"></div>
-            <div id="side-bar-toggle-container">
-                <div id="side-bar-toggle" onclick="toggleSideBar()">
-                    <div class="side-bar-open-only">
-                        % include('components/svg', name='paging/left-double')
-                    </div>
-                    <div class="side-bar-closed-only">
-                        % include('components/svg', name='paging/right-double')
-                    </div>
-                </div>
-                <div class="side-bar-open-only">Hide Systems</div>
-            </div>
-        </div>
-        <div id="main">
-            <div id="banners">
-                % if system is not None and system.id == 'cowichan-valley':
-                    <div class="banner">
-                        <div class="content">
-                            <h1>Due to ongoing job action, service in the Cowichan Valley area is currently suspended.</h1>
-                            <p>For more information and updates please visit the <a target="_blank" href="https://www.bctransit.com/cowichan-valley/news">BC Transit News Page</a>.</p>
+            <div id="main">
+                <div id="banners">
+                    % if system is not None and system.id == 'cowichan-valley':
+                        <div class="banner">
+                            <div class="content">
+                                <h1>Due to ongoing job action, service in the Cowichan Valley area is currently suspended.</h1>
+                                <p>For more information and updates please visit the <a target="_blank" href="https://www.bctransit.com/cowichan-valley/news">BC Transit News Page</a>.</p>
+                            </div>
                         </div>
-                    </div>
-                % end
-            </div>
-            % if full_map:
-                <div id="map" class="full-screen"></div>
-                <script>
-                    const map = new ol.Map({
-                        target: 'map',
-                        controls: ol.control.defaults.defaults({
-                            zoom: false,
-                            rotate: false
-                        }),
-                        layers: [
-                            new ol.layer.Tile({
-                                source: new ol.source.OSM(),
-                                className: "ol-layer tile-layer"
-                            })
-                        ],
-                        view: new ol.View({
-                            center: [0, 0],
-                            zoom: 3,
-                            maxZoom: 22,
-                            minZoom: 3
-                        }),
-                        interactions: ol.interaction.defaults.defaults().extend([
-                            new ol.interaction.DblClickDragZoom()
-                        ])
-                    });
-                    map.getViewport().style.cursor = "grab";
-                    map.on('pointerdrag', function(event) {
-                        map.getViewport().style.cursor = "grabbing";
-                    });
-                    map.on('pointerup', function(event) {
+                    % end
+                </div>
+                % if full_map:
+                    <div id="map" class="full-screen"></div>
+                    <script>
+                        const map = new ol.Map({
+                            target: 'map',
+                            controls: ol.control.defaults.defaults({
+                                zoom: false,
+                                rotate: false
+                            }),
+                            layers: [
+                                new ol.layer.Tile({
+                                    source: new ol.source.OSM(),
+                                    className: "ol-layer tile-layer"
+                                })
+                            ],
+                            view: new ol.View({
+                                center: [0, 0],
+                                zoom: 3,
+                                maxZoom: 22,
+                                minZoom: 3
+                            }),
+                            interactions: ol.interaction.defaults.defaults().extend([
+                                new ol.interaction.DblClickDragZoom()
+                            ])
+                        });
                         map.getViewport().style.cursor = "grab";
-                    });
-                </script>
-                
-                % include('components/loading')
-                % include('components/map_controls')
-            % end
-            <div id="page">{{ !base }}</div>
-        </div>
-        <div id="search" class="display-none" tabindex="0">
-            <div id="search-header">
-                <div id="search-bar">
-                    <input type="text" id="search-input" placeholder="Search" oninput="searchInputChanged()">
-                </div>
-                % if system:
-                    <div id="search-filters">
-                        <div class="flex-1">Filters:</div>
-                        <div id="search-filter-bus" class="button tooltip-anchor" onclick="toggleSearchBusFilter()">
-                            % include('components/svg', name='bus')
-                            <div class="tooltip left">Include Buses</div>
-                        </div>
-                        <div id="search-filter-route" class="button tooltip-anchor" onclick="toggleSearchRouteFilter()">
-                            % include('components/svg', name='route')
-                            <div class="tooltip left">Include Routes</div>
-                        </div>
-                        <div id="search-filter-stop" class="button tooltip-anchor" onclick="toggleSearchStopFilter()">
-                            % include('components/svg', name='stop')
-                            <div class="tooltip left">Include Stops</div>
-                        </div>
-                        <div id="search-filter-block" class="button tooltip-anchor" onclick="toggleSearchBlockFilter()">
-                            % include('components/svg', name='block')
-                            <div class="tooltip left">Include Blocks</div>
-                        </div>
+                        map.on('pointerdrag', function(event) {
+                            map.getViewport().style.cursor = "grabbing";
+                        });
+                        map.on('pointerup', function(event) {
+                            map.getViewport().style.cursor = "grab";
+                        });
+                    </script>
+                    
+                    % include('components/loading')
+                    % include('components/map_controls')
+                % end
+                <div id="page">{{ !base }}</div>
+            </div>
+            <div id="search" class="display-none" tabindex="0">
+                <div id="search-header">
+                    <div id="search-bar">
+                        <input type="text" id="search-input" placeholder="Search" oninput="searchInputChanged()">
                     </div>
-                % end
-            </div>
-            <div id="search-placeholder">
-                % if system:
-                    Search for {{ system }} buses, routes, stops, and blocks
-                % else:
-                    Search for buses in all systems
-                % end
-            </div>
-            <div id="search-results" class="display-none">
-                
-            </div>
-            <div id="search-paging" class="display-none">
-                <div id="search-paging-previous" class="icon button" onclick="searchPreviousPage()">
-                    % include('components/svg', name='paging/left')
+                    % if system:
+                        <div id="search-filters">
+                            <div class="flex-1">Filters:</div>
+                            <div id="search-filter-bus" class="button tooltip-anchor" onclick="toggleSearchBusFilter()">
+                                % include('components/svg', name='bus')
+                                <div class="tooltip left">Include Buses</div>
+                            </div>
+                            <div id="search-filter-route" class="button tooltip-anchor" onclick="toggleSearchRouteFilter()">
+                                % include('components/svg', name='route')
+                                <div class="tooltip left">Include Routes</div>
+                            </div>
+                            <div id="search-filter-stop" class="button tooltip-anchor" onclick="toggleSearchStopFilter()">
+                                % include('components/svg', name='stop')
+                                <div class="tooltip left">Include Stops</div>
+                            </div>
+                            <div id="search-filter-block" class="button tooltip-anchor" onclick="toggleSearchBlockFilter()">
+                                % include('components/svg', name='block')
+                                <div class="tooltip left">Include Blocks</div>
+                            </div>
+                        </div>
+                    % end
                 </div>
-                <div id="search-count" class="flex-1">
+                <div id="search-placeholder">
+                    % if system:
+                        Search for {{ system }} buses, routes, stops, and blocks
+                    % else:
+                        Search for buses in all systems
+                    % end
+                </div>
+                <div id="search-results" class="display-none">
                     
                 </div>
-                <div id="search-paging-next" class="icon button" onclick="searchNextPage()">
-                    % include('components/svg', name='paging/right')
+                <div id="search-paging" class="display-none">
+                    <div id="search-paging-previous" class="icon button" onclick="searchPreviousPage()">
+                        % include('components/svg', name='paging/left')
+                    </div>
+                    <div id="search-count" class="flex-1">
+                        
+                    </div>
+                    <div id="search-paging-next" class="icon button" onclick="searchNextPage()">
+                        % include('components/svg', name='paging/right')
+                    </div>
                 </div>
             </div>
         </div>
@@ -853,14 +836,17 @@
         search();
     }
     
-    function toggleSideBar() {
-        const element = document.getElementsByTagName("body")[0];
-        element.classList.toggle("side-bar-open");
-        element.classList.toggle("side-bar-closed");
-        if (element.classList.contains("side-bar-open")) {
-            setCookie("hide_systems", "no");
-        } else {
+    function toggleSystemMenuMobile() {
+        document.getElementById("system-menu").classList.toggle("collapse-non-desktop");
+    }
+    
+    function toggleSystemMenuDesktop() {
+        const element = document.getElementById("system-menu");
+        element.classList.toggle("collapse-desktop");
+        if (element.classList.contains("collapse-desktop")) {
             setCookie("hide_systems", "yes");
+        } else {
+            setCookie("hide_systems", "no");
         }
         if ("map" in window) {
             map.updateSize();

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -115,6 +115,7 @@
                 setTimeout(function() {
                     const element = document.getElementById("refresh-button")
                     element.classList.remove("disabled");
+                    element.innerHTML += "<div class='tooltip right'>Refresh Page</div>";
                     element.onclick = refresh
                 }, 1000 * (timeToNextUpdate + 15));
                 
@@ -382,18 +383,19 @@
                 % include('components/svg', name='system')
             </div>
             <div class="details">
-                <div id="system" onclick="toggleSystemMenuDesktop()">
+                <div id="system" class="tooltip-anchor" onclick="toggleSystemMenuDesktop()">
                     % if system:
                         {{ system }}
                     % else:
                         All Transit Systems
                     % end
+                    <div class="tooltip right">Toggle Systems List</div>
                 </div>
                 % if last_updated:
                     <div id="last-updated">Updated {{ last_updated.format_web(time_format) }}</div>
                 % end
             </div>
-            <div id="refresh-button" class="disabled">
+            <div id="refresh-button" class="disabled tooltip-anchor">
                 % include('components/svg', name='action/refresh')
             </div>
         </div>


### PR DESCRIPTION
- Status bar is now the full page width on desktop instead of just in the sidebar
- Clicking on the system in the status bar will now toggle the systems list open and closed
  - For new users or anyone who hasn't toggled the side bar it will now default to closed, for anyone who has toggled it before it'll remain in that state
- No changes overall to site behaviour, but UI is now better overall
  - System/last updated time are no longer hidden when the sidebar is closed
  - Overall sidebar width is reduced, leaving more space for main content
- Behaviour on tablet/mobile is unchanged, though some spacing and sizing may be slightly different
  - Tablet/mobile also now shows the BCTracker icon next to the title in the nabber
- Lots of general improvements and simplifications to CSS

<img width="1728" alt="Screenshot 2025-04-19 at 23 01 36" src="https://github.com/user-attachments/assets/bd4f04ea-db14-48c7-881e-04a0520768b9" />
<img width="1728" alt="Screenshot 2025-04-19 at 23 01 50" src="https://github.com/user-attachments/assets/5f16d897-3ff6-4735-9476-1fc31339693d" />

Potential future directions:
- Add icon to systems menu toggle if it needs to be clearer to users how to use it
- Add more functionality to the remaining real estate of the status bar on desktop
  - Potential options include showing favourites, alerts about the website, or alerts from BC Transit
  - Would need to consider implications for mobile
