### PR TITLE
Add support for trip custom headsigns

### DIFF
--- a/database.py
+++ b/database.py
@@ -113,6 +113,7 @@ SQL_SCRIPTS = [
             dropoff_type TEXT NOT NULL,
             timepoint INTEGER NOT NULL,
             distance REAL,
+            headsign TEXT,
             PRIMARY KEY (system_id, trip_id, sequence),
             FOREIGN KEY (system_id, trip_id) REFERENCES trip (system_id, trip_id),
             FOREIGN KEY (system_id, stop_id) REFERENCES stop (system_id, stop_id)

--- a/models/departure.py
+++ b/models/departure.py
@@ -64,7 +64,8 @@ class Departure:
         'pickup_type',
         'dropoff_type',
         'timepoint',
-        'distance'
+        'distance',
+        'headsign'
     )
     
     @classmethod
@@ -86,7 +87,8 @@ class Departure:
             dropoff_type = DropoffType.NORMAL
         timepoint = row[f'{prefix}_timepoint'] == 1
         distance = row[f'{prefix}_distance']
-        return cls(system, trip_id, sequence, stop_id, time, pickup_type, dropoff_type, timepoint, distance)
+        headsign = row[f'{prefix}_headsign']
+        return cls(system, trip_id, sequence, stop_id, time, pickup_type, dropoff_type, timepoint, distance, headsign)
     
     @property
     def stop(self):
@@ -112,7 +114,7 @@ class Departure:
             return self.trip and self == self.trip.last_departure
         return False
     
-    def __init__(self, system, trip_id, sequence, stop_id, time, pickup_type, dropoff_type, timepoint, distance, **kwargs):
+    def __init__(self, system, trip_id, sequence, stop_id, time, pickup_type, dropoff_type, timepoint, distance, headsign, **kwargs):
         self.system = system
         self.trip_id = trip_id
         self.sequence = sequence
@@ -122,8 +124,16 @@ class Departure:
         self.dropoff_type = dropoff_type
         self.timepoint = timepoint
         self.distance = distance
+        self.headsign = headsign
         
         self.departure_repository = kwargs.get('departure_repository') or di[DepartureRepository]
+    
+    def __str__(self):
+        if self.headsign:
+            if self.system.agency.prefix_headsigns and self.trip.route:
+                return f'{self.trip.route.number} {self.headsign}'
+            return self.headsign
+        return str(self.trip)
     
     def __eq__(self, other):
         return self.trip_id == other.trip_id and self.sequence == other.sequence

--- a/models/position.py
+++ b/models/position.py
@@ -109,6 +109,11 @@ class Position:
             return trip.route.text_colour
         return 'FFFFFF'
     
+    @property
+    def departure(self):
+        '''Returns the departure associated with this position'''
+        return self.departure_repository.find(self.system, self.trip_id, self.sequence)
+    
     def __init__(self, system, bus, trip_id, stop_id, block_id, route_id, sequence, lat, lon, bearing, speed, adherence, occupancy, timestamp, **kwargs):
         self.system = system
         self.bus = bus
@@ -164,7 +169,11 @@ class Position:
             data['adornment'] = str(adornment)
         trip = self.trip
         if trip:
-            data['headsign'] = str(trip).replace("'", '&apos;')
+            departure = self.departure
+            if departure and departure.headsign:
+                data['headsign'] = str(departure).replace("'", '&apos;')
+            else:
+                data['headsign'] = str(trip).replace("'", '&apos;')
             data['route_number'] = trip.route.number
             data['system_id'] = trip.system.id
             data['shape_id'] = trip.shape_id

--- a/models/route.py
+++ b/models/route.py
@@ -145,7 +145,12 @@ class Route:
     
     def get_headsigns(self, service_group=None, date=None):
         '''Returns all headsigns from this route'''
