### PR TITLE
Revert converting model systems/agencies to contexts

### DIFF
--- a/models/agency.py
+++ b/models/agency.py
@@ -1,6 +1,8 @@
 
 from dataclasses import dataclass
 
+from models.context import Context
+
 from constants import *
 
 @dataclass(slots=True)
@@ -21,6 +23,10 @@ class Agency:
     show_stop_number: bool = DEFAULT_SHOW_STOP_NUMBER
     vehicle_name_length: int | None = DEFAULT_VEHICLE_NAME_LENGTH
     distance_scale: int = DEFAULT_DISTANCE_SCALE
+    
+    @property
+    def context(self):
+        return Context(agency=self)
     
     @property
     def gtfs_enabled(self):

--- a/models/assignment.py
+++ b/models/assignment.py
@@ -1,8 +1,13 @@
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.system import System
+
 from dataclasses import dataclass
 
 from models.bus import Bus
-from models.context import Context
 from models.date import Date
 from models.row import Row
 
@@ -10,7 +15,7 @@ from models.row import Row
 class Assignment:
     '''An association between a block and a bus for a specific date'''
     
-    context: Context
+    system: System
     block_id: str
     bus_number: int
     date: Date
@@ -22,12 +27,17 @@ class Assignment:
         block_id = row['block_id']
         bus_number = row['bus_number']
         date = Date.parse(row['date'], context.timezone)
-        return cls(context, block_id, bus_number, date)
+        return cls(context.system, block_id, bus_number, date)
+    
+    @property
+    def context(self):
+        '''The context for this assignment'''
+        return self.system.context
     
     @property
     def key(self):
         '''The unique identifier for this assignment'''
-        return (self.context.system_id, self.block_id)
+        return (self.system.id, self.block_id)
     
     @property
     def bus(self):

--- a/models/bus.py
+++ b/models/bus.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
 
 from dataclasses import dataclass
 
+from models.agency import Agency
 from models.context import Context
 
 import repositories
@@ -15,7 +16,7 @@ import repositories
 class Bus:
     '''A public transportation vehicle'''
     
-    context: Context
+    agency: Agency
     number: int
     order: Order
     
@@ -23,7 +24,12 @@ class Bus:
     def find(cls, context: Context, number):
         '''Returns a bus for the given context with the given number'''
         order = repositories.order.find(context, number)
-        return cls(context, number, order)
+        return cls(context.agency, number, order)
+    
+    @property
+    def context(self):
+        '''The context for this bus'''
+        return self.agency.context
     
     @property
     def url_id(self):

--- a/models/departure.py
+++ b/models/departure.py
@@ -1,8 +1,13 @@
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.system import System
+
 from dataclasses import dataclass
 from enum import Enum
 
-from models.context import Context
 from models.row import Row
 from models.time import Time
 
@@ -70,7 +75,7 @@ class DropoffType(Enum):
 class Departure:
     '''An association between a trip and a stop'''
     
-    context: Context
+    system: System
     trip_id: str
     sequence: int
     stop_id: str
@@ -94,17 +99,22 @@ class Departure:
         timepoint = row['timepoint'] == 1
         distance = row['distance']
         headsign = row['headsign']
-        return cls(context, trip_id, sequence, stop_id, time, pickup_type, dropoff_type, timepoint, distance, headsign)
+        return cls(context.system, trip_id, sequence, stop_id, time, pickup_type, dropoff_type, timepoint, distance, headsign)
+    
+    @property
+    def context(self):
+        '''The context for this system'''
+        return self.system.context
     
     @property
     def stop(self):
         '''Returns the stop associated with this departure'''
-        return self.context.system.get_stop(stop_id=self.stop_id)
+        return self.system.get_stop(stop_id=self.stop_id)
     
     @property
     def trip(self):
         '''Returns the trip associated with this departure'''
-        return self.context.system.get_trip(self.trip_id)
+        return self.system.get_trip(self.trip_id)
     
     @property
     def pickup_only(self):

--- a/models/order.py
+++ b/models/order.py
@@ -1,15 +1,15 @@
 
 from dataclasses import dataclass, field
 
+from models.agency import Agency
 from models.bus import Bus
-from models.context import Context
 from models.model import Model
 
 @dataclass(slots=True)
 class Order:
     '''A range of buses of a specific model ordered in a specific year'''
     
