### PR TITLE
Show next stop for NIS buses

### DIFF
--- a/views/pages/block/overview.tpl
+++ b/views/pages/block/overview.tpl
@@ -276,26 +276,41 @@
                                 <td class="non-mobile">
                                     % include('components/year_model', year_model=bus.year_model)
                                 </td>
-                                % if position and position.trip:
+                                % if position:
+                                    % trip = position.trip
                                     % stop = position.stop
-                                    <td>
-                                        <div class="column">
-                                            % include('components/headsign', departure=position.departure, trip=position.trip)
-                                            <div class="non-desktop smaller-font">
-                                                Trip:
-                                                % include('components/trip', include_tooltip=False, trip=position.trip)
-                                            </div>
-                                            % if stop:
-                                                <div class="mobile-only smaller-font">
-                                                    <span class="align-middle">Next Stop:</span>
-                                                    % include('components/stop')
+                                    % if trip:
+                                        <td>
+                                            <div class="column">
+                                                % include('components/headsign', departure=position.departure, trip=position.trip)
+                                                <div class="non-desktop smaller-font">
+                                                    Trip:
+                                                    % include('components/trip', include_tooltip=False, trip=position.trip)
                                                 </div>
-                                            % end
-                                        </div>
-                                    </td>
-                                    <td class="desktop-only">
-                                        % include('components/trip', include_tooltip=False, trip=position.trip)
-                                    </td>
+                                                % if stop:
+                                                    <div class="mobile-only smaller-font">
+                                                        <span class="align-middle">Next Stop:</span>
+                                                        % include('components/stop')
+                                                    </div>
+                                                % end
+                                            </div>
+                                        </td>
+                                        <td class="desktop-only">
+                                            % include('components/trip', include_tooltip=False, trip=position.trip)
+                                        </td>
+                                    % else:
+                                        <td colspan="2">
+                                            <div class="column">
+                                                <div class="lighter-text">Not In Service</div>
+                                                % if stop:
+                                                    <div class="mobile-only smaller-font">
+                                                        <span class="align-middle">Next Stop:</span>
+                                                        % include('components/stop')
+                                                    </div>
+                                                % end
+                                            </div>
+                                        </td>
+                                    % end
                                     <td class="non-mobile">
                                         % include('components/stop')
                                     </td>

--- a/views/pages/bus/map.tpl
+++ b/views/pages/bus/map.tpl
@@ -29,6 +29,6 @@
     % end
 % else:
     <div class="placeholder">
-        <h3>Not in service</h3>
+        <h3>Not In Service</h3>
     </div>
 % end

--- a/views/pages/bus/overview.tpl
+++ b/views/pages/bus/overview.tpl
@@ -41,55 +41,54 @@
                 % include('components/toggle')
             </div>
             <div class="content">
-                % if not position:
-                    <div class="info-box">
-                        <div class="section">
-                            <h3>Not in service</h3>
-                        </div>
-                        <div class="row section">
-                            <div class="name">Last Seen</div>
-                            <div class="value">
-                                % if overview:
-                                    % last_seen = overview.last_seen_date
-                                    % if last_seen.is_today:
-                                        <div>Today</div>
-                                    % else:
-                                        <div>{{ last_seen.format_long() }}</div>
-                                        <div class="smaller-font">{{ last_seen.format_since() }}</div>
-                                    % end
+                % if position:
+                    % trip = position.trip
+                    % if trip:
+                        % include('components/map', map_position=position, map_trip=trip, map_departures=trip.find_departures(), zoom_trips=False, zoom_departures=False)
+                    % else:
+                        % include('components/map', map_position=position)
+                    % end
+                % else:
+                    % trip = None
+                % end
+                
+                <div class="info-box">
+                    <div class="section">
+                        % if position and trip:
+                            <div class="row">
+                                % include('components/adherence', adherence=position.adherence, size='large')
+                                % departure = position.departure
+                                % if departure and departure.headsign:
+                                    <h3>{{ departure }}</h3>
                                 % else:
-                                    <div class="lighter-text">Never</div>
+                                    <h3>{{ trip }}</h3>
                                 % end
                             </div>
