### PR TITLE
Add record warnings to first/last seen history pages

### DIFF
--- a/style/dark.css
+++ b/style/dark.css
@@ -147,6 +147,10 @@
     background-color: #003B00;
 }
 
+.record-warnings {
+    --image-color: #DC5050;
+}
+
 .very-ahead {
     --adherence-background: #FF0007;
 }

--- a/style/light.css
+++ b/style/light.css
@@ -123,6 +123,10 @@
     background-color: #509F5E;
 }
 
+.record-warnings {
+    --image-color: #DC5050;
+}
+
 .very-ahead {
     --adherence-background: #FD393E;
 }

--- a/style/themes/bc-hydro.css
+++ b/style/themes/bc-hydro.css
@@ -383,10 +383,6 @@ table tr.table-button:hover {
     background-color: #61C315;
 }
 
-.record-warnings {
-    --image-color: #FF0000;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;

--- a/style/themes/bc-transit-classic.css
+++ b/style/themes/bc-transit-classic.css
@@ -387,10 +387,6 @@ table tr.table-button:hover {
     background-color: #E20000;
 }
 
-.record-warnings {
-    --image-color: #FF0000;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;

--- a/style/themes/bc-transit.dark.css
+++ b/style/themes/bc-transit.dark.css
@@ -396,10 +396,6 @@ table tr.table-button:hover {
     background-color: #2247B7;
 }
 
-.record-warnings {
-    --image-color: #FF0000;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #393939;

--- a/style/themes/bc-transit.light.css
+++ b/style/themes/bc-transit.light.css
@@ -387,10 +387,6 @@ table tr.table-button:hover {
     background-color: #365CCB;
 }
 
-.record-warnings {
-    --image-color: #FF0000;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -367,10 +367,6 @@ table tr.table-button:hover {
     background-color: #165ABE;
 }
 
-.record-warnings {
-    --image-color: #FF0000;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -389,10 +389,6 @@ table tr.table-button:hover {
     background-color: #AB0000;
 }
 
-.record-warnings {
-    --image-color: #FF0000;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -369,10 +369,6 @@ table tr.table-button:hover {
     background-color: #AAAAAA;
 }
 
-.record-warnings {
-    --image-color: #FF0000;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -396,10 +396,6 @@ table tr.table-button:hover {
     background-color: #E56100;
 }
 
-.record-warnings {
-    --image-color: #FF0000;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #393939;

--- a/style/themes/pride.dark.css
+++ b/style/themes/pride.dark.css
@@ -384,10 +384,6 @@ table tr.table-button:hover {
     background-color: #000000;
 }
 
-.record-warnings {
-    --image-color: #FF0000;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;

--- a/style/themes/pride.light.css
+++ b/style/themes/pride.light.css
@@ -382,10 +382,6 @@ table tr.table-button:hover {
     background-color: #000000;
 }
 
-.record-warnings {
-    --image-color: #FF0000;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -523,10 +523,6 @@ table tr.table-button:hover {
     text-shadow: none;
 }
 
-.record-warnings {
-    --image-color: #FF0000;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -383,10 +383,6 @@ table tr.table-button:hover {
     background-color: #C7743B;
 }
 
-.record-warnings {
-    --image-color: #FF0000;
-}
-
 .route {
     color: #FFFFFF;
     border-color: #FFFFFF;

--- a/views/pages/block/history.tpl
+++ b/views/pages/block/history.tpl
@@ -81,8 +81,8 @@
                                     <tr>
                                         <td>{{ record.date.format_day() }}</td>
                                         <td>
-                                            <div class="column">
-                                                <div class="row">
+                                            <div class="column stretch">
+                                                <div class="row space-between">
                                                     % include('components/bus')
                                                     % include('components/record_warnings')
                                                 </div>

--- a/views/pages/bus/history.tpl
+++ b/views/pages/bus/history.tpl
@@ -118,8 +118,8 @@
                                         </td>
                                         <td class="desktop-only">{{ record.context }}</td>
                                         <td>
-                                            <div class="column">
-                                                <div class="row">
+                                            <div class="column stretch">
+                                                <div class="row space-between">
                                                     % if record.is_available:
                                                         % block = record.block
                                                         <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>

--- a/views/pages/bus/overview.tpl
+++ b/views/pages/bus/overview.tpl
@@ -363,8 +363,8 @@
                                     </td>
                                     <td class="desktop-only">{{ record.context }}</td>
                                     <td>
-                                        <div class="column">
-                                            <div class="row">
+                                        <div class="column stretch">
+                                            <div class="row space-between">
                                                 % if record.is_available:
                                                     % block = record.block
                                                     <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>

--- a/views/pages/history/first_seen.tpl
+++ b/views/pages/history/first_seen.tpl
@@ -10,91 +10,109 @@
     </div>
 </div>
 
-% if overviews:
-    <table>
-        <thead>
-            <tr>
-                <th>Date</th>
-                <th>Bus</th>
-                <th class="desktop-only">Model</th>
-                % if not context.system:
-                    <th class="non-mobile">System</th>
+<div class="container">
+    <div class="section">
+        <div class="content">
+            % if overviews:
+                % if [o for o in overviews if o.first_record and o.first_record.warnings]:
+                    <p>
+                        <span>Entries with a</span>
+                        <span class="record-warnings">
+                            % include('components/svg', name='status/warning')
+                        </span>
+                        <span>may be accidental logins.</span>
+                    </p>
                 % end
-                <th>Block</th>
-                <th class="desktop-only">Routes</th>
-            </tr>
-        </thead>
-        <tbody>
-            % last_date = None
-            % for overview in overviews:
-                % record = overview.first_record
-                % bus = record.bus
-                % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
-                    <tr class="header">
-                        <td colspan="6">{{ record.date.format_month() }}</td>
-                        <tr class="display-none"></tr>
-                    </tr>
-                % end
-                % last_date = record.date
-                <tr>
-                    <td>
-                        <div class="column">
-                            {{ record.date.format_day() }}
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>Bus</th>
+                            <th class="desktop-only">Model</th>
                             % if not context.system:
-                                <span class="mobile-only smaller-font">{{ record.context }}</span>
+                                <th class="non-mobile">System</th>
                             % end
-                        </div>
-                    </td>
-                    <td>
-                        <div class="column">
-                            % include('components/bus')
-                            <span class="non-desktop smaller-font">
-                                % include('components/order', order=bus.order)
-                            </span>
-                        </div>
-                    </td>
-                    <td class="desktop-only">
-                        % include('components/order', order=bus.order)
-                    </td>
+                            <th>Block</th>
+                            <th class="desktop-only">Routes</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        % last_date = None
+                        % for overview in overviews:
+                            % record = overview.first_record
+                            % bus = record.bus
+                            % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
+                                <tr class="header">
+                                    <td colspan="6">{{ record.date.format_month() }}</td>
+                                    <tr class="display-none"></tr>
+                                </tr>
+                            % end
+                            % last_date = record.date
+                            <tr>
+                                <td>
+                                    <div class="column">
+                                        {{ record.date.format_day() }}
+                                        % if not context.system:
+                                            <span class="mobile-only smaller-font">{{ record.context }}</span>
+                                        % end
+                                    </div>
+                                </td>
+                                <td>
+                                    <div class="column">
+                                        % include('components/bus')
+                                        <span class="non-desktop smaller-font">
+                                            % include('components/order', order=bus.order)
+                                        </span>
+                                    </div>
+                                </td>
+                                <td class="desktop-only">
+                                    % include('components/order', order=bus.order)
+                                </td>
+                                % if not context.system:
+                                    <td class="non-mobile">{{ record.context }}</td>
+                                % end
+                                <td>
+                                    <div class="column">
+                                        <div class="row">
+                                            % if record.is_available:
+                                                % block = record.block
+                                                <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
+                                            % else:
+                                                <span>{{ record.block_id }}</span>
+                                            % end
+                                            % include('components/record_warnings')
+                                        </div>
+                                        <div class="non-desktop">
+                                            % include('components/route_list', routes=record.routes)
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="desktop-only">
+                                    % include('components/route_list', routes=record.routes)
+                                </td>
+                            </tr>
+                        % end
+                    </tbody>
+                </table>
+            % else:
+                <div class="placeholder">
                     % if not context.system:
-                        <td class="non-mobile">{{ record.context }}</td>
-                    % end
-                    <td>
-                        <div class="column">
-                            % if record.is_available:
-                                % block = record.block
-                                <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
-                            % else:
-                                <span>{{ record.block_id }}</span>
-                            % end
-                            <div class="non-desktop">
-                                % include('components/route_list', routes=record.routes)
-                            </div>
+                        <h3>No vehicle history found</h3>
+                        <p>Something has probably gone terribly wrong if you're seeing this.</p>
+                    % elif not context.realtime_enabled:
+                        <h3>{{ context }} realtime information is not supported</h3>
+                        <p>You can browse schedule data using the links above, or choose a different system.</p>
+                        <div class="non-desktop">
+                            % include('components/systems')
                         </div>
-                    </td>
-                    <td class="desktop-only">
-                        % include('components/route_list', routes=record.routes)
-                    </td>
-                </tr>
+                    % else:
+                        <h3>No {{ context }} buses have been recorded</h3>
+                        <p>Please check again later!</p>
+                    % end
+                </div>
             % end
-        </tbody>
-    </table>
-% else:
-    <div class="placeholder">
-        % if not context.system:
-            <h3>No vehicle history found</h3>
-            <p>Something has probably gone terribly wrong if you're seeing this.</p>
-        % elif not context.realtime_enabled:
-            <h3>{{ context }} realtime information is not supported</h3>
-            <p>You can browse schedule data using the links above, or choose a different system.</p>
-            <div class="non-desktop">
-                % include('components/systems')
-            </div>
-        % else:
-            <h3>No {{ context }} buses have been recorded</h3>
-            <p>Please check again later!</p>
-        % end
+        </div>
     </div>
-% end
+</div>
 
 % include('components/top_button')

--- a/views/pages/history/first_seen.tpl
+++ b/views/pages/history/first_seen.tpl
@@ -72,8 +72,8 @@
                                     <td class="non-mobile">{{ record.context }}</td>
                                 % end
                                 <td>
-                                    <div class="column">
-                                        <div class="row">
+                                    <div class="column stretch">
+                                        <div class="row space-between">
                                             % if record.is_available:
                                                 % block = record.block
                                                 <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -115,6 +115,15 @@
                     % known_overviews = [o for o in overviews if o.bus.order]
                     % unknown_overviews = [o for o in overviews if not o.bus.order]
                     % orders = sorted({o.bus.order for o in known_overviews})
+                    % if [o for o in overviews if o.last_record and o.last_record.warnings]:
+                        <p>
+                            <span>Entries with a</span>
+                            <span class="record-warnings">
+                                % include('components/svg', name='status/warning')
+                            </span>
+                            <span>may be accidental logins.</span>
+                        </p>
+                    % end
                     <table>
                         <thead>
                             <tr>
@@ -159,12 +168,15 @@
                                         % end
                                         <td>
                                             <div class="column">
-                                                % if record.is_available:
-                                                    % block = record.block
-                                                    <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
-                                                % else:
-                                                    <span>{{ record.block_id }}</span>
-                                                % end
+                                                <div class="row">
+                                                    % if record.is_available:
+                                                        % block = record.block
+                                                        <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
+                                                    % else:
+                                                        <span>{{ record.block_id }}</span>
+                                                    % end
+                                                    % include('components/record_warnings')
+                                                </div>
                                                 <div class="non-desktop">
                                                     % include('components/route_list', routes=record.routes)
                                                 </div>
@@ -208,12 +220,15 @@
                                         % end
                                         <td>
                                             <div class="column">
-                                                % if record.is_available:
-                                                    % block = record.block
-                                                    <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
-                                                % else:
-                                                    <span>{{ record.block_id }}</span>
-                                                % end
+                                                <div class="row">
+                                                    % if record.is_available:
+                                                        % block = record.block
+                                                        <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
+                                                    % else:
+                                                        <span>{{ record.block_id }}</span>
+                                                    % end
+                                                    % include('components/record_warnings')
+                                                </div>
                                                 <div class="non-desktop">
                                                     % include('components/route_list', routes=record.routes)
                                                 </div>

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -168,7 +168,7 @@
                                         % end
                                         <td>
                                             <div class="column">
-                                                <div class="row">
+                                                <div class="row space-between">
                                                     % if record.is_available:
                                                         % block = record.block
                                                         <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
@@ -219,8 +219,8 @@
                                             <td class="non-mobile">{{ record.context }}</td>
                                         % end
                                         <td>
-                                            <div class="column">
-                                                <div class="row">
+                                            <div class="column stretch">
+                                                <div class="row space-between">
                                                     % if record.is_available:
                                                         % block = record.block
                                                         <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>

--- a/views/pages/trip/history.tpl
+++ b/views/pages/trip/history.tpl
@@ -88,8 +88,8 @@
                                     <tr>
                                         <td>{{ record.date.format_day() }}</td>
                                         <td>
-                                            <div class="column">
-                                                <div class="row">
+                                            <div class="column stretch">
+                                                <div class="row space-between">
                                                     % include('components/bus')
                                                     % include('components/record_warnings')
                                                 </div>


### PR DESCRIPTION
For a long time we've supported warnings on the history pages for buses, indicating if a login was potentially a mistake. However the main history page for all buses does not have this feature, making it more likely for someone to think a bus' first/last login was real even if it wasn't. For example, the First Seen page shows 7011 and 7500 as first logging in June/May when that isn't actually true.

<img width="955" alt="Screenshot 2025-07-05 at 00 42 29" src="https://github.com/user-attachments/assets/4439563d-44dc-4c4a-9096-89b0972e301a" />

It's a simple change to add warnings to these pages too, making it easier to identify potential false logins without having to view the bus history directly. There is a slight difference between the pages as the Last Seen records will change regularly so warnings may come and go, whereas on the First Seen page if a record has a warning it will continue to exist forever (unless we change the warning criteria or tamper with the bus' history in the database).

<img width="779" alt="Screenshot 2025-07-05 at 00 42 48" src="https://github.com/user-attachments/assets/8c1fd8ec-4364-4c93-ba89-5fd1bc55cb70" />
<img width="1096" alt="Screenshot 2025-07-05 at 00 42 57" src="https://github.com/user-attachments/assets/ccad49ae-a3bf-43ea-a1f2-e4bfe04720c5" />

(Note: my local data is fairly warning-heavy from me starting and stopping the server a bunch, making many records incomplete. I'm not sure how many first/last records in production will actually show warnings)

The overall change is straightforward - just adding `components/record_warnings` wrapped in a `row` with the block ID, and the optional info text at the top if any records do have warnings. The first login page changes appear more complicated only because of indentation changes from me adding a wrapper `container` to ensure correct spacing for the text.