-    context: Context
+    agency: Agency
     model: Model
     low: int
     high: int
@@ -21,14 +21,19 @@ class Order:
     size: int = field(init=False)
     
     @property
+    def context(self):
+        '''The context for this order'''
+        return self.agency.context
+    
+    @property
     def first_bus(self):
         '''The first bus in the order'''
-        return Bus(self.context, self.low, self)
+        return Bus(self.agency, self.low, self)
     
     @property
     def last_bus(self):
         '''The last bus in the order'''
-        return Bus(self.context, self.high, self)
+        return Bus(self.agency, self.high, self)
     
     def __post_init__(self):
         self.size = (self.high - self.low) + 1 - len(self.exceptions)
@@ -54,7 +59,7 @@ class Order:
     def __iter__(self):
         for number in range(self.low, self.high + 1):
             if number not in self.exceptions:
-                yield Bus(self.context, number, self)
+                yield Bus(self.agency, number, self)
     
     def __contains__(self, bus_number):
         if bus_number in self.exceptions:
@@ -68,7 +73,7 @@ class Order:
         previous_bus_number = bus_number - 1
         if previous_bus_number in self.exceptions:
             return self.previous_bus(previous_bus_number)
-        return Bus(self.context, previous_bus_number, self)
+        return Bus(self.agency, previous_bus_number, self)
     
     def next_bus(self, bus_number):
         '''The next bus following the given bus number'''
@@ -77,4 +82,4 @@ class Order:
         next_bus_number = bus_number + 1
         if next_bus_number in self.exceptions:
             return self.next_bus(next_bus_number)
-        return Bus(self.context, next_bus_number, self)
+        return Bus(self.agency, next_bus_number, self)

--- a/models/overview.py
+++ b/models/overview.py
@@ -1,4 +1,10 @@
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.system import System
+
 from dataclasses import dataclass
 
 from models.bus import Bus
@@ -13,10 +19,10 @@ class Overview:
     
     bus: Bus
     first_seen_date: Date
-    first_seen_context: Context
+    first_seen_system: System
     first_record: Record | None
     last_seen_date: Date
-    last_seen_context: Context
+    last_seen_system: System
     last_record: Record | None
     
     @classmethod
@@ -30,4 +36,14 @@ class Overview:
         last_seen_context = row.context('last_seen_system_id')
         last_seen_date = Date.parse(row['last_seen_date'], last_seen_context.timezone)
         last_record = row.obj('last_record', Record.from_db)
-        return cls(bus, first_seen_date, first_seen_context, first_record, last_seen_date, last_seen_context, last_record)
+        return cls(bus, first_seen_date, first_seen_context.system, first_record, last_seen_date, last_seen_context.system, last_record)
+    
+    @property
+    def first_seen_context(self):
+        '''The first seen context for this overview'''
+        return self.first_seen_system.context
+    
+    @property
+    def last_seen_context(self):
+        '''The last seen context for this overview'''
+        return self.last_seen_system.context

--- a/models/point.py
+++ b/models/point.py
@@ -1,14 +1,19 @@
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.system import System
+
 from dataclasses import dataclass
 
-from models.context import Context
 from models.row import Row
 
 @dataclass(slots=True)
 class Point:
     '''The coordinates and sequence number of a single point in a line'''
     
-    context: Context
+    system: System
     shape_id: str
     sequence: int
     lat: float
@@ -22,7 +27,12 @@ class Point:
         sequence = row['sequence']
         lat = row['lat']
         lon = row['lon']
-        return cls(context, shape_id, sequence, lat, lon)
+        return cls(context.system, shape_id, sequence, lat, lon)
+    
+    @property
+    def context(self):
+        '''The context for this point'''
+        return self.system.context
     
     def __eq__(self, other):
         return self.sequence == other.sequence

--- a/models/record.py
+++ b/models/record.py
@@ -1,8 +1,13 @@
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.system import System
+
 from dataclasses import dataclass, field
 
 from models.bus import Bus
-from models.context import Context
 from models.date import Date
 from models.row import Row
 from models.time import Time
@@ -11,7 +16,7 @@ from models.time import Time
 class Record:
     '''Information about a bus' history on a specific date'''
     
-    context: Context
+    system: System
     id: int
     bus: Bus
     date: Date