-                        </div>
-                        % if overview:
-                            <div class="row section">
-                                <div class="name">System</div>
-                                <div class="value">
-                                    <a href="{{ get_url(overview.last_seen_context) }}">{{ overview.last_seen_context }}</a>
+                        % else:
+                            <h3>Not In Service</h3>
+                        % end
+                    </div>
+                    % if position:
+                        % stop = position.stop
+                        % if trip:
+                            % route = trip.route
+                            % block = trip.block
+                        % else:
+                            % route = None
+                            % block = None
+                        % end
+                        % if route:
+                            <div class="section">
+                                <div class="row">
+                                    % include('components/route')
+                                    <a href="{{ get_url(route.context, 'routes', route) }}">{{! route.display_name }}</a>
                                 </div>
                             </div>
                         % end
-                    </div>
-                % elif not position.trip:
-                    % include('components/map', map_position=position)
-                    
-                    <div class="info-box">
-                        <div class="section">
-                            <h3>Not in service</h3>
-                        </div>
-                        % last_record = overview.last_record
-                        % if last_record and last_record.date.is_today:
-                            % block = last_record.block
-                            % if block:
-                                % date = Date.today(block.context.timezone)
-                                % end_time = block.get_end_time(date=date)
-                                % if end_time and end_time.is_later:
-                                    <div class="section no-flex">
-                                        % include('components/block_timeline', date=date)
-                                    </div>
-                                % end
-                            % end
+                        % if context.enable_blocks and block:
+                            <div class="section">
+                                % include('components/block_timeline', date=Date.today(block.context.timezone))
+                            </div>
                         % end
                         % if position.timestamp:
                             <div class="row section">
@@ -124,74 +123,7 @@
                                 <div class="value">{{ position.speed }} km/h</div>
                             </div>
                         % end
-                    </div>
-                % else:
-                    % trip = position.trip
-                    % stop = position.stop
-                    % block = trip.block
-                    % route = trip.route
-                    
-                    % include('components/map', map_position=position, map_trip=trip, map_departures=trip.find_departures(), zoom_trips=False, zoom_departures=False)
-                    
-                    <div class="info-box">
-                        <div class="section">
-                            <div class="row">
-                                % include('components/adherence', adherence=position.adherence, size='large')
-                                % departure = position.departure
-                                % if departure and departure.headsign:
-                                    <h3>{{ departure }}</h3>
-                                % else:
-                                    <h3>{{ trip }}</h3>
-                                % end
-                            </div>
-                        </div>
-                        <div class="section">
-                            <div class="row">
-                                % include('components/route')
-                                <a href="{{ get_url(route.context, 'routes', route) }}">{{! route.display_name }}</a>
-                            </div>
-                        </div>
-                        % if context.enable_blocks:
-                            <div class="section">
-                                % include('components/block_timeline', date=Date.today(block.context.timezone))
-                            </div>
-                        % end
-                        % if position.timestamp:
-                            <div class="row section">
-                                <div class="name">Last Update</div>
-                                <div class="value">
-                                    <div id="timestamp"></div>
-                                    <script>
-                                        updateTimestampFunctions.push(function(currentTime) {
-                                            const difference = getDifference(currentTime, originalTimestamp + timestampOffset);
-                                            document.getElementById("timestamp").innerHTML = difference;
-                                        });
-                                    </script>
-                                </div>
-                            </div>
-                        % end
-                        <div class="row section">
-                            <div class="name">System</div>
-                            <div class="value">
-                                <a href="{{ get_url(position.context) }}">{{ position.context }}</a>
-                            </div>
-                        </div>
-                        <div class="row section">
-                            <div class="name">Occupancy</div>
-                            <div class="value">
-                                <div class="row gap-5 center">
-                                    <div>{{ position.occupancy }}</div>
-                                    % include('components/occupancy', occupancy=position.occupancy, size='large')
-                                </div>
-                            </div>
-                        </div>
-                        % if show_speed:
-                            <div class="row section">
-                                <div class="name">Speed</div>
-                                <div class="value">{{ position.speed }} km/h</div>
-                            </div>
-                        % end
-                        % if context.enable_blocks:
+                        % if context.enable_blocks and block:
                             <div class="row section">
                                 <div class="name">Block</div>
                                 <div class="value">
@@ -204,15 +136,17 @@
                                 </div>
                             </div>
                         % end
-                        <div class="row section">
-                            <div class="name">Trip</div>
-                            <div class="value">
-                                % include('components/trip')
-                                % start_time = trip.start_time.format_web(time_format)
-                                % end_time = trip.end_time.format_web(time_format)
-                                <span class="smaller-font">{{ start_time }} - {{ end_time }} ({{ trip.duration }})</span>
+                        % if trip:
+                            <div class="row section">
+                                <div class="name">Trip</div>
+                                <div class="value">
+                                    % include('components/trip')
+                                    % start_time = trip.start_time.format_web(time_format)
+                                    % end_time = trip.end_time.format_web(time_format)
+                                    <span class="smaller-font">{{ start_time }} - {{ end_time }} ({{ trip.duration }})</span>
+                                </div>
                             </div>