-        return sorted({str(t) for t in self.get_trips(service_group, date)})
+        headsigns = set()
+        for trip in self.get_trips(service_group, date):
+            headsigns.add(str(trip))
+            for headsign in trip.custom_headsigns:
+                headsigns.add(headsign)
+        return sorted(headsigns)
     
     def get_match(self, query):
         '''Returns a match for this route with the given query'''

--- a/models/trip.py
+++ b/models/trip.py
@@ -142,6 +142,11 @@ class Trip:
         '''Returns the direction for this trip'''
         return self.cache.direction
     
+    @property
+    def custom_headsigns(self):
+        '''Returns the custom headsigns for this trip'''
+        return self.cache.custom_headsigns
+    
     def __init__(self, system, trip_id, route_id, service_id, block_id, direction_id, shape_id, headsign, **kwargs):
         self.system = system
         self.id = trip_id
@@ -221,7 +226,8 @@ class TripCache:
         'first_departure',
         'last_departure',
         'departure_count',
-        'direction'
+        'direction',
+        'custom_headsigns'
     )
     
     def __init__(self, departures):
@@ -230,8 +236,16 @@ class TripCache:
             self.last_departure = departures[-1]
             self.departure_count = len(departures)
             self.direction = Direction.calculate(departures[0].stop, departures[-1].stop)
+            headsigns = [str(d) for d in departures if d.headsign]
+            previous_headsign = None
+            self.custom_headsigns = []
+            for headsign in headsigns:
+                if headsign != previous_headsign:
+                    self.custom_headsigns.append(headsign)
+                previous_headsign = headsign
         else:
             self.first_departure = None
             self.last_departure = None
             self.departure_count = 0
             self.direction = Direction.UNKNOWN
+            self.custom_headsigns = []

--- a/repositories/sql/departure.py
+++ b/repositories/sql/departure.py
@@ -33,6 +33,10 @@ class SQLDepartureRepository(DepartureRepository):
             distance = int(row['shape_dist_traveled'])
         except (KeyError, ValueError):
             distance = None
+        try:
+            headsign = row['stop_headsign']
+        except KeyError:
+            headsign = None
         self.database.insert('departure', {
             'system_id': system_id,
             'trip_id': row['trip_id'],
@@ -42,7 +46,8 @@ class SQLDepartureRepository(DepartureRepository):
             'pickup_type': pickup_type.value,
             'dropoff_type': dropoff_type.value,
             'timepoint': 1 if timepoint else 0,
-            'distance': distance
+            'distance': distance,
+            'headsign': headsign
         })
     
     def find(self, system, trip=None, sequence=None, stop=None):
@@ -85,7 +90,8 @@ class SQLDepartureRepository(DepartureRepository):
                 'departure.pickup_type': 'departure_pickup_type',
                 'departure.dropoff_type': 'departure_dropoff_type',
                 'departure.timepoint': 'departure_timepoint',
-                'departure.distance': 'departure_distance'
+                'departure.distance': 'departure_distance',
+                'departure.headsign': 'departure_headsign'
             },
             joins=joins,
             filters={
@@ -115,7 +121,8 @@ class SQLDepartureRepository(DepartureRepository):
                 'departure.pickup_type': 'departure_pickup_type',
                 'departure.dropoff_type': 'departure_dropoff_type',
                 'departure.timepoint': 'departure_timepoint',
-                'departure.distance': 'departure_distance'
+                'departure.distance': 'departure_distance',
+                'departure.headsign': 'departure_headsign'
             },
             filters={
                 'departure.system_id': system_id,
@@ -155,7 +162,8 @@ class SQLDepartureRepository(DepartureRepository):
                 'departure.pickup_type': 'departure_pickup_type',
                 'departure.dropoff_type': 'departure_dropoff_type',
                 'departure.timepoint': 'departure_timepoint',
-                'departure.distance': 'departure_distance'
+                'departure.distance': 'departure_distance',
+                'departure.headsign': 'departure_headsign'
             },
             ctes={
                 'stop_trip': cte

--- a/style/dark.css
+++ b/style/dark.css
@@ -27,6 +27,10 @@
     --adherence-background: #FF6A00;
 }
 
