### PR TITLE
Align bus status icons

### DIFF
--- a/style/devices/desktop.css
+++ b/style/devices/desktop.css
@@ -195,7 +195,7 @@ table th {
     text-decoration: underline;
 }
 
-.bus .number {
+.bus {
     min-width: 38px;
 }
 

--- a/style/devices/desktop.css
+++ b/style/devices/desktop.css
@@ -195,6 +195,10 @@ table th {
     text-decoration: underline;
 }
 
+.bus .number {
+    min-width: 38px;
+}
+
 .button {
     font-size: 12pt;
     vertical-align: middle;

--- a/style/devices/mobile.css
+++ b/style/devices/mobile.css
@@ -202,6 +202,10 @@ table th {
     --image-size: 32px;
 }
 
+.bus .number {
+    min-width: 34px;
+}
+
 .button {
     font-size: 14pt;
     overflow: hidden;

--- a/style/devices/mobile.css
+++ b/style/devices/mobile.css
@@ -202,7 +202,7 @@ table th {
     --image-size: 32px;
 }
 
-.bus .number {
+.bus {
     min-width: 34px;
 }
 

--- a/style/devices/tablet.css
+++ b/style/devices/tablet.css
@@ -170,7 +170,7 @@ table th {
     --image-size: 28px;
 }
 
-.bus .number {
+.bus {
     min-width: 38px;
 }
 

--- a/style/devices/tablet.css
+++ b/style/devices/tablet.css
@@ -170,6 +170,10 @@ table th {
     --image-size: 28px;
 }
 
+.bus .number {
+    min-width: 38px;
+}
+
 .button {
     font-size: 14pt;
     overflow: hidden;

--- a/views/components/bus.tpl
+++ b/views/components/bus.tpl
@@ -1,8 +1,8 @@
 <div class="bus">
     % if bus.is_known and get('enable_link', True):
-        <a href="{{ get_url(context, 'bus', bus) }}">{{ bus }}</a>
+        <a class="number" href="{{ get_url(context, 'bus', bus) }}">{{ bus }}</a>
     % else:
-        <div>{{ bus }}</div>
+        <div class="number">{{ bus }}</div>
     % end
     % decoration = bus.find_decoration()
     % if decoration and decoration.enabled:

--- a/views/components/bus.tpl
+++ b/views/components/bus.tpl
@@ -1,8 +1,8 @@
 <div class="bus">
     % if bus.is_known and get('enable_link', True):
-        <a class="number" href="{{ get_url(context, 'bus', bus) }}">{{ bus }}</a>
+        <a href="{{ get_url(context, 'bus', bus) }}">{{ bus }}</a>
     % else:
-        <div class="number">{{ bus }}</div>
+        <div>{{ bus }}</div>
     % end
     % decoration = bus.find_decoration()
     % if decoration and decoration.enabled:


### PR DESCRIPTION
Added a min-width to bus numbers to make the occupancy and adherence icons align better. In rare cases where the bus number is longer, such as when there is a decoration, the icons will still be pushed over to make space.

<img width="1241" height="755" alt="Screenshot 2025-07-19 at 14 17 01" src="https://github.com/user-attachments/assets/487ba375-38fe-4182-b32e-8087db40f6bb" />
<img width="328" height="392" alt="Screenshot 2025-07-19 at 14 22 37" src="https://github.com/user-attachments/assets/6b8d68e3-894a-4911-94db-82e0a3cf5a23" />