@@ -37,7 +42,12 @@ class Record:
         end_time = Time.parse(row['end_time'], context.timezone, context.accurate_seconds)
         first_seen = Time.parse(row['first_seen'], context.timezone, context.accurate_seconds)
         last_seen = Time.parse(row['last_seen'], context.timezone, context.accurate_seconds)
-        return cls(context, id, bus, date, block_id, route_numbers, start_time, end_time, first_seen, last_seen)
+        return cls(context.system, id, bus, date, block_id, route_numbers, start_time, end_time, first_seen, last_seen)
+    
+    @property
+    def context(self):
+        '''The context for this record'''
+        return self.system.context
     
     @property
     def total_minutes(self):
@@ -56,7 +66,7 @@ class Record:
     @property
     def block(self):
         '''Returns the block associated with this record'''
-        return self.context.system.get_block(self.block_id)
+        return self.system.get_block(self.block_id)
     
     @property
     def is_available(self):
@@ -66,7 +76,7 @@ class Record:
     @property
     def routes(self):
         if self.is_available:
-            return [self.context.system.get_route(number=n) for n in self.route_numbers]
+            return [self.system.get_route(number=n) for n in self.route_numbers]
         return self.route_numbers
     
     def __post_init__(self):

--- a/models/route.py
+++ b/models/route.py
@@ -1,4 +1,10 @@
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.system import System
+
 from dataclasses import dataclass, field
 from random import randint, seed
 from math import sqrt
@@ -20,7 +26,7 @@ import repositories
 class Route:
     '''A list of trips that follow a regular pattern with a given number'''
     
-    context: Context
+    system: System
     id: str
     number: str
     name: str
@@ -38,7 +44,12 @@ class Route:
         name = row['name']
         colour = row['colour'] or generate_colour(context, number)
         text_colour = row['text_colour'] or 'FFFFFF'
-        return cls(context, id, number, name, colour, text_colour)
+        return cls(context.system, id, number, name, colour, text_colour)
+    
+    @property
+    def context(self):
+        '''The context for this route'''
+        return self.system.context
     
     @property
     def url_id(self):
@@ -55,7 +66,7 @@ class Route:
     @property
     def cache(self):
         '''Returns the cache for this route'''
-        return self.context.system.get_route_cache(self)
+        return self.system.get_route_cache(self)
     
     @property
     def trips(self):
