### PR TITLE
Convert models to dataclasses

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,3 +1,6 @@
+
+import pytz
+
 # Agency config
 DEFAULT_PREFIX_HEADSIGNS = False
 DEFAULT_ACCURATE_SECONDS = True
@@ -6,3 +9,6 @@ DEFAULT_PREFER_STOP_ID = False
 DEFAULT_SHOW_STOP_NUMBER = True
 DEFAULT_VEHICLE_NAME_LENGTH = None
 DEFAULT_DISTANCE_SCALE = 1
+
+# Date/time config
+DEFAULT_TIMEZONE = pytz.timezone('America/Vancouver')

--- a/database.py
+++ b/database.py
@@ -1,6 +1,7 @@
 
 import sqlite3
 import shutil
+from dataclasses import dataclass, field
 
 SQL_SCRIPTS = [
     '''
@@ -145,16 +146,11 @@ SQL_SCRIPTS = [
     'CREATE INDEX IF NOT EXISTS departure_stop_id ON departure (stop_id)'
 ]
 
+@dataclass(slots=True)
 class Database:
     
-    __slots__ = (
-        'name',
-        'connection'
-    )
-    
-    def __init__(self, name='bctracker'):
-        self.name = name
-        self.connection = None
+    name: str = 'bctracker'
+    connection: sqlite3.Connection | None = field(default=None, init=False)
     
     def connect(self, foreign_keys=True):
         '''Opens a connection to the database and runs setup scripts'''

--- a/models/adherence.py
+++ b/models/adherence.py
@@ -1,5 +1,6 @@
 
 import math
+from dataclasses import dataclass, field
 
 from di import di
 
@@ -9,15 +10,15 @@ from repositories import DepartureRepository
 
 MINIMUM_MINUTES = 4
 
+@dataclass(slots=True)
 class Adherence:
     '''Indicates how far ahead or behind a bus is compared to its trip's schedule'''
     
-    __slots__ = (
-        'value',
-        'layover',
-        'status_class',
-        'description'
-    )
+    value: int
+    layover: bool
+    
+    status_class: str = field(init=False)
+    description: str = field(init=False)
     
     @classmethod
     def calculate(cls, trip, stop, sequence, lat, lon, timestamp, **kwargs):
@@ -45,9 +46,9 @@ class Adherence:
         except AttributeError:
             return None
     
-    def __init__(self, value, layover):
-        self.value = value
-        self.layover = layover
+    def __post_init__(self):
+        value = self.value
+        layover = self.layover
         
         if layover:
             self.status_class = 'layover'

--- a/models/adornment.py
+++ b/models/adornment.py
@@ -1,21 +1,15 @@
 
+from dataclasses import dataclass
+
+@dataclass(slots=True)
 class Adornment:
     '''Text placed after a bus number'''
     
-    __slots__ = (
-        'agency_id',
-        'bus_number',
-        'text',
-        'description',
-        'enabled'
-    )
-    
-    def __init__(self, agency_id, bus_number, text, **kwargs):
-        self.agency_id = agency_id
-        self.bus_number = bus_number
-        self.text = text
-        self.description = kwargs.get('description')
-        self.enabled = kwargs.get('enabled', True)
+    agency_id: str
+    bus_number: int
+    text: str
+    description: str | None = None
+    enabled: bool = True
     
     def __str__(self):
         return self.text

--- a/models/agency.py
+++ b/models/agency.py
@@ -1,24 +1,26 @@
 
+from dataclasses import dataclass
+
 from constants import *
 
+@dataclass(slots=True)
 class Agency:
     '''A company or entity that runs transit'''
     
-    __slots__ = (
-        'id',
-        'name',
-        'website',
-        'gtfs_url',
-        'realtime_url',
-        'enabled',
-        'prefix_headsigns',
-        'accurate_seconds',
-        'prefer_route_id',
-        'prefer_stop_id',
-        'show_stop_number',
-        'vehicle_name_length',
-        'distance_scale'
-    )
+    id: str
+    name: str
+    
+    website: str | None = None
+    gtfs_url: str | None = None
+    realtime_url: str | None = None
+    enabled: bool = True
+    prefix_headsigns: bool = DEFAULT_PREFIX_HEADSIGNS
+    accurate_seconds: bool = DEFAULT_ACCURATE_SECONDS
+    prefer_route_id: bool = DEFAULT_PREFER_ROUTE_ID
+    prefer_stop_id: bool = DEFAULT_PREFER_STOP_ID
+    show_stop_number: bool = DEFAULT_SHOW_STOP_NUMBER
+    vehicle_name_length: int | None = DEFAULT_VEHICLE_NAME_LENGTH
+    distance_scale: int = DEFAULT_DISTANCE_SCALE
     
     @property
     def gtfs_enabled(self):
@@ -29,21 +31,6 @@ class Agency:
     def realtime_enabled(self):
         '''Checks if realtime is enabled for this agency'''
         return self.enabled and self.realtime_url
-    
-    def __init__(self, id, name, **kwargs):
-        self.id = id
-        self.name = name
-        self.website = kwargs.get('website')
-        self.gtfs_url = kwargs.get('gtfs_url')
-        self.realtime_url = kwargs.get('realtime_url')
-        self.enabled = kwargs.get('enabled', True)
-        self.prefix_headsigns = kwargs.get('prefix_headsigns', DEFAULT_PREFIX_HEADSIGNS)
-        self.accurate_seconds = kwargs.get('accurate_seconds', DEFAULT_ACCURATE_SECONDS)
-        self.prefer_route_id = kwargs.get('prefer_route_id', DEFAULT_PREFER_ROUTE_ID)
-        self.prefer_stop_id = kwargs.get('prefer_stop_id', DEFAULT_PREFER_STOP_ID)
-        self.show_stop_number = kwargs.get('show_stop_number', DEFAULT_SHOW_STOP_NUMBER)
-        self.vehicle_name_length = kwargs.get('vehicle_name_length', DEFAULT_VEHICLE_NAME_LENGTH)
-        self.distance_scale = kwargs.get('distance_scale', DEFAULT_DISTANCE_SCALE)
     
     def __str__(self):
         return self.name

--- a/models/area.py
+++ b/models/area.py
@@ -1,13 +1,14 @@
 
+from dataclasses import dataclass
+
+@dataclass(slots=True)
 class Area:
     '''A geographic area defined by min/max latitudes and longitudes'''
     
-    __slots__ = (
-        'min_lat',
-        'max_lat',
-        'min_lon',
-        'max_lon'
-    )
+    min_lat: float
+    max_lat: float
+    min_lon: float
+    max_lon: float
     
     @classmethod
     def from_db(cls, row):
@@ -18,15 +19,6 @@ class Area:
         return area
     
     @classmethod
-    def calculate(cls, lats, lons):
+    def calculate(cls, lats: list[float], lons: list[float]):
         '''Returns the area of the given lats and lons'''
         return cls(min(lats), max(lats), min(lons), max(lons))
-    
-    def __init__(self, min_lat, max_lat, min_lon, max_lon):
-        self.min_lat = min_lat
-        self.max_lat = max_lat
-        self.min_lon = min_lon
-        self.max_lon = max_lon
-    
-    def __eq__(self, other):
-        return self.min_lat == other.min_lat and self.max_lat == other.max_lat and self.min_lon == other.min_lon and self.max_lon == other.max_lon

--- a/models/assignment.py
+++ b/models/assignment.py
@@ -1,17 +1,18 @@
 
+from dataclasses import dataclass
+
 from models.bus import Bus
 from models.context import Context
 from models.date import Date
 
+@dataclass(slots=True)
 class Assignment:
     '''An association between a block and a bus for a specific date'''
     
-    __slots__ = (
-        'context',
-        'block_id',
-        'bus_number',
-        'date'
-    )
+    context: Context
+    block_id: str
+    bus_number: int
+    date: Date
     
     @classmethod
     def from_db(cls, row, prefix='assignment'):
@@ -31,9 +32,3 @@ class Assignment:
     def bus(self):
         '''The bus for this assignment'''
         return Bus.find(self.context, self.bus_number)
-    
-    def __init__(self, context: Context, block_id, bus_number, date):
-        self.context = context
-        self.block_id = block_id
-        self.bus_number = bus_number
-        self.date = date

--- a/models/backoff.py
+++ b/models/backoff.py
@@ -1,20 +1,14 @@
 
+from dataclasses import dataclass
+
+@dataclass(slots=True)
 class Backoff:
     
-    __slots__ = (
-        'value',
-        'target',
-        'scale',
-        'initial_target',
-        'max_target'
-    )
-    
-    def __init__(self, scale=2, initial_target=1, max_target=None):
-        self.value = 0
-        self.target = 1
-        self.scale = scale
-        self.initial_target = initial_target
-        self.max_target = max_target
+    value: int = 0
+    target: int = 1
+    scale: int = 2
+    initial_target: int = 1
+    max_target: int | None = None
     
     def check(self):
         '''Checks if the value has reached the target'''

--- a/models/block.py
+++ b/models/block.py
@@ -1,12 +1,15 @@
 
 from dataclasses import dataclass, field
+from typing import Self
 
 from di import di
 
 from models.context import Context
 from models.match import Match
 from models.schedule import Schedule
+from models.sheet import Sheet
 from models.time import Time
+from models.trip import Trip
 
 from repositories import DepartureRepository
 
@@ -16,12 +19,12 @@ class Block:
     
     context: Context
     id: str
-    trips: list
+    trips: list[Trip]
     
     schedule: Schedule = field(init=False)
-    sheets: list = field(init=False)
+    sheets: list[Sheet] = field(init=False)
     
-    _related_blocks: list | None = field(default=None, init=False)
+    _related_blocks: list[Self] | None = field(default=None, init=False)
     
     departure_repository: DepartureRepository = field(init=False)
     

--- a/models/bus.py
+++ b/models/bus.py
@@ -1,19 +1,27 @@
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.order import Order
+
+from dataclasses import dataclass, field
+
 from di import di
 
 from models.context import Context
 
 from repositories import AdornmentRepository, OrderRepository
 
+@dataclass(slots=True)
 class Bus:
     '''A public transportation vehicle'''
     
-    __slots__ = (
-        'adornment_repository',
-        'context',
-        'number',
-        'order'
-    )
+    context: Context
+    number: int
+    order: Order
+    
+    adornment_repository: AdornmentRepository = field(init=False)
     
     @classmethod
     def find(cls, context: Context, number, **kwargs):
@@ -48,11 +56,7 @@ class Bus:
             return order.model
         return None
     
-    def __init__(self, context: Context, number, order, **kwargs):
-        self.context = context
-        self.number = number
-        self.order = order
-        
+    def __post_init__(self, **kwargs):
         self.adornment_repository = kwargs.get('adornment_repository') or di[AdornmentRepository]
     
     def __str__(self):

--- a/models/context.py
+++ b/models/context.py
@@ -6,19 +6,20 @@ if TYPE_CHECKING:
     from models.agency import Agency
     from models.system import System
 
+from dataclasses import dataclass
+
 from constants import *
 
 from di import di
 
 from repositories import AgencyRepository, SystemRepository
 
+@dataclass(init=False, slots=True)
 class Context:
     '''A context representing an agency and system'''
     
-    __slots__ = (
-        'agency',
-        'system'
-    )
+    agency: Agency | None
+    system: System | None
     
     @classmethod
     def find(cls, agency_id=None, system_id=None, **kwargs):
@@ -122,7 +123,7 @@ class Context:
             return self.agency.distance_scale
         return DEFAULT_DISTANCE_SCALE
     
-    def __init__(self, agency: Agency = None, system: System = None):
+    def __init__(self, agency: Agency | None = None, system: System | None = None):
         if agency and system and agency != system.agency:
             raise ValueError('Agency mismatch')
         if system and not agency:

--- a/models/context.py
+++ b/models/context.py
@@ -79,7 +79,7 @@ class Context:
     def timezone(self):
         if self.system:
             return self.system.timezone
-        return None
+        return DEFAULT_TIMEZONE
     
     @property
     def prefix_headsigns(self):

--- a/models/date.py
+++ b/models/date.py
@@ -1,4 +1,5 @@
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 import calendar
@@ -6,36 +7,31 @@ import pytz
 
 from models.weekday import Weekday
 
+from constants import DEFAULT_TIMEZONE
+
+@dataclass(slots=True)
 class Date:
     '''A specific year, month, and day'''
     
-    __slots__ = (
-        'year',
-        'month',
-        'day',
-        'timezone'
-    )
+    year: int
+    month: int
+    day: int
+    timezone: pytz.BaseTzInfo = DEFAULT_TIMEZONE
     
     @classmethod
-    def parse(cls, date_string, timezone=None, format='%Y-%m-%d'):
+    def parse(cls, date_string, timezone=DEFAULT_TIMEZONE, format='%Y-%m-%d'):
         '''Returns a date parsed from a string in the given format'''
         date = datetime.strptime(date_string, format)
-        if not timezone:
-            timezone = pytz.timezone('America/Vancouver')
         return cls(date.year, date.month, date.day, timezone)
     
     @classmethod
-    def today(cls, timezone=None):
+    def today(cls, timezone=DEFAULT_TIMEZONE):
         '''Returns the current date'''
-        if not timezone:
-            timezone = pytz.timezone('America/Vancouver')
         return cls.fromdatetime(datetime.now(timezone), timezone)
     
     @classmethod
-    def fromdatetime(cls, datetime, timezone=None):
+    def fromdatetime(cls, datetime, timezone=DEFAULT_TIMEZONE):
         '''Returns a date from the given datetime'''
-        if not timezone:
-            timezone = pytz.timezone('America/Vancouver')
         if datetime.hour < 4:
             datetime = datetime - timedelta(days=1)
         return cls(datetime.year, datetime.month, datetime.day, timezone)

--- a/models/daterange.py
+++ b/models/daterange.py
@@ -1,11 +1,14 @@
 
+from dataclasses import dataclass
+
+from models.date import Date
+
+@dataclass(slots=True)
 class DateRange:
     '''A set of dates between starting and ending points'''
     
-    __slots__ = (
-        'start',
-        'end'
-    )
+    start: Date
+    end: Date
     
     @classmethod
     def combine(cls, date_ranges):
@@ -14,10 +17,6 @@ class DateRange:
         end = max({r.end for r in date_ranges})
         return cls(start, end)
     
-    def __init__(self, start, end):
-        self.start = start
-        self.end = end
-    
     def __str__(self):
         if self.start == self.end:
             return str(self.start)
@@ -25,9 +24,6 @@ class DateRange:
     
     def __hash__(self):
         return hash((self.start, self.end))
-    
-    def __eq__(self, other):
-        return self.start == other.start and self.end == other.end
     
     def __lt__(self, other):
         if self.start == other.start:

--- a/models/departure.py
+++ b/models/departure.py
@@ -1,4 +1,5 @@
 
+from dataclasses import dataclass, field
 from enum import Enum
 
 from di import di
@@ -52,22 +53,22 @@ class DropoffType(Enum):
         '''Checks if this is a normal dropoff'''
         return self == DropoffType.NORMAL
 
+@dataclass(slots=True)
 class Departure:
     '''An association between a trip and a stop'''
     
-    __slots__ = (
-        'departure_repository',
-        'context',
-        'trip_id',
-        'sequence',
-        'stop_id',
-        'time',
-        'pickup_type',
-        'dropoff_type',
-        'timepoint',
-        'distance',
-        'headsign'
-    )
+    context: Context
+    trip_id: str
+    sequence: int
+    stop_id: str
+    time: Time
+    pickup_type: PickupType
+    dropoff_type: DropoffType
+    timepoint: bool
+    distance: float | None
+    headsign: str | None
+    
+    departure_repository: DepartureRepository = field(init=False)
     
     @classmethod
     def from_db(cls, row, prefix='departure'):
@@ -114,18 +115,7 @@ class Departure:
             return self.trip and self == self.trip.last_departure
         return False
     
-    def __init__(self, context: Context, trip_id, sequence, stop_id, time, pickup_type, dropoff_type, timepoint, distance, headsign, **kwargs):
-        self.context = context
-        self.trip_id = trip_id
-        self.sequence = sequence
-        self.stop_id = stop_id
-        self.time = time
-        self.pickup_type = pickup_type
-        self.dropoff_type = dropoff_type
-        self.timepoint = timepoint
-        self.distance = distance
-        self.headsign = headsign
-        
+    def __post_init__(self, **kwargs):
         self.departure_repository = kwargs.get('departure_repository') or di[DepartureRepository]
     
     def __str__(self):

--- a/models/event.py
+++ b/models/event.py
@@ -1,18 +1,16 @@
 
+from dataclasses import dataclass
+
+from models.date import Date
+
+@dataclass(slots=True)
 class Event:
     '''Something that occurred on a specific date'''
     
-    __slots__ = (
-        'date',
-        'name',
-        'description'
-    )
+    date: Date
+    name: str
+    description: str | None = None
     
     @property
     def is_today(self):
         return self.date.is_today
-    
-    def __init__(self, date, name, description=None):
-        self.date = date
-        self.name = name
-        self.description = description

--- a/models/favourite.py
+++ b/models/favourite.py
@@ -1,18 +1,21 @@
 
+from dataclasses import dataclass
+
 from di import di
 
 from models.bus import Bus
 from models.context import Context
+from models.route import Route
+from models.stop import Stop
 
 from repositories import RouteRepository, StopRepository
 
+@dataclass(slots=True)
 class Favourite:
     '''A vehicle, route, or stop selected by a user to have quick access to'''
     
-    __slots__ = (
-        'type',
-        'value'
-    )
+    type: str
+    value: Bus | Route | Stop
     
     @classmethod
     def parse(cls, string, **kwargs):
@@ -41,10 +44,6 @@ class Favourite:
         if value:
             return cls(type, value)
         return None
-    
-    def __init__(self, type, value):
-        self.type = type
-        self.value = value
     
     def __str__(self):
         if self.type == 'vehicle':
@@ -78,12 +77,11 @@ class Favourite:
             return self.value < other.value
         return self.type < other.type
 
+@dataclass(slots=True)
 class FavouriteSet:
     '''A set of favourites selected by a user'''
     
-    __slots__ = (
-        'favourites'
-    )
+    favourites: set[Favourite]
     
     @classmethod
     def parse(cls, string):
@@ -96,9 +94,6 @@ class FavouriteSet:
     def is_full(self):
         '''Checks if the set has the maximum number of favourites'''
         return len(self.favourites) >= 20
-    
-    def __init__(self, favourites):
-        self.favourites = favourites
     
     def __str__(self):
         return ','.join([str(f) for f in self.favourites])

--- a/models/match.py
+++ b/models/match.py
@@ -1,21 +1,15 @@
 
+from dataclasses import dataclass
+
+@dataclass(slots=True)
 class Match:
     '''A search result with a value indicating how closely it matches the query'''
     
-    __slots__ = (
-        'name',
-        'description',
-        'icon',
-        'path',
-        'value'
-    )
-    
-    def __init__(self, name, description, icon, path, value):
-        self.name = name
-        self.description = description
-        self.icon = icon
-        self.path = path
-        self.value = value
+    name: str
+    description: str
+    icon: str
+    path: str
+    value: int
     
     def __eq__(self, other):
         return self.value == other.value

--- a/models/model.py
+++ b/models/model.py
@@ -1,4 +1,5 @@
 
+from dataclasses import dataclass
 from enum import Enum
 
 class ModelType(Enum):
@@ -22,17 +23,16 @@ class ModelType(Enum):
     def __lt__(self, other):
         return self.value < other.value
 
+@dataclass(slots=True)
 class Model:
     '''A specific version of a vehicle'''
     
-    __slots__ = (
-        'id',
-        'type',
-        'name',
-        'manufacturer',
-        'length',
-        'fuel'
-    )
+    id: str
+    type: ModelType
+    name: str
+    manufacturer: str | None = None
+    length: float | None = None
+    fuel: str | None = None
     
     @property
     def display_manufacturer(self):
@@ -45,14 +45,6 @@ class Model:
     def display_name(self):
         '''Formats the model name for web display'''
         return self.name.replace('/', '/<wbr />')
-    
-    def __init__(self, id, type, name, **kwargs):
-        self.id = id
-        self.type = type
-        self.name = name
-        self.manufacturer = kwargs.get('manufacturer')
-        self.length = kwargs.get('length')
-        self.fuel = kwargs.get('fuel')
     
     def __str__(self):
         if self.manufacturer:

--- a/models/order.py
+++ b/models/order.py
@@ -1,21 +1,24 @@
 
+from dataclasses import dataclass, field
+
 from models.bus import Bus
 from models.context import Context
+from models.model import Model
 
+@dataclass(slots=True)
 class Order:
     '''A range of buses of a specific model ordered in a specific year'''
     
-    __slots__ = (
-        'context',
-        'model',
-        'low',
-        'high',
-        'year',
-        'visible',
-        'demo',
-        'exceptions',
-        'size'
-    )
+    context: Context
+    model: Model
+    low: int
+    high: int
+    year: int | None = None
+    visible: bool = True
+    demo: bool = False
+    exceptions: set[int] = field(default_factory=set)
+    
+    size: int = field(init=False)
     
     @property
     def first_bus(self):
@@ -27,23 +30,7 @@ class Order:
         '''The last bus in the order'''
         return Bus(self.context, self.high, self)
     
-    def __init__(self, context: Context, model, **kwargs):
-        self.context = context
-        self.model = model
-        if 'number' in kwargs:
-            self.low = kwargs['number']
-            self.high = kwargs['number']
-        else:
-            self.low = kwargs['low']
-            self.high = kwargs['high']
-        self.year = kwargs.get('year')
-        self.visible = kwargs.get('visible', True)
-        self.demo = kwargs.get('demo', False)
-        if 'exceptions' in kwargs:
-            self.exceptions = set(kwargs['exceptions'])
-        else:
-            self.exceptions = set()
-        
+    def __post_init__(self):
         self.size = (self.high - self.low) + 1 - len(self.exceptions)
     
     def __str__(self):

--- a/models/overview.py
+++ b/models/overview.py
@@ -1,21 +1,22 @@
 
+from dataclasses import dataclass
+
 from models.bus import Bus
 from models.context import Context
 from models.date import Date
 from models.record import Record
 
+@dataclass(slots=True)
 class Overview:
     '''An overview of a bus' history'''
     
-    __slots__ = (
-        'bus',
-        'first_seen_date',
-        'first_seen_context',
-        'first_record',
-        'last_seen_date',
-        'last_seen_context',
-        'last_record'
-    )
+    bus: Bus
+    first_seen_date: Date
+    first_seen_context: Context
+    first_record: Record | None
+    last_seen_date: Date
+    last_seen_context: Context
+    last_record: Record | None
     
     @classmethod
     def from_db(cls, row, prefix='overview'):
@@ -35,12 +36,3 @@ class Overview:
         else:
             last_record = Record.from_db(row, prefix=f'{prefix}_last_record')
         return cls(bus, first_seen_date, first_seen_context, first_record, last_seen_date, last_seen_context, last_record)
-    
-    def __init__(self, bus, first_seen_date, first_seen_context: Context, first_record, last_seen_date, last_seen_context: Context, last_record):
-        self.bus = bus
-        self.first_seen_date = first_seen_date
-        self.first_seen_context = first_seen_context
-        self.first_record = first_record
-        self.last_seen_date = last_seen_date
-        self.last_seen_context = last_seen_context
-        self.last_record = last_record

--- a/models/point.py
+++ b/models/point.py
@@ -1,16 +1,17 @@
 
+from dataclasses import dataclass
+
 from models.context import Context
 
+@dataclass(slots=True)
 class Point:
     '''The coordinates and sequence number of a single point in a line'''
     
-    __slots__ = (
-        'context',
-        'shape_id',
-        'sequence',
-        'lat',
-        'lon'
-    )
+    context: Context
+    shape_id: str
+    sequence: int
+    lat: float
+    lon: float
     
     @classmethod
     def from_db(cls, row, prefix='point'):
@@ -21,13 +22,6 @@ class Point:
         lat = row[f'{prefix}_lat']
         lon = row[f'{prefix}_lon']
         return cls(context, shape_id, sequence, lat, lon)
-    
-    def __init__(self, context: Context, shape_id, sequence, lat, lon):
-        self.context = context
-        self.shape_id = shape_id
-        self.sequence = sequence
-        self.lat = lat
-        self.lon = lon
     
     def __eq__(self, other):
         return self.sequence == other.sequence

--- a/models/position.py
+++ b/models/position.py
@@ -1,4 +1,6 @@
 
+from dataclasses import dataclass, field
+
 from di import di
 
 from models.adherence import Adherence
@@ -9,26 +11,26 @@ from models.timestamp import Timestamp
 
 from repositories import DepartureRepository
 
+@dataclass(slots=True)
 class Position:
     '''Current information about a bus' coordinates, trip, and stop'''
     
-    __slots__ = (
-        'departure_repository',
-        'context',
-        'bus',
-        'trip_id',
-        'stop_id',
-        'block_id',
-        'route_id',
-        'sequence',
-        'lat',
-        'lon',
-        'bearing',
-        'speed',
-        'adherence',
-        'occupancy',
-        'timestamp'
-    )
+    context: Context
+    bus: Bus
+    trip_id: str | None
+    stop_id: str | None
+    block_id: str | None
+    route_id: str | None
+    sequence: int | None
+    lat: float | None
+    lon: float | None
+    bearing: float | None
+    speed: float | None
+    adherence: Adherence | None
+    occupancy: Occupancy | None
+    timestamp: Timestamp
+    
+    departure_repository: DepartureRepository = field(init=False)
     
     @classmethod
     def from_db(cls, row, prefix='position'):
@@ -112,22 +114,7 @@ class Position:
         '''Returns the departure associated with this position'''
         return self.departure_repository.find(self.context, self.trip_id, self.sequence)
     
-    def __init__(self, context: Context, bus, trip_id, stop_id, block_id, route_id, sequence, lat, lon, bearing, speed, adherence, occupancy, timestamp, **kwargs):
-        self.context = context
-        self.bus = bus
-        self.trip_id = trip_id
-        self.stop_id = stop_id
-        self.block_id = block_id
-        self.route_id = route_id
-        self.sequence = sequence
-        self.lat = lat
-        self.lon = lon
-        self.bearing = bearing
-        self.speed = speed
-        self.adherence = adherence
-        self.occupancy = occupancy
-        self.timestamp = timestamp
-        
+    def __post_init__(self, **kwargs):
         self.departure_repository = kwargs.get('departure_repository') or di[DepartureRepository]
     
     def __eq__(self, other):

--- a/models/region.py
+++ b/models/region.py
@@ -1,15 +1,12 @@
 
+from dataclasses import dataclass
+
+@dataclass(slots=True)
 class Region:
     '''A large area that contains multiple systems'''
     
-    __slots__ = (
-        'id',
-        'name'
-    )
-    
-    def __init__(self, id, name):
-        self.id = id
-        self.name = name
+    id: str
+    name: str
     
     def __str__(self):
         return self.name

--- a/models/route.py
+++ b/models/route.py
@@ -1,4 +1,5 @@
 
+from dataclasses import dataclass, field
 from random import randint, seed
 from math import sqrt
 from colorsys import hls_to_rgb
@@ -14,19 +15,20 @@ from repositories import DepartureRepository
 
 import helpers
 
+@dataclass(slots=True)
 class Route:
     '''A list of trips that follow a regular pattern with a given number'''
     
-    __slots__ = (
-        'departure_repository',
-        'context',
-        'id',
-        'number',
-        'key',
-        'name',
-        'colour',
-        'text_colour'
-    )
+    context: Context
+    id: str
+    number: str
+    name: str
+    colour: str
+    text_colour: str
+    
+    key: str = field(init=False)
+    
+    departure_repository: DepartureRepository = field(init=False)
     
     @classmethod
     def from_db(cls, row, prefix='route'):
@@ -78,15 +80,8 @@ class Route:
         '''Returns the indicator points for this route'''
         return self.cache.indicator_points
     
-    def __init__(self, context: Context, id, number, name, colour, text_colour, **kwargs):
-        self.context = context
-        self.id = id
-        self.number = number
-        self.name = name
-        self.colour = colour
-        self.text_colour = text_colour
-        
-        self.key = helpers.key(number)
+    def __post_init__(self, **kwargs):
+        self.key = helpers.key(self.number)
         
         self.departure_repository = kwargs.get('departure_repository') or di[DepartureRepository]
     

--- a/models/route.py
+++ b/models/route.py
@@ -9,7 +9,10 @@ from di import di
 from models.context import Context
 from models.daterange import DateRange
 from models.match import Match
+from models.point import Point
 from models.schedule import Schedule
+from models.sheet import Sheet
+from models.trip import Trip
 
 from repositories import DepartureRepository
 
@@ -196,10 +199,10 @@ def generate_colour(context: Context, number):
 class RouteCache:
     '''A collection of calculated values for a single route'''
     
-    trips: list
+    trips: list[Trip]
     schedule: Schedule | None
-    sheets: list
-    indicator_points: list
+    sheets: list[Sheet]
+    indicator_points: list[Point]
     
     @classmethod
     def build(cls, system, trips):

--- a/models/service.py
+++ b/models/service.py
@@ -1,4 +1,5 @@
 
+from dataclasses import dataclass
 from enum import IntEnum
 
 from models.context import Context
@@ -11,14 +12,13 @@ class ServiceExceptionType(IntEnum):
     INCLUDED = 1
     EXCLUDED = 2
 
+@dataclass(slots=True)
 class ServiceException:
     '''A date that is explicitly included or excluded from a service'''
     
-    __slots__ = (
-        'service_id',
-        'date',
-        'type'
-    )
+    service_id: str
+    date: Date
+    type: ServiceExceptionType
     
     @classmethod
     def from_csv(cls, row, context: Context):
@@ -28,25 +28,19 @@ class ServiceException:
         type = ServiceExceptionType(int(row['exception_type']))
         return cls(service_id, date, type)
     
-    def __init__(self, service_id, date, type):
-        self.service_id = service_id
-        self.date = date
-        self.type = type
-    
     def __hash__(self):
         return hash((self.service_id, self.date))
     
     def __eq__(self, other):
         return self.service_id == other.service_id and self.date == other.date
 
+@dataclass(slots=True)
 class Service:
     '''A set of dates when a transit service is operating'''
     
-    __slots__ = (
-        'context',
-        'id',
-        'schedule'
-    )
+    context: Context
+    id: int
+    schedule: Schedule
     
     @classmethod
     def from_csv(cls, row, context: Context, exceptions):
@@ -82,11 +76,6 @@ class Service:
         date_range = DateRange(min(dates), max(dates))
         schedule = Schedule(dates, date_range)
         return cls(context, id, schedule)
-    
-    def __init__(self, context: Context, id, schedule):
-        self.context = context
-        self.id = id
-        self.schedule = schedule
     
     def __hash__(self):
         return hash(self.id)

--- a/models/sheet.py
+++ b/models/sheet.py
@@ -1,18 +1,19 @@
 
+from dataclasses import dataclass, field
+
 from models.context import Context
 from models.schedule import Schedule
 
+@dataclass(init=False, slots=True)
 class Sheet:
     '''A collection of overlapping services'''
     
-    __slots__ = (
-        'context',
-        'schedule',
-        'services',
-        'service_groups',
-        'modifications',
-        'copies'
-    )
+    context: Context
+    schedule: Schedule
+    services: list
+    service_groups: list
+    modifications: set
+    copies: dict
     
     @property
     def normal_service_groups(self):
@@ -49,7 +50,8 @@ class Sheet:
             if not service_set:
                 continue
             dates = {k for k,v in date_services.items() if v == service_set}
-            service_group = ServiceGroup(context, dates, date_range, service_set)
+            schedule = Schedule(dates, date_range)
+            service_group = ServiceGroup(context, schedule, service_set)
             service_groups.append(service_group)
         
         self.service_groups = sorted(service_groups)
@@ -94,19 +96,13 @@ class Sheet:
             return 'modified-service'
         return self.schedule.get_date_status(date)
 
+@dataclass(slots=True)
 class ServiceGroup:
     '''A collection of services represented as a single schedule'''
     
-    __slots__ = (
-        'context',
-        'schedule',
-        'services'
-    )
-    
-    def __init__(self, context: Context, dates, date_range, services):
-        self.context = context
-        self.schedule = Schedule(dates, date_range)
-        self.services = services
+    context: Context
+    schedule: Schedule
+    services: tuple
     
     def __str__(self):
         return str(self.schedule)

--- a/models/sheet.py
+++ b/models/sheet.py
@@ -1,8 +1,34 @@
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from typing import Self
 
 from models.context import Context
+from models.date import Date
 from models.schedule import Schedule
+from models.service import Service
+
+@dataclass(slots=True)
+class ServiceGroup:
+    '''A collection of services represented as a single schedule'''
+    
+    context: Context
+    schedule: Schedule
+    services: tuple
+    
+    def __str__(self):
+        return str(self.schedule)
+    
+    def __hash__(self):
+        return hash(self.schedule)
+    
+    def __eq__(self, other):
+        return self.schedule == other.schedule
+    
+    def __lt__(self, other):
+        return self.schedule < other.schedule
+    
+    def __contains__(self, service):
+        return service in self.services
 
 @dataclass(init=False, slots=True)
 class Sheet:
@@ -10,10 +36,10 @@ class Sheet:
     
     context: Context
     schedule: Schedule
-    services: list
-    service_groups: list
-    modifications: set
-    copies: dict
+    services: list[Service]
+    service_groups: list[ServiceGroup]
+    modifications: set[Date]
+    copies: dict[tuple, Self]
     
     @property
     def normal_service_groups(self):
@@ -95,26 +121,3 @@ class Sheet:
         if date in self.modifications:
             return 'modified-service'
         return self.schedule.get_date_status(date)
-
-@dataclass(slots=True)
-class ServiceGroup:
-    '''A collection of services represented as a single schedule'''
-    
-    context: Context
-    schedule: Schedule
-    services: tuple
-    
-    def __str__(self):
-        return str(self.schedule)
-    
-    def __hash__(self):
-        return hash(self.schedule)
-    
-    def __eq__(self, other):
-        return self.schedule == other.schedule
-    
-    def __lt__(self, other):
-        return self.schedule < other.schedule
-    
-    def __contains__(self, service):
-        return service in self.services

--- a/models/stop.py
+++ b/models/stop.py
@@ -1,4 +1,5 @@
 
+from dataclasses import dataclass, field
 from math import sqrt
 
 from di import di
@@ -12,19 +13,20 @@ from repositories import DepartureRepository
 
 import helpers
 
+@dataclass(slots=True)
 class Stop:
     '''A location where a vehicle stops along a trip'''
     
-    __slots__ = (
-        'departure_repository',
-        'context',
-        'id',
-        'number',
-        'key',
-        'name',
-        'lat',
-        'lon'
-    )
+    context: Context
+    id: str
+    number: str
+    name: str
+    lat: float
+    lon: float
+    
+    key: str = field(init=False)
+    
+    departure_repository: DepartureRepository = field(init=False)
     
     @classmethod
     def from_db(cls, row, prefix='stop'):
@@ -72,15 +74,8 @@ class Stop:
         '''Returns the routes for this stop'''
         return self.cache.routes
     
-    def __init__(self, context: Context, id, number, name, lat, lon, **kwargs):
-        self.context = context
-        self.id = id
-        self.number = number
-        self.name = name
-        self.lat = lat
-        self.lon = lon
-        
-        self.key = helpers.key(number)
+    def __post_init__(self, **kwargs):
+        self.key = helpers.key(self.number)
         
         self.departure_repository = kwargs.get('departure_repository') or di[DepartureRepository]
     

--- a/models/stop.py
+++ b/models/stop.py
@@ -145,21 +145,22 @@ class Stop:
         '''Returns all departures on trips that serve this stop'''
         return self.departure_repository.find_adjacent(self.context, self)
 
+@dataclass(slots=True)
 class StopCache:
     '''A collection of calculated values for a single stop'''
     
-    __slots__ = (
-        'schedule',
-        'sheets',
-        'routes'
-    )
+    schedule: Schedule
+    sheets: list
+    routes: list
     
-    def __init__(self, system, departures):
+    @classmethod
+    def build(cls, system, departures):
         services = {d.trip.service for d in departures if d.trip}
-        self.sheets = system.copy_sheets(services)
-        if self.sheets:
-            date_range = DateRange.combine([s.schedule.date_range for s in self.sheets])
-            self.schedule = Schedule.combine(services, date_range)
+        sheets = system.copy_sheets(services)
+        if sheets:
+            date_range = DateRange.combine([s.schedule.date_range for s in sheets])
+            schedule = Schedule.combine(services, date_range)
         else:
-            self.schedule = None
-        self.routes = sorted({d.trip.route for d in departures if d.trip and d.trip.route})
+            schedule = None
+        routes = sorted({d.trip.route for d in departures if d.trip and d.trip.route})
+        return cls(schedule, sheets, routes)

--- a/models/stop.py
+++ b/models/stop.py
@@ -7,7 +7,9 @@ from di import di
 from models.context import Context
 from models.daterange import DateRange
 from models.match import Match
+from models.route import Route
 from models.schedule import Schedule
+from models.sheet import Sheet
 
 from repositories import DepartureRepository
 
@@ -150,8 +152,8 @@ class StopCache:
     '''A collection of calculated values for a single stop'''
     
     schedule: Schedule
-    sheets: list
-    routes: list
+    sheets: list[Sheet]
+    routes: list[Route]
     
     @classmethod
     def build(cls, system, departures):

--- a/models/system.py
+++ b/models/system.py
@@ -34,7 +34,7 @@ class System:
     
     gtfs_downloaded: bool | None = field(default=None, init=False)
     gtfs_loaded: bool = field(default=False, init=False)
-    reload_backoff: bool = field(init=False)
+    reload_backoff: Backoff = field(init=False)
     last_updated: Date | None = field(default=None, init=False)
     
     blocks: dict = field(default_factory=dict, init=False)

--- a/models/system.py
+++ b/models/system.py
@@ -6,13 +6,16 @@ from di import di
 
 from models.agency import Agency
 from models.backoff import Backoff
+from models.block import Block
 from models.context import Context
 from models.date import Date
 from models.region import Region
-from models.route import RouteCache
+from models.route import Route, RouteCache
 from models.schedule import Schedule
-from models.stop import StopCache
-from models.trip import TripCache
+from models.service import Service
+from models.sheet import Sheet
+from models.stop import Stop, StopCache
+from models.trip import Trip, TripCache
 
 from repositories import DepartureRepository, OverviewRepository, PositionRepository
 
@@ -37,18 +40,18 @@ class System:
     reload_backoff: Backoff = field(init=False)
     last_updated: Date | None = field(default=None, init=False)
     
-    blocks: dict = field(default_factory=dict, init=False)
-    routes: dict = field(default_factory=dict, init=False)
-    routes_by_number: dict = field(default_factory=dict, init=False)
-    services: dict = field(default_factory=dict, init=False)
-    sheets: list = field(default_factory=list, init=False)
-    stops: dict = field(default_factory=dict, init=False)
-    stops_by_number: dict = field(default_factory=dict, init=False)
-    trips: dict = field(default_factory=dict, init=False)
+    blocks: dict[str, Block] = field(default_factory=dict, init=False)
+    routes: dict[str, Route] = field(default_factory=dict, init=False)
+    routes_by_number: dict[str, Route] = field(default_factory=dict, init=False)
+    services: dict[str, Service] = field(default_factory=dict, init=False)
+    sheets: list[Sheet] = field(default_factory=list, init=False)
+    stops: dict[str, Stop] = field(default_factory=dict, init=False)
+    stops_by_number: dict[str, Stop] = field(default_factory=dict, init=False)
+    trips: dict[str, Trip] = field(default_factory=dict, init=False)
     
-    route_caches: dict = field(default_factory=dict, init=False)
-    stop_caches: dict = field(default_factory=dict, init=False)
-    trip_caches: dict = field(default_factory=dict, init=False)
+    route_caches: dict[str, RouteCache] = field(default_factory=dict, init=False)
+    stop_caches: dict[str, StopCache] = field(default_factory=dict, init=False)
+    trip_caches: dict[str, TripCache] = field(default_factory=dict, init=False)
     
     departure_repository: DepartureRepository = field(init=False)
     overview_repository: OverviewRepository = field(init=False)

--- a/models/theme.py
+++ b/models/theme.py
@@ -1,21 +1,15 @@
 
+from dataclasses import dataclass
+
+@dataclass(slots=True)
 class Theme:
     '''A set of CSS styles that feature different colours'''
     
-    __slots__ = (
-        'id',
-        'name',
-        'visible',
-        'light',
-        'dark'
-    )
-    
-    def __init__(self, id, name, **kwargs):
-        self.id = id
-        self.name = name
-        self.visible = kwargs.get('visible', True)
-        self.light = kwargs.get('light', False)
-        self.dark = kwargs.get('dark', False)
+    id: str
+    name: str
+    visible: bool = True
+    light: bool = False
+    dark: bool = False
     
     def __str__(self):
         return self.name

--- a/models/time.py
+++ b/models/time.py
@@ -1,22 +1,22 @@
 
+from dataclasses import dataclass
 from datetime import datetime
 import pytz
 
+from constants import DEFAULT_TIMEZONE
+
+@dataclass(slots=True)
 class Time:
     '''A specific hour, minute, and second'''
     
-    __slots__ = (
-        'hour',
-        'minute',
-        'second',
-        'timezone'
-    )
+    hour: int | None
+    minute: int | None
+    second: int | None
+    timezone: pytz.BaseTzInfo = DEFAULT_TIMEZONE
     
     @classmethod
-    def parse(cls, time_string, timezone=None, accurate_seconds=False):
+    def parse(cls, time_string, timezone=DEFAULT_TIMEZONE, accurate_seconds=False):
         '''Returns a time parsed from the given string in HH:MM:SS format'''
-        if not timezone:
-            timezone = pytz.timezone('America/Vancouver')
         if not time_string:
             return cls.unknown(timezone)
         time_parts = time_string.split(':')
@@ -30,17 +30,13 @@ class Time:
         return cls(hour, minute, second, timezone)
     
     @classmethod
-    def now(cls, timezone=None, accurate_seconds=True):
+    def now(cls, timezone=DEFAULT_TIMEZONE, accurate_seconds=True):
         '''Returns the current time'''
-        if not timezone:
-            timezone = pytz.timezone('America/Vancouver')
         return cls.fromdatetime(datetime.now(timezone), timezone, accurate_seconds)
     
     @classmethod
-    def fromdatetime(cls, datetime, timezone=None, accurate_seconds=True):
+    def fromdatetime(cls, datetime, timezone=DEFAULT_TIMEZONE, accurate_seconds=True):
         '''Returns a time from the given datetime'''
-        if not timezone:
-            timezone = pytz.timezone('America/Vancouver')
         hour = datetime.hour
         if hour < 4:
             hour += 24
@@ -51,10 +47,8 @@ class Time:
         return cls(hour, datetime.minute, second, timezone)
     
     @classmethod
-    def unknown(cls, timezone=None):
+    def unknown(cls, timezone=DEFAULT_TIMEZONE):
         '''Returns an unknown time'''
-        if not timezone:
-            timezone = pytz.timezone('America/Vancouver')
         return cls(None, None, None, timezone)
     
     @property
@@ -92,12 +86,6 @@ class Time:
     def timezone_name(self):
         '''Returns the name of this time's timezone'''
         return datetime.now(self.timezone).tzname()
-    
-    def __init__(self, hour, minute, second, timezone):
-        self.hour = hour
-        self.minute = minute
-        self.second = second
-        self.timezone = timezone
     
     def __str__(self):
         return self.format_web()

--- a/models/timestamp.py
+++ b/models/timestamp.py
@@ -1,32 +1,30 @@
 
+from dataclasses import dataclass
 from datetime import datetime
 import pytz
 
 from models.date import Date
 from models.time import Time
 
+from constants import DEFAULT_TIMEZONE
+
+@dataclass(slots=True)
 class Timestamp:
     
-    __slots__ = (
-        'value',
-        'timezone',
-        'accurate_seconds'
-    )
+    value: float
+    timezone: pytz.BaseTzInfo = DEFAULT_TIMEZONE
+    accurate_seconds: bool = True
     
     @classmethod
-    def now(cls, timezone=None, accurate_seconds=True):
+    def now(cls, timezone=DEFAULT_TIMEZONE, accurate_seconds=True):
         '''Returns the current timestamp'''
-        if not timezone:
-            timezone = pytz.timezone('America/Vancouver')
         return cls.parse(datetime.now(timezone).timestamp(), timezone, accurate_seconds)
     
     @classmethod
-    def parse(cls, value, timezone=None, accurate_seconds=True):
+    def parse(cls, value, timezone=DEFAULT_TIMEZONE, accurate_seconds=True):
         '''Returns a timestamp with the given value'''
         if not value:
             return None
-        if not timezone:
-            timezone = pytz.timezone('America/Vancouver')
         return cls(value, timezone, accurate_seconds)
     
     @property
@@ -68,11 +66,6 @@ class Timestamp:
     def timezone_name(self):
         '''Returns the name of this timestamp's timezone'''
         return datetime.now(self.timezone).tzname()
-    
-    def __init__(self, value, timezone, accurate_seconds):
-        self.value = value
-        self.timezone = timezone
-        self.accurate_seconds = accurate_seconds
     
     def __str__(self):
         date = self.date

--- a/models/transfer.py
+++ b/models/transfer.py
@@ -1,18 +1,19 @@
 
+from dataclasses import dataclass
+
 from models.bus import Bus
 from models.context import Context
 from models.date import Date
 
+@dataclass(slots=True)
 class Transfer:
     '''Information about a bus moving from one system to another system'''
     
-    __slots__ = (
-        'id',
-        'bus',
-        'date',
-        'old_context',
-        'new_context'
-    )
+    id: int
+    bus: Bus
+    date: Date
+    old_context: Context
+    new_context: Context
     
     @classmethod
     def from_db(cls, row, prefix='transfer'):
@@ -24,10 +25,3 @@ class Transfer:
         new_context = Context.find(system_id=row[f'{prefix}_new_system_id'])
         date = Date.parse(row[f'{prefix}_date'], new_context.timezone)
         return cls(id, bus, date, old_context, new_context)
-    
-    def __init__(self, id, bus, date, old_context: Context, new_context: Context):
-        self.id = id
-        self.bus = bus
-        self.date = date
-        self.old_context = old_context
-        self.new_context = new_context

--- a/models/trip.py
+++ b/models/trip.py
@@ -1,11 +1,13 @@
 
 from dataclasses import dataclass, field
+from typing import Self
 
 from di import di
 
 from models.context import Context
 from models.departure import Departure
 from models.direction import Direction
+from models.sheet import Sheet
 from models.time import Time
 
 from repositories import DepartureRepository, PointRepository
@@ -24,9 +26,9 @@ class Trip:
     headsign: str
     
     short_id: str = field(init=False)
-    sheets: list = field(init=False)
+    sheets: list[Sheet] = field(init=False)
     
-    _related_trips: list | None = field(default=None, init=False)
+    _related_trips: list[Self] | None = field(default=None, init=False)
     
     departure_repository: DepartureRepository = field(init=False)
     point_repository: PointRepository = field(init=False)

--- a/models/trip.py
+++ b/models/trip.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from di import di
 
 from models.context import Context
+from models.departure import Departure
 from models.direction import Direction
 from models.time import Time
 
@@ -212,33 +213,34 @@ class Trip:
             return False
         return True
 
+@dataclass(slots=True)
 class TripCache:
     '''A collection of calculated values for a single trip'''
     
-    __slots__ = (
-        'first_departure',
-        'last_departure',
-        'departure_count',
-        'direction',
-        'custom_headsigns'
-    )
+    first_departure: Departure | None
+    last_departure: Departure | None
+    departure_count: int
+    direction: Direction
+    custom_headsigns: list[str]
     
-    def __init__(self, departures):
+    @classmethod
+    def build(cls, departures):
         if departures:
-            self.first_departure = departures[0]
-            self.last_departure = departures[-1]
-            self.departure_count = len(departures)
-            self.direction = Direction.calculate(departures[0].stop, departures[-1].stop)
+            first_departure = departures[0]
+            last_departure = departures[-1]
+            departure_count = len(departures)
+            direction = Direction.calculate(departures[0].stop, departures[-1].stop)
             headsigns = [str(d) for d in departures if d.headsign]
             previous_headsign = None
-            self.custom_headsigns = []
+            custom_headsigns = []
             for headsign in headsigns:
                 if headsign != previous_headsign:
-                    self.custom_headsigns.append(headsign)
+                    custom_headsigns.append(headsign)
                 previous_headsign = headsign
         else:
-            self.first_departure = None
-            self.last_departure = None
-            self.departure_count = 0
-            self.direction = Direction.UNKNOWN
-            self.custom_headsigns = []
+            first_departure = None
+            last_departure = None
+            departure_count = 0
+            direction = Direction.UNKNOWN
+            custom_headsigns = []
+        return cls(first_departure, last_departure, departure_count, direction, custom_headsigns)

--- a/repositories/file/order.py
+++ b/repositories/file/order.py
@@ -35,6 +35,12 @@ class FileOrderRepository(OrderRepository):
                 for (model_id, model_values) in agency_values.items():
                     model = self.model_repository.find(model_id)
                     for values in model_values:
+                        if 'number' in values:
+                            values['low'] = values['number']
+                            values['high'] = values['number']
+                            del values['number']
+                        if 'exceptions' in values:
+                            values['exceptions'] = set(values['exceptions'])
                         agency_orders.append(Order(context, model, **values))
                 self.orders[agency_id] = agency_orders
     

--- a/repositories/file/system.py
+++ b/repositories/file/system.py
@@ -1,5 +1,6 @@
 
 import json
+import pytz
 
 from di import di
 
@@ -31,6 +32,10 @@ class FileSystemRepository(SystemRepository):
                 for (region_id, region_values) in agency_values.items():
                     region = self.region_repository.find(region_id)
                     for (id, values) in region_values.items():
+                        if not agency.enabled:
+                            values['enabled'] = False
+                        if 'timezone' in values:
+                            values['timezone'] = pytz.timezone(values['timezone'])
                         self.systems[id] = System(id, agency, region, **values)
     
     def find(self, system_id):

--- a/settings.py
+++ b/settings.py
@@ -1,41 +1,28 @@
 
+from dataclasses import dataclass
+
+@dataclass(slots=True)
 class Settings:
     
-    __slots__ = (
-        'cron_id',
-        'admin_key',
-        'all_systems_domain',
-        'system_domain',
-        'system_domain_path',
-        'cookie_domain',
-        'analytics_key',
-        'enable_analytics',
-        'enable_gtfs_backups',
-        'enable_realtime_backups',
-        'enable_database_backups',
-        'update_cache_in_background'
-    )
+    # Basic settings
+    cron_id: str = 'bctracker-muncher'
+    admin_key: str | None = None
     
-    def __init__(self):
-        # Basic settings
-        self.cron_id = None
-        self.admin_key = None
-        
-        # Domain settings
-        self.all_systems_domain = None
-        self.system_domain = None
-        self.system_domain_path = None
-        self.cookie_domain = None
-        
-        # Key settings
-        self.analytics_key = None
-        
-        # Functionality settings
-        self.enable_analytics = True
-        self.enable_gtfs_backups = True
-        self.enable_realtime_backups = True
-        self.enable_database_backups = True
-        self.update_cache_in_background = True
+    # Domain settings
+    all_systems_domain: str | None = None
+    system_domain: str | None = None
+    system_domain_path: str | None = None
+    cookie_domain: str | None = None
+    
+    # Key settings
+    analytics_key: str | None = None
+    
+    # Functionality settings
+    enable_analytics: bool = True
+    enable_gtfs_backups: bool = True
+    enable_realtime_backups: bool = True
+    enable_database_backups: bool = True
+    update_cache_in_background: bool = True
     
     def setup(self, config):
         self.cron_id = config.get('cron_id', 'bctracker-muncher')


### PR DESCRIPTION
- All models now use `@dataclass`
- Removed `__slots__` from models; now created automatically
- Removed `__init__` from models; now created automatically
  - Dataclass' `__post_init__` is used in a few places for post-init setup
- A few JSON repositories now do a bit of data manipulation before creating objects
- Some general improvements for type hinting (with more to come in future PRs)