+.custom-headsigns {
+    --image-color: #ABABAB;
+}
+
 .marker .bearing {
     filter: brightness(80%);
 }

--- a/style/light.css
+++ b/style/light.css
@@ -19,6 +19,10 @@
     --adherence-background: #FF9A3A;
 }
 
+.custom-headsigns {
+    --image-color: #666666;
+}
+
 .modified-service {
     background-color: #FFA560;
     color: #000000;

--- a/style/main.css
+++ b/style/main.css
@@ -74,6 +74,10 @@ h1 .stop .stop-number {
     font-size: 20pt;
 }
 
+h2 .custom-headsigns {
+    --image-size: 24px;
+}
+
 h2 .route {
     font-size: 16pt;
     min-width: 16px;
@@ -688,6 +692,15 @@ table tr.table-button {
 .container > .section.closed > .header > .toggle {
     -webkit-transform: scaleY(-1);
     transform: scaleY(-1);
+}
+
+.custom-headsigns div {
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.custom-headsigns svg {
+    vertical-align: middle;
 }
 
 .display-none {

--- a/utilities/migrate-departure-headsign.py
+++ b/utilities/migrate-departure-headsign.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+import sys
+import os
+
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+
+from database import Database
+
+database = Database()
+database.connect()
+database.execute('ALTER TABLE departure ADD headsign TEXT')
+database.commit()
+database.disconnect()

--- a/views/components/custom_headsigns.tpl
+++ b/views/components/custom_headsigns.tpl
@@ -1,0 +1,18 @@
+<div class="custom-headsigns">
+    <div>{{ custom_headsigns[0] }}</div>
+    % if len(custom_headsigns) > 2:
+        % include('components/svg', name='paging/right')
+        <div class="tooltip-anchor lighter-text">
+            ...
+            <div class="tooltip right">
+                % for headsign in custom_headsigns[1:-1]:
+                    <div>{{ headsign }}</div>
+                % end
+            </div>
+        </div>
+    % end
+    % if len(custom_headsigns) > 1:
+        % include('components/svg', name='paging/right')
+        <div>{{ custom_headsigns[-1] }}</div>
+    % end
+</div>

--- a/views/components/headsign.tpl
+++ b/views/components/headsign.tpl
@@ -1,6 +1,22 @@
-% if trip and trip.route:
+% if get('departure') and departure.headsign:
     <div class="headsign">
-        <div class="route-line" style="background-color: #{{ trip.route.colour }}"></div>
-        <div>{{ trip }}</div>
+        <div class="route-line" style="background-color: #{{ departure.trip.route.colour }}"></div>
+        <div>{{ departure }}</div>
     </div>
+% elif trip and trip.route:
+    % if trip.custom_headsigns:
+        <div class="column">
+            % for headsign in trip.custom_headsigns:
+                <div class="headsign">
+                    <div class="route-line" style="background-color: #{{ trip.route.colour }}"></div>
+                    <div>{{ headsign }}</div>
+                </div>
+            % end
+        </div>
+    % else:
+        <div class="headsign">
+            <div class="route-line" style="background-color: #{{ trip.route.colour }}"></div>
+            <div>{{ trip }}</div>
+        </div>
+    % end
 % end

--- a/views/pages/block/overview.tpl
+++ b/views/pages/block/overview.tpl
@@ -214,7 +214,7 @@
                                     </td>
                                     <td>
                                         <div class="column">
-                                            % include('components/headsign')
+                                            % include('components/headsign', departure=position.departure)
                                             <div class="mobile-only smaller-font">
                                                 Trip:
                                                 % include('components/trip', include_tooltip=False)
@@ -280,7 +280,7 @@
                                     % stop = position.stop
                                     <td>
                                         <div class="column">
-                                            % include('components/headsign', trip=position.trip)
+                                            % include('components/headsign', departure=position.departure, trip=position.trip)
                                             <div class="non-desktop smaller-font">
                                                 Trip:
                                                 % include('components/trip', include_tooltip=False, trip=position.trip)

--- a/views/pages/bus/overview.tpl
+++ b/views/pages/bus/overview.tpl
@@ -136,7 +136,12 @@
                         <div class="section">
                             <div class="row">
                                 % include('components/adherence', adherence=position.adherence, size='large')
-                                <h3>{{ trip }}</h3>
+                                % departure = position.departure
+                                % if departure and departure.headsign:
+                                    <h3>{{ departure }}</h3>
+                                % else:
+                                    <h3>{{ trip }}</h3>
+                                % end
                             </div>
                         </div>
                         <div class="section">

--- a/views/pages/home.tpl
+++ b/views/pages/home.tpl
@@ -159,7 +159,7 @@
                                                         </td>
                                                         <td>
                                                             % if position and position.trip:
-                                                                % include('components/headsign', trip=position.trip)
+                                                                % include('components/headsign', departure=position.departure, trip=position.trip)
                                                             % else:
                                                                 <div class="lighter-text">Not in service</div>
                                                             % end

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -99,7 +99,7 @@
                                     % stop = position.stop
                                     <td>
                                         <div class="column">
-                                            % include('components/headsign')
+                                            % include('components/headsign', departure=position.departure)
                                             <div class="mobile-only smaller-font">
                                                 Trip:
                                                 % include('components/trip', include_tooltip=False)

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -73,7 +73,7 @@
                         % stop = position.stop
                         <td>
                             <div class="column">
-                                % include('components/headsign')
+                                % include('components/headsign', departure=position.departure)
                                 <span class="non-desktop smaller-font no-wrap">{{ position.speed }} km/h</span>
                                 <div class="mobile-only smaller-font">
                                     Trip:

--- a/views/pages/route/overview.tpl
+++ b/views/pages/route/overview.tpl
@@ -99,7 +99,7 @@
                                     </td>
                                     <td>
                                         <div class="column">
-                                            % include('components/headsign')
+                                            % include('components/headsign', departure=position.departure)
                                             <div class="mobile-only smaller-font">
                                                 Trip:
                                                 % include('components/trip', include_tooltip=False)

--- a/views/pages/trip/history.tpl
+++ b/views/pages/trip/history.tpl
@@ -3,7 +3,13 @@
 
 <div id="page-header">
     <h1>Trip {{! trip.display_id }}</h1>
-    <h2>{{ trip }}</h2>
+    <h2>
+        % if trip.custom_headsigns:
+            % include('components/custom_headsigns', custom_headsigns=trip.custom_headsigns)
+        % else:
+            {{ trip }}
+        % end
+    </h2>
     <div class="tab-button-bar">
         <a href="{{ get_url(system, 'trips', trip) }}" class="tab-button">Overview</a>
         <a href="{{ get_url(system, 'trips', trip, 'map') }}" class="tab-button">Map</a>

--- a/views/pages/trip/map.tpl
+++ b/views/pages/trip/map.tpl
@@ -3,7 +3,7 @@
 
 <div id="page-header">
     <h1>Trip {{! trip.display_id }}</h1>
-    <h2 class="headsigns">
+    <h2>
         % if trip.custom_headsigns:
             % include('components/custom_headsigns', custom_headsigns=trip.custom_headsigns)
         % else:

--- a/views/pages/trip/map.tpl
+++ b/views/pages/trip/map.tpl
@@ -3,7 +3,13 @@
 
 <div id="page-header">
     <h1>Trip {{! trip.display_id }}</h1>
-    <h2>{{ trip }}</h2>
+    <h2 class="headsigns">
+        % if trip.custom_headsigns:
+            % include('components/custom_headsigns', custom_headsigns=trip.custom_headsigns)
+        % else:
+            {{ trip }}
+        % end
+    </h2>
     <div class="tab-button-bar">
         <a href="{{ get_url(system, 'trips', trip) }}" class="tab-button">Overview</a>
         <span class="tab-button current">Map</span>

--- a/views/pages/trip/overview.tpl
+++ b/views/pages/trip/overview.tpl
@@ -5,7 +5,13 @@
 
 <div id="page-header">
     <h1>Trip {{! trip.display_id }}</h1>
-    <h2>{{ trip }}</h2>
+    <h2>
+        % if trip.custom_headsigns:
+            % include('components/custom_headsigns', custom_headsigns=trip.custom_headsigns)
+        % else:
+            {{ trip }}
+        % end
+    </h2>
     <div class="tab-button-bar">
         <span class="tab-button current">Overview</span>
         <a href="{{ get_url(system, 'trips', trip, 'map') }}" class="tab-button">Map</a>
@@ -246,7 +252,7 @@
                                     % stop = position.stop
                                     <td>
                                         <div class="column">
-                                            % include('components/headsign', trip=position.trip)
+                                            % include('components/headsign', departure=position.departure, trip=position.trip)
                                             <div class="non-desktop smaller-font">
                                                 Trip:
                                                 % include('components/trip', include_tooltip=False, trip=position.trip)
@@ -284,6 +290,7 @@
                 % if [d for d in departures if d.timepoint]:
                     <p>Departures in <span class="timing-point">bold</span> are timing points.</p>
                 % end
+                % last_headsign = None
                 <table>
                     <thead>
                         <tr>
@@ -294,6 +301,15 @@
                     <tbody>
                         % for departure in departures:
                             % stop = departure.stop
+                            % if trip.custom_headsigns:
+                                % if departure.headsign != last_headsign:
+                                    <tr class="header">
+                                        <td colspan="2">{{ departure }}</td>
+                                    </tr>
+                                    <tr class="display-none"></tr>
+                                % end
+                                % last_headsign = departure.headsign
+                            % end
                             <tr>
                                 <td class="{{ 'timing-point' if departure.timepoint else '' }}">
                                     {{ departure.time.format_web(time_format) }}

--- a/views/rows/realtime.tpl
+++ b/views/rows/realtime.tpl
@@ -25,7 +25,7 @@
         % stop = position.stop
         <td>
             <div class="column">
-                % include('components/headsign')
+                % include('components/headsign', departure=position.departure)
                 <div class="mobile-only smaller-font">
                     Trip:
                     % include('components/trip', include_tooltip=False)


### PR DESCRIPTION
- Departure model and table now have optional `headsign` property
- Position model now has optional `departure` property
- Updated `headsign` view template
  - If a departure is provided which has a custom headsign, shows that headsign
  - Otherwise, if the trip has multiple custom headsigns, shows all of those headsigns vertically
  - Otherwise, shows the main trip headsign as normal
- Added `custom_headsigns` view template
  - Always shows the first and last custom headsigns
  - If more headsigns are available, shows ... with a tooltip to view the hidden headsigns
- Headsign view templates used for realtime positions now receive the position's current departure to prioritize showing that specific headsign
- Headsign view templates used in stop page departure lists now receive the departure to prioritize showing that specific headsign
- Trip page departures list now shows custom headsigns as a header row within the table, if there are custom headsigns available
- Route page headsigns list now shows all custom headsigns

<img width="1414" alt="Screenshot 2025-05-05 at 23 19 22" src="https://github.com/user-attachments/assets/2d117a46-fcdb-4e3e-bf3d-924a0e3d767f" />
<img width="958" alt="Screenshot 2025-05-05 at 23 19 49" src="https://github.com/user-attachments/assets/6fad750a-678d-4894-8f9a-0bc54aae35fd" />
<img width="835" alt="Screenshot 2025-05-05 at 23 20 09" src="https://github.com/user-attachments/assets/dc48ffac-0422-4a64-8480-5ba45e678ad3" />
<img width="942" alt="Screenshot 2025-05-05 at 23 21 42" src="https://github.com/user-attachments/assets/aa74d3d7-0a7a-4f43-a706-883159c2d1e6" />


**NOTE: The departure headsign migration must be run before deploying**