-                        </div>
+                        % end
                         % if stop:
                             <div class="row section">
                                 <div class="name">Next Stop</div>
@@ -225,8 +159,33 @@
                                 </div>
                             </div>
                         % end
-                    </div>
-                % end
+                    % else:
+                        <div class="row section">
+                            <div class="name">Last Seen</div>
+                            <div class="value">
+                                % if overview:
+                                    % last_seen = overview.last_seen_date
+                                    % if last_seen.is_today:
+                                        <div>Today</div>
+                                    % else:
+                                        <div>{{ last_seen.format_long() }}</div>
+                                        <div class="smaller-font">{{ last_seen.format_since() }}</div>
+                                    % end
+                                % else:
+                                    <div class="lighter-text">Never</div>
+                                % end
+                            </div>
+                        </div>
+                        % if overview:
+                            <div class="row section">
+                                <div class="name">System</div>
+                                <div class="value">
+                                    <a href="{{ get_url(overview.last_seen_context) }}">{{ overview.last_seen_context }}</a>
+                                </div>
+                            </div>
+                        % end
+                    % end
+                </div>
             </div>
         </div>
         
@@ -308,7 +267,7 @@
                         % include('components/toggle')
                     </div>
                     <div class="content">
-                        % if [d for d in upcoming_departures if d.timepoint]:
+                        % if any(d.timepoint for d in upcoming_departures):
                             <p>Departures in <span class="timing-point">bold</span> are timing points.</p>
                         % end
                         % if position.adherence and position.adherence.value != 0 and not position.adherence.layover:
@@ -360,7 +319,7 @@
             </div>
             <div class="content">
                 % if records:
-                    % if [r for r in records if r.warnings]:
+                    % if any(r.warnings for r in records):
                         <p>
                             <span>Entries with a</span>
                             <span class="record-warnings">

--- a/views/pages/home.tpl
+++ b/views/pages/home.tpl
@@ -162,7 +162,7 @@
                                                             % if position and position.trip:
                                                                 % include('components/headsign', departure=position.departure, trip=position.trip)
                                                             % else:
-                                                                <div class="lighter-text">Not in service</div>
+                                                                <div class="lighter-text">Not In Service</div>
                                                             % end
                                                         </td>
                                                     </tr>

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -149,12 +149,14 @@
                                 % if not context.system:
                                     <th>System</th>
                                 % end
+                                <th>Next Stop</th>
                             </tr>
                         </thead>
                         <tbody>
                             % last_bus = None
                             % for position in no_route_positions:
                                 % bus = position.bus
+                                % stop = position.stop
                                 % order_id = bus.order_id
                                 % if not last_bus:
                                     % same_order = True
@@ -181,6 +183,9 @@
                                     % if not context.system:
                                         <td>{{ position.context }}</td>
                                     % end
+                                    <td>
+                                        % include('components/stop')
+                                    </td>
                                 </tr>
                             % end
                         </tbody>

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -45,6 +45,8 @@
             % last_speed = None
             % for position in sorted(positions, key=lambda p: p.speed, reverse=True):
                 % bus = position.bus
+                % trip = position.trip
+                % stop = position.stop
                 % same_speed = not last_speed or position.speed // 10 == last_speed
                 % last_speed = position.speed // 10
                 <tr class="{{'' if same_speed else 'divider'}}">
@@ -69,10 +71,8 @@
                         <td class="desktop-only">{{ position.context }}</td>
                     % end
                     <td class="desktop-only no-wrap">{{ position.speed }} km/h</td>
-                    % if position.trip:
-                        % trip = position.trip
+                    % if trip:
                         % block = trip.block
-                        % stop = position.stop
                         <td>
                             <div class="column">
                                 % include('components/headsign', departure=position.departure)
@@ -97,17 +97,23 @@
                         <td class="non-mobile">
                             % include('components/trip')
                         </td>
-                        <td class="desktop-only">
-                            % include('components/stop')
-                        </td>
                     % else:
-                        <td colspan="4">
+                        <td colspan="3">
                             <div class="column">
-                                <span class="lighter-text">Not in service</span>
+                                <span class="lighter-text">Not In Service</span>
                                 <span class="non-desktop smaller-font no-wrap">{{ position.speed }} km/h</span>