@@ -111,8 +122,8 @@ class Route:
         json = []
         for point in self.indicator_points:
             json.append({
-                'system_id': self.context.system_id,
-                'system_name': str(self.context.system),
+                'system_id': self.system.id,
+                'system_name': str(self.system),
                 'agency_id': self.context.agency_id,
                 'number': self.number,
                 'name': self.name.replace("'", '&apos;'),

--- a/models/service.py
+++ b/models/service.py
@@ -1,4 +1,10 @@
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.system import System
+
 from dataclasses import dataclass
 from enum import IntEnum
 
@@ -38,7 +44,7 @@ class ServiceException:
 class Service:
     '''A set of dates when a transit service is operating'''
     
-    context: Context
+    system: System
     id: int
     schedule: Schedule
     
@@ -67,7 +73,7 @@ class Service:
         dates.difference_update(removed_dates)
         
         schedule = Schedule(dates, date_range)
-        return cls(context, id, schedule)
+        return cls(context.system, id, schedule)
     
     @classmethod
     def combine(cls, context: Context, id, exceptions):
@@ -75,7 +81,12 @@ class Service:
         dates = {e.date for e in exceptions if e.type == ServiceExceptionType.INCLUDED}
         date_range = DateRange(min(dates), max(dates))
         schedule = Schedule(dates, date_range)
-        return cls(context, id, schedule)
+        return cls(context.system, id, schedule)
+    
+    @property
+    def context(self):
+        '''The context for this service'''
+        return self.system.context
     
     def __hash__(self):
         return hash(self.id)

--- a/models/transfer.py
+++ b/models/transfer.py
@@ -1,4 +1,10 @@
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.system import System
+
 from dataclasses import dataclass
 
 from models.bus import Bus
@@ -13,8 +19,18 @@ class Transfer:
     id: int
     bus: Bus
     date: Date
-    old_context: Context
-    new_context: Context
+    old_system: System
+    new_system: System
+    
+    @property
+    def old_context(self):
+        '''The old context for this transfer'''
+        return self.old_system.context
+    
+    @property
+    def new_context(self):
+        '''The new context for this transfer'''
+        return self.new_system.context
     
     @classmethod
     def from_db(cls, row: Row):
@@ -25,4 +41,4 @@ class Transfer:
         old_context = row.context('old_system_id')
         new_context = row.context('new_system_id')
         date = Date.parse(row['date'], new_context.timezone)
-        return cls(id, bus, date, old_context, new_context)
+        return cls(id, bus, date, old_context.system, new_context.system)

--- a/repositories/impl/order.py
+++ b/repositories/impl/order.py
@@ -21,7 +21,6 @@ class OrderRepository:
         with open(f'./static/orders.json', 'r') as file:
             for (agency_id, agency_values) in json.load(file).items():
                 agency = repositories.agency.find(agency_id)
-                context = Context(agency=agency)
                 agency_orders = []
                 for (model_id, model_values) in agency_values.items():
                     model = repositories.model.find(model_id)
@@ -32,7 +31,7 @@ class OrderRepository:
                             del values['number']
                         if 'exceptions' in values:
                             values['exceptions'] = set(values['exceptions'])
-                        agency_orders.append(Order(context, model, **values))
+                        agency_orders.append(Order(agency, model, **values))
                 self.orders[agency_id] = agency_orders
     
     def find(self, context: Context, bus) -> Order | None:

--- a/services/impl/gtfs.py
+++ b/services/impl/gtfs.py
@@ -70,7 +70,7 @@ class GTFSService:
         context.system.routes = {r.id: r for r in routes}
         context.system.routes_by_number = {r.number: r for r in routes}
         
-        context.system.blocks = {id: Block(context, id, trips) for id, trips in block_trips.items()}
+        context.system.blocks = {id: Block(context.system, id, trips) for id, trips in block_trips.items()}
         
         context.system.gtfs_loaded = True
     
@@ -177,11 +177,11 @@ def combine_sheets(context: Context, services):
             if previous_services.issubset(current_services) or current_services.issubset(previous_services):
                 date_range = DateRange.combine([previous_sheet.schedule.date_range, date_range])
                 new_services = {s for s in services if s.schedule.date_range.overlaps(date_range)}
-                sheets[-1] = Sheet(context, new_services, date_range)
+                sheets[-1] = Sheet(context.system, new_services, date_range)
             else:
-                sheets.append(Sheet(context, date_range_services, date_range))
+                sheets.append(Sheet(context.system, date_range_services, date_range))
         else:
-            sheets.append(Sheet(context, date_range_services, date_range))
+            sheets.append(Sheet(context.system, date_range_services, date_range))
     final_sheets = []
     for sheet in sheets:
         if final_sheets:
@@ -189,7 +189,7 @@ def combine_sheets(context: Context, services):
             if len(previous_sheet.schedule.date_range) <= 7 or len(sheet.schedule.date_range) <= 7:
                 date_range = DateRange.combine([previous_sheet.schedule.date_range, sheet.schedule.date_range])
                 combined_services = previous_sheet.services.union(sheet.services)
-                final_sheets[-1] = Sheet(context, combined_services, date_range)
+                final_sheets[-1] = Sheet(context.system, combined_services, date_range)
             else:
                 final_sheets.append(sheet)
         else:


### PR DESCRIPTION
When I first added contexts a few weeks ago, I updated models as part of the change to use that instead of just the system/agency. Shortly after merging, before the changes were deployed, I realized that this change actually had a noticeable impact on memory usage, since each route/stop/trip/etc now used a brand new context instance, rather than holding a reference to a single global system/agency. With the data that's available at the time of writing this, memory usage jumps from about 540MB to 570MB - not too big in the grand scheme of things, but also not nothing. This would also be much more noticeable if ported to ABTracker which of course has a lot more data in memory. Because of this difference, I opted to delay releasing the changes and instead started work on general memory improvements. Although I'm definitely making progress on that, I also would prefer to unblock the main branch again asap.

Enter: this MR. Basically I'm just reverting the changes to the models, so they directly reference the system/agency again. To avoid breaking anything and keep stuff straightforward, models now also have a calculated `context` property to return the appropriate context when needed. With this change, we're actually back down to even less memory than before, sitting at just under 530MB.

Down the road when the general memory improvements are completed, this change can be reverted _again_ to re-simplify the models, since everything will be more ephemeral and no longer retained in memory anyways.