+                                % if stop:
+                                    <div class="non-desktop smaller-font">
+                                        <span class="align-middle">Next Stop:</span>
+                                        % include('components/stop')
+                                    </div>
+                                % end
                             </div>
                         </td>
                     % end
+                    <td class="desktop-only">
+                        % include('components/stop')
+                    </td>
                 </tr>
             % end
         </tbody>

--- a/views/pages/trip/overview.tpl
+++ b/views/pages/trip/overview.tpl
@@ -254,26 +254,41 @@
                                 <td class="non-mobile">
                                     % include('components/year_model', year_model=bus.year_model)
                                 </td>
-                                % if position and position.trip:
+                                % if position:
+                                    % trip = position.trip
                                     % stop = position.stop
-                                    <td>
-                                        <div class="column">
-                                            % include('components/headsign', departure=position.departure, trip=position.trip)
-                                            <div class="non-desktop smaller-font">
-                                                Trip:
-                                                % include('components/trip', include_tooltip=False, trip=position.trip)
-                                            </div>
-                                            % if stop:
-                                                <div class="mobile-only smaller-font">
-                                                    <span class="align-middle">Next Stop:</span>
-                                                    % include('components/stop')
+                                    % if trip:
+                                        <td>
+                                            <div class="column">
+                                                % include('components/headsign', departure=position.departure, trip=position.trip)
+                                                <div class="non-desktop smaller-font">
+                                                    Trip:
+                                                    % include('components/trip', include_tooltip=False, trip=position.trip)
                                                 </div>
-                                            % end
-                                        </div>
-                                    </td>
-                                    <td class="desktop-only">
-                                        % include('components/trip', include_tooltip=False, trip=position.trip)
-                                    </td>
+                                                % if stop:
+                                                    <div class="mobile-only smaller-font">
+                                                        <span class="align-middle">Next Stop:</span>
+                                                        % include('components/stop')
+                                                    </div>
+                                                % end
+                                            </div>
+                                        </td>
+                                        <td class="desktop-only">
+                                            % include('components/trip', include_tooltip=False, trip=position.trip)
+                                        </td>
+                                    % else:
+                                        <td colspan="2">
+                                            <div class="column">
+                                                <div class="lighter-text">Not In Service</div>
+                                                % if stop:
+                                                    <div class="mobile-only smaller-font">
+                                                        <span class="align-middle">Next Stop:</span>
+                                                        % include('components/stop')
+                                                    </div>
+                                                % end
+                                            </div>
+                                        </td>
+                                    % end
                                     <td class="non-mobile">
                                         % include('components/stop')
                                     </td>

--- a/views/rows/realtime.tpl
+++ b/views/rows/realtime.tpl
@@ -1,6 +1,7 @@
 
 % bus = position.bus
 % trip = position.trip
+% stop = position.stop
 
 <tr>
     <td>
@@ -22,7 +23,6 @@
     % end
     % if trip:
         % block = trip.block
-        % stop = position.stop
         <td>
             <div class="column">
                 % include('components/headsign', departure=position.departure)
@@ -46,10 +46,20 @@
         <td class="non-mobile">
             % include('components/trip')
         </td>
-        <td class="desktop-only">
-            % include('components/stop')
-        </td>
     % else:
-        <td class="lighter-text" colspan="4">Not in service</td>
+        <td colspan="3">
+            <div class="column">
+                <div class="lighter-text">Not In Service</div>
+                % if stop:
+                    <div class="non-desktop smaller-font">
+                        <span class="align-middle">Next Stop:</span>
+                        % include('components/stop')
+                    </div>
+                % end
+            </div>
+        </td>
     % end
+    <td class="desktop-only">
+        % include('components/stop')
+    </td>
 </tr>


### PR DESCRIPTION
Buses can have a next stop in realtime data even if they don't have a valid trip - this is often seen with deadheading. However in most places around the site, the stop is only shown if the trip exists. Now the logic is changed so it can be shown even without a trip.

<img width="1170" height="774" alt="Screenshot 2025-07-27 at 21 45 33" src="https://github.com/user-attachments/assets/901054a5-0328-47f8-be3f-ad89ba28072c" />

A couple other changes have been made:

- There was inconsistency of spelled-out NIS as "Not in service" vs "Not In Service"; this has now been standardized as the latter
- The rendering of the main realtime info box on the bus page was done rather weirdly depending on if the bus had a position, and whether or not that position had a trip. It's now standardized to create the info box once and customize the elements within as needed