### PR TITLE
Fix table borders

### DIFF
--- a/server.py
+++ b/server.py
@@ -21,7 +21,7 @@ import repositories
 import services
 
 # Increase the version to force CSS reload
-VERSION = 58
+VERSION = 59
 
 random = Random()
 

--- a/style/devices/desktop.css
+++ b/style/devices/desktop.css
@@ -228,6 +228,10 @@ table th {
     align-self: stretch;
 }
 
+.sidebar .table-border-wrapper {
+    align-self: stretch;
+}
+
 .smaller-font {
     font-size: 10pt;
 }
@@ -237,6 +241,10 @@ table th {
 }
 
 .tab-button-bar {
+    align-self: flex-start;
+}
+
+.table-border-wrapper {
     align-self: flex-start;
 }
 
@@ -251,6 +259,10 @@ table th {
     }
     
     table {
+        align-self: stretch;
+    }
+    
+    .table-border-wrapper {
         align-self: stretch;
     }
 }

--- a/style/devices/mobile.css
+++ b/style/devices/mobile.css
@@ -293,6 +293,10 @@ table th {
     grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
 }
 
+.table-border-wrapper {
+    width: 100%;
+}
+
 .tablet-only {
     display: none !important;
 }

--- a/style/devices/tablet.css
+++ b/style/devices/tablet.css
@@ -249,6 +249,10 @@ button.compact {
     grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
 }
 
+.table-border-wrapper {
+    width: 100%;
+}
+
 .tab-button {
     flex: 1;
 }

--- a/style/main.css
+++ b/style/main.css
@@ -106,13 +106,13 @@ table {
     border-collapse: collapse;
     border-spacing: 0px;
     empty-cells: show;
-    border-width: 1px;
-    border-style: solid;
+    border: 1px solid var(--table-border);
 }
 
 table td {
     border-width: 0 0 1 0px;
     border-style: solid;
+    border-color: var(--table-border);
     margin: 0px;
     overflow: visible;
     padding: 0.5em 1em;
@@ -123,6 +123,7 @@ table th {
     vertical-align: top;
     border-width: 0 0 1 0px;
     border-style: solid;
+    border-color: var(--table-border);
     margin: 0px;
     overflow: visible;
     padding: 0.5em 1em;
@@ -130,7 +131,6 @@ table th {
 
 table tr.divider {
     border-top-width: 4px;
-    border-top-style: solid;
 }
 
 table tr.header td {
@@ -1502,6 +1502,14 @@ table tr.table-button {
 
 .tab-button.current:hover {
     cursor: default !important;
+}
+
+.table-border-wrapper {
+    border: 1px solid var(--table-border);
+}
+
+.table-border-wrapper table {
+    border-width: 0px;
 }
 
 .timeline {

--- a/style/themes/bc-ferries.dark.css
+++ b/style/themes/bc-ferries.dark.css
@@ -32,6 +32,8 @@
     --status-bar-hover: #001325;
     --status-bar-foreground: #FFFFFF;
     
+    --table-border: #003769;
+    
     --loading-background: #000E1A;
     --loading-foreground: #00284C;
     
@@ -90,10 +92,6 @@ iframe {
     color-scheme: light;
 }
 
-table {
-    border-color: #003769;
-}
-
 table tbody tr:hover {
     background-color: #002241;
 }
@@ -103,14 +101,9 @@ table tbody tr.header {
     color: #FFFFFF;
 }
 
-table td {
-    border-color: #003769;
-}
-
 table th {
     background-color: #003769;
     color: #FFFFFF;
-    border-color: #003769;
 }
 
 table tr {

--- a/style/themes/bc-ferries.light.css
+++ b/style/themes/bc-ferries.light.css
@@ -30,6 +30,8 @@
     --status-bar-hover: #001325;
     --status-bar-foreground: #FFFFFF;
     
+    --table-border: #001325;
+    
     --loading-background: #FFFFFF;
     --loading-foreground: #003769;
     
@@ -80,10 +82,6 @@ input[type="text"]:focus {
     border-color: #001325;
 }
 
-table {
-    border-color: #001325;
-}
-
 table tbody tr:hover {
     background-color: #CEE8FF;
 }
@@ -93,14 +91,9 @@ table tbody tr.header {
     color: #FFFFFF;
 }
 
-table td {
-    border-color: #001325;
-}
-
 table th {
     background-color: #003769;
     color: #FFFFFF;
-    border-color: #001325;
 }
 
 table tr {

--- a/style/themes/bc-hydro.css
+++ b/style/themes/bc-hydro.css
@@ -28,6 +28,8 @@
     --status-bar-hover: #026E6E;
     --status-bar-foreground: #FFFFFF;
     
+    --table-border: #666666;
+    
     --loading-background: #FFFBEF;
     --loading-foreground: #61C315;
     
@@ -74,10 +76,6 @@ input[type="text"]:focus {
     border-color: #347800;
 }
 
-table {
-    border-color: #666666;
-}
-
 table tbody tr:hover {
     background-color: #CBCBCB;
 }
@@ -87,14 +85,9 @@ table tbody tr.header {
     color: #FFFFFF;
 }
 
-table td {
-    border-color: #666666;
-}
-
 table th {
     background-color: #249B9B;
     color: #FFFFFF;
-    border-color: #666666;
 }
 
 table tr {

--- a/style/themes/bc-transit-classic.css
+++ b/style/themes/bc-transit-classic.css
@@ -28,6 +28,8 @@
     --status-bar-hover: #011E58;
     --status-bar-foreground: #FFFFFF;
     
+    --table-border: #666666;
+    
     --loading-background: #FFFFFF;
     --loading-foreground: #E20000;
     
@@ -78,10 +80,6 @@ input[type="text"]:focus {
     border-color: #840000;
 }
 
-table {
-    border-color: #666666;
-}
-
 table tbody tr:hover {
     background-color: #CBCBCB;
 }
@@ -91,14 +89,9 @@ table tbody tr.header {
     color: #FFFFFF;
 }
 
-table td {
-    border-color: #666666;
-}
-
 table th {
     background-color: #023496;
     color: #FFFFFF;
-    border-color: #666666;
 }
 
 table tr {

--- a/style/themes/bc-transit.dark.css
+++ b/style/themes/bc-transit.dark.css
@@ -30,6 +30,8 @@
     --status-bar-hover: #053305;
     --status-bar-foreground: #FFFFFF;
     
+    --table-border: #565656;
+    
     --loading-background: #2F2F2F;
     --loading-foreground: #154E15;
     
@@ -88,10 +90,6 @@ iframe {
     color-scheme: light;
 }
 
-table {
-    border-color: #565656;
-}
-
 table tbody tr:hover {
     background-color: #565656;
 }
@@ -101,14 +99,9 @@ table tbody tr.header {
     color: #FFFFFF;
 }
 
-table td {
-    border-color: #565656;
-}
-
 table th {
     background-color: #276227;
     color: #FFFFFF;
-    border-color: #565656;
 }
 
 table tr {

--- a/style/themes/bc-transit.light.css
+++ b/style/themes/bc-transit.light.css
@@ -28,6 +28,8 @@
     --status-bar-hover: #094409;
     --status-bar-foreground: #FFFFFF;
     
+    --table-border: #666666;
+    
     --loading-background: #FFFFFF;
     --loading-foreground: #48A348;
     
@@ -78,10 +80,6 @@ input[type="text"]:focus {
     border-color: #094409;
 }
 
-table {
-    border-color: #666666;
-}
-
 table tbody tr:hover {
     background-color: #CBCBCB;
 }
@@ -91,14 +89,9 @@ table tbody tr.header {
     color: #FFFFFF;
 }
 
-table td {
-    border-color: #666666;
-}
-
 table th {
     background-color: #48A348;
     color: #FFFFFF;
-    border-color: #666666;
 }
 
 table tr {

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -28,6 +28,8 @@
     --status-bar-hover: #C07A16;
     --status-bar-foreground: #FFFFFF;
     
+    --table-border: #000000;
+    
     --loading-background: #FFFFFF;
     --loading-foreground: #165ABE;
     
@@ -78,10 +80,6 @@ input[type="text"]:focus {
     border-color: #165ABE;
 }
 
-table {
-    border-color: #000000;
-}
-
 table tbody tr:hover {
     background-color: #CBCBCB;
 }
@@ -91,14 +89,9 @@ table tbody tr.header {
     color: #FFFFFF;
 }
 
-table td {
-    border-color: #000000;
-}
-
 table th {
     background-color: #E39B35;
     color: #FFFFFF;
-    border-color: #000000;
 }
 
 table tr {

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -28,6 +28,8 @@
     --status-bar-hover: #7A0000;
     --status-bar-foreground: #FFFFFF;
     
+    --table-border: #69BB65;
+    
     --tooltip-background: #69BB65;
     
     --loading-background: #FFFFFF;
@@ -80,10 +82,6 @@ input[type="text"]:focus {
     border-color: #7A0000;
 }
 
-table {
-    border-color: #69BB65;
-}
-
 table tbody tr:hover {
     background-color: #C3E9C1;
 }
@@ -93,14 +91,9 @@ table tbody tr.header {
     color: #FFFFFF;
 }
 
-table td {
-    border-color: #69BB65;
-}
-
 table th {
     background-color: #D70000;
     color: #FFFFFF;
-    border-color: #69BB65;
 }
 
 table tr {

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -28,6 +28,8 @@
     --status-bar-hover: #DDDDDD;
     --status-bar-foreground: #000000;
     
+    --table-border: #FFFFFF;
+    
     --tooltip-background: #888888;
     
     --loading-background: #FFFFFF;
@@ -76,10 +78,6 @@ input[type="text"]:focus {
     border-color: #AAAAAA;
 }
 
-table {
-    border-color: #FFFFFF;
-}
-
 table tbody tr:hover {
     background-color: #DDDDDD;
 }
@@ -89,13 +87,11 @@ table tbody tr.header {
 }
 
 table td {
-    border-color: #FFFFFF;
     border-width: 0px;
 }
 
 table th {
     background-color: #DDDDDD;
-    border-color: #FFFFFF;
     border-width: 0px;
 }
 

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -30,6 +30,8 @@
     --status-bar-hover: #B24C00;
     --status-bar-foreground: #FFFFFF;
     
+    --table-border: #565656;
+    
     --loading-background: #2F2F2F;
     --loading-foreground: #FF6C00;
     
@@ -88,10 +90,6 @@ iframe {
     color-scheme: light;
 }
 
-table {
-    border-color: #565656;
-}
-
 table tbody tr:hover {
     background-color: #565656;
 }
@@ -101,14 +99,9 @@ table tbody tr.header {
     color: #FFFFFF;
 }
 
-table td {
-    border-color: #565656;
-}
-
 table th {
     background-color: #FF6C00;
     color: #FFFFFF;
-    border-color: #565656;
 }
 
 table tr {

--- a/style/themes/pride.dark.css
+++ b/style/themes/pride.dark.css
@@ -13,6 +13,8 @@
     --status-bar-hover: rgba(0, 0, 0, 0.2);
     --status-bar-foreground: #FFFFFF;
     
+    --table-border: rgba(255, 255, 255, 0.3);
+    
     --tooltip-background: #000000;
     
     --loading-background: rgba(0, 0, 0, 0);
@@ -74,10 +76,6 @@ input[type="text"]:focus {
     border-color: rgba(255, 255, 255, 0.8);
 }
 
-table {
-    border-color: rgba(255, 255, 255, 0.3);
-}
-
 table tbody tr:hover {
     background-color: rgba(0, 0, 0, 0.7);
 }
@@ -86,13 +84,8 @@ table tbody tr.header {
     background-color: rgba(0, 0, 0, 0.8);
 }
 
-table td {
-    border-color: rgba(255, 255, 255, 0.5);
-}
-
 table th {
     background-color: rgba(0, 0, 0, 0.7);
-    border-color: rgba(255, 255, 255, 0.3);
 }
 
 table tr {

--- a/style/themes/pride.light.css
+++ b/style/themes/pride.light.css
@@ -11,6 +11,8 @@
     --status-bar-hover: rgba(0, 0, 0, 0.6);
     --status-bar-foreground: #FFFFFF;
     
+    --table-border: rgba(0, 0, 0, 0.5);
+    
     --tooltip-background: #000000;
     
     --loading-background: rgba(0, 0, 0, 0);
@@ -72,10 +74,6 @@ input[type="text"]:focus {
     border-color: rgba(0, 0, 0, 0.8);
 }
 
-table {
-    border-color: rgba(0, 0, 0, 0.5);
-}
-
 table tbody tr:hover {
     background-color: rgba(255, 255, 255, 0.7);
 }
@@ -84,13 +82,8 @@ table tbody tr.header {
     background-color: rgba(255, 255, 255, 0.8);
 }
 
-table td {
-    border-color: rgba(0, 0, 0, 0.5);
-}
-
 table th {
     background-color: rgba(255, 255, 255, 0.7);
-    border-color: rgba(0, 0, 0, 0.5);
 }
 
 table tr {

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -15,6 +15,8 @@
     --status-bar-hover: #444444;
     --status-bar-foreground: #FFFFFF;
     
+    --table-border: #CCCCCC;
+    
     --tooltip-background: #000000;
     
     --loading-background: #FFFFFF;
@@ -67,7 +69,6 @@ input[type="text"]:focus {
 }
 
 table {
-    border-color: #CCCCCC;
     box-shadow: 0 1px 4px rgb(0 0 0 / 30%);
 }
 
@@ -82,10 +83,6 @@ table tbody tr.header {
     background-image: linear-gradient(#6fACD5,#497BAE);
     text-shadow: 0 -1px 1px #3E6790;
     color: #FFFFFF;
-}
-
-table td {
-    border-color: #CCCCCC;
 }
 
 table th {
@@ -585,6 +582,14 @@ table tr.table-button:hover {
     color: #FFFFFF;
     text-shadow: 0 1px 1px #3373a5;
     background-image: linear-gradient( #5393c5,#6facd5 );
+}
+
+.table-border-wrapper {
+    box-shadow: 0 1px 4px rgb(0 0 0 / 30%);
+}
+
+.table-border-wraper table {
+    box-shadow: unset;
 }
 
 .timeline .now {

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -28,6 +28,8 @@
     --status-bar-hover: #985C0A;
     --status-bar-foreground: #FFFFFF;
     
+    --table-border: #666666;
+    
     --loading-background: #FFFBEF;
     --loading-foreground: #C7743B;
     
@@ -74,10 +76,6 @@ input[type="text"]:focus {
     border-color: #7E3704;
 }
 
-table {
-    border-color: #666666;
-}
-
 table tbody tr:hover {
     background-color: #CBCBCB;
 }
@@ -87,14 +85,9 @@ table tbody tr.header {
     color: #FFFFFF;
 }
 
-table td {
-    border-color: #666666;
-}
-
 table th {
     background-color: #DC9B41;
     color: #FFFFFF;
-    border-color: #666666;
 }
 
 table tr {

--- a/views/pages/admin.tpl
+++ b/views/pages/admin.tpl
@@ -35,102 +35,104 @@
             </div>
             <div class="content">
                 <div class="container">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>System</th>
-                                <th class="non-mobile">Enabled</th>
-                                <th class="non-mobile">Cache</th>
-                                <th>GTFS</th>
-                                <th>Realtime</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            % for region in regions:
-                                % region_systems = [s for s in repositories.system.find_all(enabled_only=False) if s.region == region]
-                                % if region_systems:
-                                    <tr class="header">
-                                        <td class="section" colspan="11">{{ region }}</td>
-                                    </tr>
-                                    <tr class="display-none"></tr>
-                                    % for system in sorted(region_systems):
-                                        % total = len(system.routes) + len(system.stops) + len(system.trips)
-                                        % progress = len(system.route_caches) + len(system.stop_caches) + len(system.trip_caches)
-                                        <tr>
-                                            <td>
-                                                <div class="row">
-                                                    % include('components/agency_logo', agency=system.agency)
-                                                    <div class="column">
-                                                        {{ system }}
-                                                        <div class="mobile-only smaller-font {{ 'positive' if system.enabled else 'negative' }}">
-                                                            {{ 'Enabled' if system.enabled else 'Disabled' }}
-                                                        </div>
-                                                        <div class="mobile-only smaller-font row">
-                                                            % include('components/percentage', numerator=progress, denominator=total, low_cutoff=60, high_cutoff=90, inverted=True)
-                                                            % if total:
-                                                                <div class="button icon small" onclick="resetCache('{{ system.id }}')">
-                                                                    % include('components/svg', name='action/delete')
-                                                                </div>
-                                                            % end
+                    <div class="table-border-wrapper">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>System</th>
+                                    <th class="non-mobile">Enabled</th>
+                                    <th class="non-mobile">Cache</th>
+                                    <th>GTFS</th>
+                                    <th>Realtime</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                % for region in regions:
+                                    % region_systems = [s for s in repositories.system.find_all(enabled_only=False) if s.region == region]
+                                    % if region_systems:
+                                        <tr class="header">
+                                            <td class="section" colspan="5">{{ region }}</td>
+                                        </tr>
+                                        <tr class="display-none"></tr>
+                                        % for system in sorted(region_systems):
+                                            % total = len(system.routes) + len(system.stops) + len(system.trips)
+                                            % progress = len(system.route_caches) + len(system.stop_caches) + len(system.trip_caches)
+                                            <tr>
+                                                <td>
+                                                    <div class="row">
+                                                        % include('components/agency_logo', agency=system.agency)
+                                                        <div class="column">
+                                                            {{ system }}
+                                                            <div class="mobile-only smaller-font {{ 'positive' if system.enabled else 'negative' }}">
+                                                                {{ 'Enabled' if system.enabled else 'Disabled' }}
+                                                            </div>
+                                                            <div class="mobile-only smaller-font row">
+                                                                % include('components/percentage', numerator=progress, denominator=total, low_cutoff=60, high_cutoff=90, inverted=True)
+                                                                % if total:
+                                                                    <div class="button icon small" onclick="resetCache('{{ system.id }}')">
+                                                                        % include('components/svg', name='action/delete')
+                                                                    </div>
+                                                                % end
+                                                            </div>
                                                         </div>
                                                     </div>
-                                                </div>
-                                            </td>
-                                            <td class="non-mobile {{ 'positive' if system.enabled else 'negative' }}">
-                                                % if system.enabled:
-                                                    % include('components/svg', name='status/enabled')
-                                                % else:
-                                                    % include('components/svg', name='status/disabled')
-                                                % end
-                                            </td>
-                                            <td class="non-mobile">
-                                                <div class="row space-between">
-                                                    % include('components/percentage', numerator=progress, denominator=total, low_cutoff=60, high_cutoff=90, inverted=True)
-                                                    % if total:
-                                                        <div class="button icon small" onclick="resetCache('{{ system.id }}')">
-                                                            % include('components/svg', name='action/delete')
+                                                </td>
+                                                <td class="non-mobile {{ 'positive' if system.enabled else 'negative' }}">
+                                                    % if system.enabled:
+                                                        % include('components/svg', name='status/enabled')
+                                                    % else:
+                                                        % include('components/svg', name='status/disabled')
+                                                    % end
+                                                </td>
+                                                <td class="non-mobile">
+                                                    <div class="row space-between">
+                                                        % include('components/percentage', numerator=progress, denominator=total, low_cutoff=60, high_cutoff=90, inverted=True)
+                                                        % if total:
+                                                            <div class="button icon small" onclick="resetCache('{{ system.id }}')">
+                                                                % include('components/svg', name='action/delete')
+                                                            </div>
+                                                        % end
+                                                    </div>
+                                                </td>
+                                                <td>
+                                                    % if system.gtfs_enabled:
+                                                        <div class="row">
+                                                            <div class="positive">
+                                                                % include('components/svg', name='status/enabled')
+                                                            </div>
+                                                            <div class="button icon small" onclick="reloadGTFS('{{ system.id }}')">
+                                                                % include('components/svg', name='action/refresh')
+                                                            </div>
+                                                        </div>
+                                                    % else:
+                                                        <div class="negative">
+                                                            % include('components/svg', name='status/disabled')
                                                         </div>
                                                     % end
-                                                </div>
-                                            </td>
-                                            <td>
-                                                % if system.gtfs_enabled:
-                                                    <div class="row">
-                                                        <div class="positive">
-                                                            % include('components/svg', name='status/enabled')
+                                                </td>
+                                                <td>
+                                                    % if system.realtime_enabled:
+                                                        <div class="row">
+                                                            <div class="positive">
+                                                                % include('components/svg', name='status/enabled')
+                                                            </div>
+                                                            <div class="button icon small" onclick="reloadRealtime('{{ system.id }}')">
+                                                                % include('components/svg', name='action/refresh')
+                                                            </div>
                                                         </div>
-                                                        <div class="button icon small" onclick="reloadGTFS('{{ system.id }}')">
-                                                            % include('components/svg', name='action/refresh')
+                                                    % else:
+                                                        <div class="negative">
+                                                            % include('components/svg', name='status/disabled')
                                                         </div>
-                                                    </div>
-                                                % else:
-                                                    <div class="negative">
-                                                        % include('components/svg', name='status/disabled')
-                                                    </div>
-                                                % end
-                                            </td>
-                                            <td>
-                                                % if system.realtime_enabled:
-                                                    <div class="row">
-                                                        <div class="positive">
-                                                            % include('components/svg', name='status/enabled')
-                                                        </div>
-                                                        <div class="button icon small" onclick="reloadRealtime('{{ system.id }}')">
-                                                            % include('components/svg', name='action/refresh')
-                                                        </div>
-                                                    </div>
-                                                % else:
-                                                    <div class="negative">
-                                                        % include('components/svg', name='status/disabled')
-                                                    </div>
-                                                % end
-                                            </td>
-                                        </tr>
+                                                    % end
+                                                </td>
+                                            </tr>
+                                        % end
                                     % end
                                 % end
-                            % end
-                        </tbody>
-                    </table>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
         </div>

--- a/views/pages/block/history.tpl
+++ b/views/pages/block/history.tpl
@@ -56,49 +56,51 @@
                                 <span>may be accidental logins.</span>
                             </p>
                         % end
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>Date</th>
-                                    <th>Bus</th>
-                                    <th class="desktop-only">Model</th>
-                                    <th class="no-wrap non-mobile">First Seen</th>
-                                    <th class="no-wrap">Last Seen</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                % last_date = None
-                                % for record in records:
-                                    % bus = record.bus
-                                    % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
-                                        <tr class="header">
-                                            <td colspan="5">{{ record.date.format_month() }}</td>
-                                            <tr class="display-none"></tr>
+                        <div class="table-border-wrapper">
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th>Date</th>
+                                        <th>Bus</th>
+                                        <th class="desktop-only">Model</th>
+                                        <th class="no-wrap non-mobile">First Seen</th>
+                                        <th class="no-wrap">Last Seen</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    % last_date = None
+                                    % for record in records:
+                                        % bus = record.bus
+                                        % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
+                                            <tr class="header">
+                                                <td colspan="5">{{ record.date.format_month() }}</td>
+                                                <tr class="display-none"></tr>
+                                            </tr>
+                                        % end
+                                        % last_date = record.date
+                                        <tr>
+                                            <td>{{ record.date.format_day() }}</td>
+                                            <td>
+                                                <div class="column stretch">
+                                                    <div class="row space-between">
+                                                        % include('components/bus')
+                                                        % include('components/record_warnings')
+                                                    </div>
+                                                    <span class="non-desktop smaller-font">
+                                                        % include('components/year_model', year_model=bus.year_model)
+                                                    </span>
+                                                </div>
+                                            </td>
+                                            <td class="desktop-only">
+                                                % include('components/year_model', year_model=bus.year_model)
+                                            </td>
+                                            <td class="non-mobile">{{ record.first_seen.format_web(time_format) }}</td>
+                                            <td>{{ record.last_seen.format_web(time_format) }}</td>
                                         </tr>
                                     % end
-                                    % last_date = record.date
-                                    <tr>
-                                        <td>{{ record.date.format_day() }}</td>
-                                        <td>
-                                            <div class="column stretch">
-                                                <div class="row space-between">
-                                                    % include('components/bus')
-                                                    % include('components/record_warnings')
-                                                </div>
-                                                <span class="non-desktop smaller-font">
-                                                    % include('components/year_model', year_model=bus.year_model)
-                                                </span>
-                                            </div>
-                                        </td>
-                                        <td class="desktop-only">
-                                            % include('components/year_model', year_model=bus.year_model)
-                                        </td>
-                                        <td class="non-mobile">{{ record.first_seen.format_web(time_format) }}</td>
-                                        <td>{{ record.last_seen.format_web(time_format) }}</td>
-                                    </tr>
-                                % end
-                            </tbody>
-                        </table>
+                                </tbody>
+                            </table>
+                        </div>
                     % else:
                         <div class="placeholder">
                             <h3>This block doesn't have any recorded history</h3>

--- a/views/pages/block/overview.tpl
+++ b/views/pages/block/overview.tpl
@@ -248,78 +248,80 @@
                 </div>
                 <div class="content">
                     <p>This bus is currently assigned to this block but may be swapped off.</p>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Bus</th>
-                                <th class="non-mobile">Model</th>
-                                <th>Current Headsign</th>
-                                <th class="desktop-only">Current Trip</th>
-                                <th class="non-mobile">Next Stop</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <div class="column">
-                                        <div class="row">
-                                            % include('components/bus')
-                                            % if position:
-                                                % include('components/adherence', adherence=position.adherence)
-                                            % end
-                                        </div>
-                                        <span class="mobile-only smaller-font">
-                                            % include('components/year_model', year_model=bus.year_model)
-                                        </span>
-                                    </div>
-                                </td>
-                                <td class="non-mobile">
-                                    % include('components/year_model', year_model=bus.year_model)
-                                </td>
-                                % if position:
-                                    % trip = position.trip
-                                    % stop = position.stop
-                                    % if trip:
-                                        <td>
-                                            <div class="column">
-                                                % include('components/headsign', departure=position.departure, trip=position.trip)
-                                                <div class="non-desktop smaller-font">
-                                                    Trip:
-                                                    % include('components/trip', include_tooltip=False, trip=position.trip)
-                                                </div>
-                                                % if stop:
-                                                    <div class="mobile-only smaller-font">
-                                                        <span class="align-middle">Next Stop:</span>
-                                                        % include('components/stop')
-                                                    </div>
+                    <div class="table-border-wrapper">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Bus</th>
+                                    <th class="non-mobile">Model</th>
+                                    <th>Current Headsign</th>
+                                    <th class="desktop-only">Current Trip</th>
+                                    <th class="non-mobile">Next Stop</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <div class="column">
+                                            <div class="row">
+                                                % include('components/bus')
+                                                % if position:
+                                                    % include('components/adherence', adherence=position.adherence)
                                                 % end
                                             </div>
-                                        </td>
-                                        <td class="desktop-only">
-                                            % include('components/trip', include_tooltip=False, trip=position.trip)
+                                            <span class="mobile-only smaller-font">
+                                                % include('components/year_model', year_model=bus.year_model)
+                                            </span>
+                                        </div>
+                                    </td>
+                                    <td class="non-mobile">
+                                        % include('components/year_model', year_model=bus.year_model)
+                                    </td>
+                                    % if position:
+                                        % trip = position.trip
+                                        % stop = position.stop
+                                        % if trip:
+                                            <td>
+                                                <div class="column">
+                                                    % include('components/headsign', departure=position.departure, trip=position.trip)
+                                                    <div class="non-desktop smaller-font">
+                                                        Trip:
+                                                        % include('components/trip', include_tooltip=False, trip=position.trip)
+                                                    </div>
+                                                    % if stop:
+                                                        <div class="mobile-only smaller-font">
+                                                            <span class="align-middle">Next Stop:</span>
+                                                            % include('components/stop')
+                                                        </div>
+                                                    % end
+                                                </div>
+                                            </td>
+                                            <td class="desktop-only">
+                                                % include('components/trip', include_tooltip=False, trip=position.trip)
+                                            </td>
+                                        % else:
+                                            <td colspan="2">
+                                                <div class="column">
+                                                    <div class="lighter-text">Not In Service</div>
+                                                    % if stop:
+                                                        <div class="mobile-only smaller-font">
+                                                            <span class="align-middle">Next Stop:</span>
+                                                            % include('components/stop')
+                                                        </div>
+                                                    % end
+                                                </div>
+                                            </td>
+                                        % end
+                                        <td class="non-mobile">
+                                            % include('components/stop')
                                         </td>
                                     % else:
-                                        <td colspan="2">
-                                            <div class="column">
-                                                <div class="lighter-text">Not In Service</div>
-                                                % if stop:
-                                                    <div class="mobile-only smaller-font">
-                                                        <span class="align-middle">Next Stop:</span>
-                                                        % include('components/stop')
-                                                    </div>
-                                                % end
-                                            </div>
-                                        </td>
+                                        <td class="lighter-text" colspan="3">Not In Service</td>
                                     % end
-                                    <td class="non-mobile">
-                                        % include('components/stop')
-                                    </td>
-                                % else:
-                                    <td class="lighter-text" colspan="3">Not In Service</td>
-                                % end
-                            </tr>
-                        </tbody>
-                    </table>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
         % end
@@ -352,7 +354,8 @@
                                                 <table>
                                                     <thead>
                                                         <tr>
-                                                            <th>Start Time</th>
+                                                            <th class="non-mobile">Start Time</th>
+                                                            <th class="mobile-only">Start</th>
                                                             <th class="non-mobile">End Time</th>
                                                             <th class="desktop-only">Duration</th>
                                                             <th class="non-mobile">Headsign</th>

--- a/views/pages/blocks/overview.tpl
+++ b/views/pages/blocks/overview.tpl
@@ -71,60 +71,62 @@
                         </div>
                         <div class="content">
                             % if today_blocks:
-                                <table>
-                                    <thead>
-                                        <tr>
-                                            <th>Block</th>
-                                            <th>Routes</th>
-                                            <th class="non-mobile">Start Time</th>
-                                            <th class="non-mobile">End Time</th>
-                                            <th class="desktop-only">Duration</th>
-                                            % if context.realtime_enabled:
-                                                <th>Bus</th>
-                                                <th class="non-mobile">Model</th>
-                                            % end
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        % for block in today_blocks:
-                                            % start_time = block.get_start_time(date=today).format_web(time_format)
-                                            % end_time = block.get_end_time(date=today).format_web(time_format)
+                                <div class="table-border-wrapper">
+                                    <table>
+                                        <thead>
                                             <tr>
-                                                <td>
-                                                    <div class="column">
-                                                        <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
-                                                        <div class="mobile-only smaller-font">{{ start_time }} - {{ end_time }}</div>
-                                                    </div>
-                                                </td>
-                                                <td>
-                                                    % include('components/route_list', routes=block.get_routes(date=today))
-                                                </td>
-                                                <td class="non-mobile">{{ start_time }}</td>
-                                                <td class="non-mobile">{{ end_time }}</td>
-                                                <td class="desktop-only">{{ block.get_duration(date=today) }}</td>
+                                                <th>Block</th>
+                                                <th>Routes</th>
+                                                <th class="non-mobile">Start Time</th>
+                                                <th class="non-mobile">End Time</th>
+                                                <th class="desktop-only">Duration</th>
                                                 % if context.realtime_enabled:
-                                                    % if block.id in recorded_buses:
-                                                        % bus = recorded_buses[block.id]
-                                                        <td>
-                                                            <div class="column">
-                                                                % include('components/bus')
-                                                                <span class="mobile-only smaller-font">
-                                                                    % include('components/year_model', year_model=bus.year_model)
-                                                                </span>
-                                                            </div>
-                                                        </td>
-                                                        <td class="non-mobile">
-                                                            % include('components/year_model', year_model=bus.year_model)
-                                                        </td>
-                                                    % else:
-                                                        <td class="non-mobile lighter-text" colspan="2">Unavailable</td>
-                                                        <td class="mobile-only lighter-text">Unavailable</td>
-                                                    % end
+                                                    <th>Bus</th>
+                                                    <th class="non-mobile">Model</th>
                                                 % end
                                             </tr>
-                                        % end
-                                    </tbody>
-                                </table>
+                                        </thead>
+                                        <tbody>
+                                            % for block in today_blocks:
+                                                % start_time = block.get_start_time(date=today).format_web(time_format)
+                                                % end_time = block.get_end_time(date=today).format_web(time_format)
+                                                <tr>
+                                                    <td>
+                                                        <div class="column">
+                                                            <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
+                                                            <div class="mobile-only smaller-font">{{ start_time }} - {{ end_time }}</div>
+                                                        </div>
+                                                    </td>
+                                                    <td>
+                                                        % include('components/route_list', routes=block.get_routes(date=today))
+                                                    </td>
+                                                    <td class="non-mobile">{{ start_time }}</td>
+                                                    <td class="non-mobile">{{ end_time }}</td>
+                                                    <td class="desktop-only">{{ block.get_duration(date=today) }}</td>
+                                                    % if context.realtime_enabled:
+                                                        % if block.id in recorded_buses:
+                                                            % bus = recorded_buses[block.id]
+                                                            <td>
+                                                                <div class="column">
+                                                                    % include('components/bus')
+                                                                    <span class="mobile-only smaller-font">
+                                                                        % include('components/year_model', year_model=bus.year_model)
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                            <td class="non-mobile">
+                                                                % include('components/year_model', year_model=bus.year_model)
+                                                            </td>
+                                                        % else:
+                                                            <td class="non-mobile lighter-text" colspan="2">Unavailable</td>
+                                                            <td class="mobile-only lighter-text">Unavailable</td>
+                                                        % end
+                                                    % end
+                                                </tr>
+                                            % end
+                                        </tbody>
+                                    </table>
+                                </div>
                             % else:
                                 <div class="placeholder">
                                     % if context.gtfs_loaded:

--- a/views/pages/blocks/schedule.tpl
+++ b/views/pages/blocks/schedule.tpl
@@ -109,56 +109,58 @@
     % else:
         <div class="placeholder">
             <p>Choose a system to see blocks.</p>
-            <table>
-                <thead>
-                    <tr>
-                        <th>System</th>
-                        <th class="non-mobile align-right">Blocks</th>
-                        <th>Service Days</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    % for region in regions:
-                        % region_systems = [s for s in systems if s.region == region]
-                        % if region_systems:
-                            <tr class="header">
-                                <td colspan="3">{{ region }}</td>
-                            </tr>
-                            <tr class="display-none"></tr>
-                            % for system in sorted(region_systems):
-                                % count = len(system.get_blocks())
-                                <tr>
-                                    <td>
-                                        <div class="row">
-                                            % include('components/agency_logo', agency=system.agency)
-                                            <div class="column">
-                                                <a href="{{ get_url(system.context, *path) }}">{{ system }}</a>
-                                                <span class="mobile-only smaller-font">
-                                                    % if system.gtfs_loaded:
-                                                        % if count == 1:
-                                                            1 Block
-                                                        % else:
-                                                            {{ count }} Blocks
-                                                        % end
-                                                    % end
-                                                </span>
-                                            </div>
-                                        </div>
-                                    </td>
-                                    % if system.gtfs_loaded:
-                                        <td class="non-mobile align-right">{{ count }}</td>
-                                        <td>
-                                            % include('components/weekdays', schedule=system.schedule, compact=True, schedule_path='blocks')
-                                        </td>
-                                    % else:
-                                        <td class="lighter-text" colspan="2">Blocks are loading...</td>
-                                    % end
+            <div class="table-border-wrapper">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>System</th>
+                            <th class="non-mobile align-right">Blocks</th>
+                            <th>Service Days</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        % for region in regions:
+                            % region_systems = [s for s in systems if s.region == region]
+                            % if region_systems:
+                                <tr class="header">
+                                    <td colspan="3">{{ region }}</td>
                                 </tr>
+                                <tr class="display-none"></tr>
+                                % for system in sorted(region_systems):
+                                    % count = len(system.get_blocks())
+                                    <tr>
+                                        <td>
+                                            <div class="row">
+                                                % include('components/agency_logo', agency=system.agency)
+                                                <div class="column">
+                                                    <a href="{{ get_url(system.context, *path) }}">{{ system }}</a>
+                                                    <span class="mobile-only smaller-font">
+                                                        % if system.gtfs_loaded:
+                                                            % if count == 1:
+                                                                1 Block
+                                                            % else:
+                                                                {{ count }} Blocks
+                                                            % end
+                                                        % end
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </td>
+                                        % if system.gtfs_loaded:
+                                            <td class="non-mobile align-right">{{ count }}</td>
+                                            <td>
+                                                % include('components/weekdays', schedule=system.schedule, compact=True, schedule_path='blocks')
+                                            </td>
+                                        % else:
+                                            <td class="lighter-text" colspan="2">Blocks are loading...</td>
+                                        % end
+                                    </tr>
+                                % end
                             % end
                         % end
-                    % end
-                </tbody>
-            </table>
+                    </tbody>
+                </table>
+            </div>
         </div>
     % end
 % else:

--- a/views/pages/bus/history.tpl
+++ b/views/pages/bus/history.tpl
@@ -87,74 +87,76 @@
                                 <span>may be accidental logins.</span>
                             </p>
                         % end
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>Date</th>
-                                    <th class="desktop-only">System</th>
-                                    % if context.enable_blocks:
-                                        <th>Block</th>
-                                        <th class="desktop-only">Routes</th>
-                                    % else:
-                                        <th>Routes</th>
-                                    % end
-                                    <th class="desktop-only">Start Time</th>
-                                    <th class="desktop-only">End Time</th>
-                                    <th class="no-wrap non-mobile">First Seen</th>
-                                    <th class="no-wrap">Last Seen</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                % last_date = None
-                                % for record in records:
-                                    % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
-                                        <tr class="header">
-                                            <td colspan="8">{{ record.date.format_month() }}</td>
-                                            <tr class="display-none"></tr>
-                                        </tr>
-                                    % end
-                                    % last_date = record.date
+                        <div class="table-border-wrapper">
+                            <table>
+                                <thead>
                                     <tr>
-                                        <td>
-                                            <div class="column">
-                                                {{ record.date.format_day() }}
-                                                <span class="non-desktop smaller-font">{{ record.context }}</span>
-                                            </div>
-                                        </td>
-                                        <td class="desktop-only">{{ record.context }}</td>
+                                        <th>Date</th>
+                                        <th class="desktop-only">System</th>
                                         % if context.enable_blocks:
+                                            <th>Block</th>
+                                            <th class="desktop-only">Routes</th>
+                                        % else:
+                                            <th>Routes</th>
+                                        % end
+                                        <th class="desktop-only">Start Time</th>
+                                        <th class="desktop-only">End Time</th>
+                                        <th class="no-wrap non-mobile">First Seen</th>
+                                        <th class="no-wrap">Last Seen</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    % last_date = None
+                                    % for record in records:
+                                        % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
+                                            <tr class="header">
+                                                <td colspan="8">{{ record.date.format_month() }}</td>
+                                                <tr class="display-none"></tr>
+                                            </tr>
+                                        % end
+                                        % last_date = record.date
+                                        <tr>
                                             <td>
-                                                <div class="column stretch">
-                                                    <div class="row space-between">
-                                                        % if record.is_available:
-                                                            % block = record.block
-                                                            <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
-                                                        % else:
-                                                            <span>{{ record.block_id }}</span>
-                                                        % end
-                                                        % include('components/record_warnings')
-                                                    </div>
-                                                    <div class="non-desktop">
-                                                        % include('components/route_list', routes=record.routes)
-                                                    </div>
+                                                <div class="column">
+                                                    {{ record.date.format_day() }}
+                                                    <span class="non-desktop smaller-font">{{ record.context }}</span>
                                                 </div>
                                             </td>
-                                            <td class="desktop-only">
-                                                % include('components/route_list', routes=record.routes)
-                                            </td>
-                                        % else:
-                                            <td>
-                                                % include('components/route_list', routes=record.routes)
-                                            </td>
-                                        % end
-                                        <td class="desktop-only">{{ record.start_time.format_web(time_format) }}</td>
-                                        <td class="desktop-only">{{ record.end_time.format_web(time_format) }}</td>
-                                        <td class="non-mobile">{{ record.first_seen.format_web(time_format) }}</td>
-                                        <td>{{ record.last_seen.format_web(time_format) }}</td>
-                                    </tr>
-                                % end
-                            </tbody>
-                        </table>
+                                            <td class="desktop-only">{{ record.context }}</td>
+                                            % if context.enable_blocks:
+                                                <td>
+                                                    <div class="column stretch">
+                                                        <div class="row space-between">
+                                                            % if record.is_available:
+                                                                % block = record.block
+                                                                <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
+                                                            % else:
+                                                                <span>{{ record.block_id }}</span>
+                                                            % end
+                                                            % include('components/record_warnings')
+                                                        </div>
+                                                        <div class="non-desktop">
+                                                            % include('components/route_list', routes=record.routes)
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                                <td class="desktop-only">
+                                                    % include('components/route_list', routes=record.routes)
+                                                </td>
+                                            % else:
+                                                <td>
+                                                    % include('components/route_list', routes=record.routes)
+                                                </td>
+                                            % end
+                                            <td class="desktop-only">{{ record.start_time.format_web(time_format) }}</td>
+                                            <td class="desktop-only">{{ record.end_time.format_web(time_format) }}</td>
+                                            <td class="non-mobile">{{ record.first_seen.format_web(time_format) }}</td>
+                                            <td>{{ record.last_seen.format_web(time_format) }}</td>
+                                        </tr>
+                                    % end
+                                </tbody>
+                            </table>
+                        </div>
                         % include('components/paging')
                     % else:
                         <div class="placeholder">

--- a/views/pages/bus/overview.tpl
+++ b/views/pages/bus/overview.tpl
@@ -328,74 +328,76 @@
                             <span>may be accidental logins.</span>
                         </p>
                     % end
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Date</th>
-                                <th class="desktop-only">System</th>
-                                % if context.enable_blocks:
-                                    <th>Block</th>
-                                    <th class="desktop-only">Routes</th>
-                                % else:
-                                    <th>Routes</th>
-                                % end
-                                <th class="desktop-only">Start Time</th>
-                                <th class="desktop-only">End Time</th>
-                                <th class="no-wrap non-mobile">First Seen</th>
-                                <th class="no-wrap">Last Seen</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            % last_date = None
-                            % for record in records:
-                                % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
-                                    <tr class="header">
-                                        <td colspan="8">{{ record.date.format_month() }}</td>
-                                        <tr class="display-none"></tr>
-                                    </tr>
-                                % end
-                                % last_date = record.date
+                    <div class="table-border-wrapper">
+                        <table>
+                            <thead>
                                 <tr>
-                                    <td>
-                                        <div class="column">
-                                            {{ record.date.format_day() }}
-                                            <span class="non-desktop smaller-font">{{ record.context }}</span>
-                                        </div>
-                                    </td>
-                                    <td class="desktop-only">{{ record.context }}</td>
+                                    <th>Date</th>
+                                    <th class="desktop-only">System</th>
                                     % if context.enable_blocks:
+                                        <th>Block</th>
+                                        <th class="desktop-only">Routes</th>
+                                    % else:
+                                        <th>Routes</th>
+                                    % end
+                                    <th class="desktop-only">Start Time</th>
+                                    <th class="desktop-only">End Time</th>
+                                    <th class="no-wrap non-mobile">First Seen</th>
+                                    <th class="no-wrap">Last Seen</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                % last_date = None
+                                % for record in records:
+                                    % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
+                                        <tr class="header">
+                                            <td colspan="8">{{ record.date.format_month() }}</td>
+                                            <tr class="display-none"></tr>
+                                        </tr>
+                                    % end
+                                    % last_date = record.date
+                                    <tr>
                                         <td>
-                                            <div class="column stretch">
-                                                <div class="row space-between">
-                                                    % if record.is_available:
-                                                        % block = record.block
-                                                        <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
-                                                    % else:
-                                                        <span>{{ record.block_id }}</span>
-                                                    % end
-                                                    % include('components/record_warnings')
-                                                </div>
-                                                <div class="non-desktop">
-                                                    % include('components/route_list', routes=record.routes)
-                                                </div>
+                                            <div class="column">
+                                                {{ record.date.format_day() }}
+                                                <span class="non-desktop smaller-font">{{ record.context }}</span>
                                             </div>
                                         </td>
-                                        <td class="desktop-only">
-                                            % include('components/route_list', routes=record.routes)
-                                        </td>
-                                    % else:
-                                        <td>
-                                            % include('components/route_list', routes=record.routes)
-                                        </td>
-                                    % end
-                                    <td class="desktop-only">{{ record.start_time.format_web(time_format) }}</td>
-                                    <td class="desktop-only">{{ record.end_time.format_web(time_format) }}</td>
-                                    <td class="non-mobile">{{ record.first_seen.format_web(time_format) }}</td>
-                                    <td>{{ record.last_seen.format_web(time_format) }}</td>
-                                </tr>
-                            % end
-                        </tbody>
-                    </table>
+                                        <td class="desktop-only">{{ record.context }}</td>
+                                        % if context.enable_blocks:
+                                            <td>
+                                                <div class="column stretch">
+                                                    <div class="row space-between">
+                                                        % if record.is_available:
+                                                            % block = record.block
+                                                            <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
+                                                        % else:
+                                                            <span>{{ record.block_id }}</span>
+                                                        % end
+                                                        % include('components/record_warnings')
+                                                    </div>
+                                                    <div class="non-desktop">
+                                                        % include('components/route_list', routes=record.routes)
+                                                    </div>
+                                                </div>
+                                            </td>
+                                            <td class="desktop-only">
+                                                % include('components/route_list', routes=record.routes)
+                                            </td>
+                                        % else:
+                                            <td>
+                                                % include('components/route_list', routes=record.routes)
+                                            </td>
+                                        % end
+                                        <td class="desktop-only">{{ record.start_time.format_web(time_format) }}</td>
+                                        <td class="desktop-only">{{ record.end_time.format_web(time_format) }}</td>
+                                        <td class="non-mobile">{{ record.first_seen.format_web(time_format) }}</td>
+                                        <td>{{ record.last_seen.format_web(time_format) }}</td>
+                                    </tr>
+                                % end
+                            </tbody>
+                        </table>
+                    </div>
                 % else:
                     <div class="placeholder">
                         <h3>This bus doesn't have any recorded history</h3>

--- a/views/pages/fleet.tpl
+++ b/views/pages/fleet.tpl
@@ -98,63 +98,65 @@
                                                 % include('components/toggle')
                                             </div>
                                             <div class="content">
-                                                <table>
-                                                    <thead>
-                                                        <tr>
-                                                            <th>Bus</th>
-                                                            <th>First Seen</th>
-                                                            <th class="non-mobile">First System</th>
-                                                            <th>Last Seen</th>
-                                                            <th class="non-mobile">Last System</th>
-                                                        </tr>
-                                                    </thead>
-                                                    <tbody>
-                                                        % for order in model_orders:
-                                                            <tr class="header">
-                                                                <td colspan="5">
-                                                                    <div class="row space-between">
-                                                                        <div>{{ order.years_string }}</div>
-                                                                        <div>{{ len(order.buses) }}</div>
-                                                                    </div>
-                                                                </td>
+                                                <div class="table-border-wrapper">
+                                                    <table>
+                                                        <thead>
+                                                            <tr>
+                                                                <th>Bus</th>
+                                                                <th>First Seen</th>
+                                                                <th class="non-mobile">First System</th>
+                                                                <th>Last Seen</th>
+                                                                <th class="non-mobile">Last System</th>
                                                             </tr>
-                                                            <tr class="display-none"></tr>
-                                                            % for bus in order.buses:
-                                                                % if bus.number in overviews:
-                                                                    % overview = overviews[bus.number]
-                                                                    <tr>
-                                                                        <td>
-                                                                            % include('components/bus')
-                                                                        </td>
-                                                                        <td class="desktop-only">{{ overview.first_seen_date.format_long() }}</td>
-                                                                        <td class="non-desktop">
-                                                                            <div class="column">
-                                                                                {{ overview.first_seen_date.format_short() }}
-                                                                                <span class="mobile-only smaller-font">{{ overview.first_seen_context }}</span>
-                                                                            </div>
-                                                                        </td>
-                                                                        <td class="non-mobile">{{ overview.first_seen_context }}</td>
-                                                                        <td class="desktop-only">{{ overview.last_seen_date.format_long() }}</td>
-                                                                        <td class="non-desktop">
-                                                                            <div class="column">
-                                                                                {{ overview.last_seen_date.format_short() }}
-                                                                                <span class="mobile-only smaller-font">{{ overview.last_seen_context }}</span>
-                                                                            </div>
-                                                                        </td>
-                                                                        <td class="non-mobile">{{ overview.last_seen_context }}</td>
-                                                                    </tr>
-                                                                % else:
-                                                                    <tr>
-                                                                        <td>
-                                                                            % include('components/bus', enable_link=False)
-                                                                        </td>
-                                                                        <td class="lighter-text" colspan="4">Unavailable</td>
-                                                                    </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                            % for order in model_orders:
+                                                                <tr class="header">
+                                                                    <td colspan="5">
+                                                                        <div class="row space-between">
+                                                                            <div>{{ order.years_string }}</div>
+                                                                            <div>{{ len(order.buses) }}</div>
+                                                                        </div>
+                                                                    </td>
+                                                                </tr>
+                                                                <tr class="display-none"></tr>
+                                                                % for bus in order.buses:
+                                                                    % if bus.number in overviews:
+                                                                        % overview = overviews[bus.number]
+                                                                        <tr>
+                                                                            <td>
+                                                                                % include('components/bus')
+                                                                            </td>
+                                                                            <td class="desktop-only">{{ overview.first_seen_date.format_long() }}</td>
+                                                                            <td class="non-desktop">
+                                                                                <div class="column">
+                                                                                    {{ overview.first_seen_date.format_short() }}
+                                                                                    <span class="mobile-only smaller-font">{{ overview.first_seen_context }}</span>
+                                                                                </div>
+                                                                            </td>
+                                                                            <td class="non-mobile">{{ overview.first_seen_context }}</td>
+                                                                            <td class="desktop-only">{{ overview.last_seen_date.format_long() }}</td>
+                                                                            <td class="non-desktop">
+                                                                                <div class="column">
+                                                                                    {{ overview.last_seen_date.format_short() }}
+                                                                                    <span class="mobile-only smaller-font">{{ overview.last_seen_context }}</span>
+                                                                                </div>
+                                                                            </td>
+                                                                            <td class="non-mobile">{{ overview.last_seen_context }}</td>
+                                                                        </tr>
+                                                                    % else:
+                                                                        <tr>
+                                                                            <td>
+                                                                                % include('components/bus', enable_link=False)
+                                                                            </td>
+                                                                            <td class="lighter-text" colspan="4">Unavailable</td>
+                                                                        </tr>
+                                                                    % end
                                                                 % end
                                                             % end
-                                                        % end
-                                                    </tbody>
-                                                </table>
+                                                        </tbody>
+                                                    </table>
+                                                </div>
                                             </div>
                                         </div>
                                     % end

--- a/views/pages/history/first_seen.tpl
+++ b/views/pages/history/first_seen.tpl
@@ -23,87 +23,89 @@
                         <span>may be accidental logins.</span>
                     </p>
                 % end
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Date</th>
-                            <th>Bus</th>
-                            <th class="desktop-only">Model</th>
-                            % if not context.system:
-                                <th class="non-mobile">System</th>
-                            % end
-                            % if context.enable_blocks:
-                                <th>Block</th>
-                                <th class="desktop-only">Routes</th>
-                            % else:
-                                <th>Routes</th>
-                            % end
-                        </tr>
-                    </thead>
-                    <tbody>
-                        % last_date = None
-                        % for overview in overviews:
-                            % record = overview.first_record
-                            % bus = record.bus
-                            % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
-                                <tr class="header">
-                                    <td colspan="6">{{ record.date.format_month() }}</td>
-                                    <tr class="display-none"></tr>
-                                </tr>
-                            % end
-                            % last_date = record.date
+                <div class="table-border-wrapper">
+                    <table>
+                        <thead>
                             <tr>
-                                <td>
-                                    <div class="column">
-                                        {{ record.date.format_day() }}
-                                        % if not context.system:
-                                            <span class="mobile-only smaller-font">{{ record.context }}</span>
-                                        % end
-                                    </div>
-                                </td>
-                                <td>
-                                    <div class="column">
-                                        % include('components/bus')
-                                        <span class="non-desktop smaller-font">
-                                            % include('components/year_model', year_model=bus.year_model)
-                                        </span>
-                                    </div>
-                                </td>
-                                <td class="desktop-only">
-                                    % include('components/year_model', year_model=bus.year_model)
-                                </td>
+                                <th>Date</th>
+                                <th>Bus</th>
+                                <th class="desktop-only">Model</th>
                                 % if not context.system:
-                                    <td class="non-mobile">{{ record.context }}</td>
+                                    <th class="non-mobile">System</th>
                                 % end
                                 % if context.enable_blocks:
+                                    <th>Block</th>
+                                    <th class="desktop-only">Routes</th>
+                                % else:
+                                    <th>Routes</th>
+                                % end
+                            </tr>
+                        </thead>
+                        <tbody>
+                            % last_date = None
+                            % for overview in overviews:
+                                % record = overview.first_record
+                                % bus = record.bus
+                                % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
+                                    <tr class="header">
+                                        <td colspan="6">{{ record.date.format_month() }}</td>
+                                        <tr class="display-none"></tr>
+                                    </tr>
+                                % end
+                                % last_date = record.date
+                                <tr>
                                     <td>
-                                        <div class="column stretch">
-                                            <div class="row space-between">
-                                                % if record.is_available:
-                                                    % block = record.block
-                                                    <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
-                                                % else:
-                                                    <span>{{ record.block_id }}</span>
-                                                % end
-                                                % include('components/record_warnings')
-                                            </div>
-                                            <div class="non-desktop">
-                                                % include('components/route_list', routes=record.routes)
-                                            </div>
+                                        <div class="column">
+                                            {{ record.date.format_day() }}
+                                            % if not context.system:
+                                                <span class="mobile-only smaller-font">{{ record.context }}</span>
+                                            % end
+                                        </div>
+                                    </td>
+                                    <td>
+                                        <div class="column">
+                                            % include('components/bus')
+                                            <span class="non-desktop smaller-font">
+                                                % include('components/year_model', year_model=bus.year_model)
+                                            </span>
                                         </div>
                                     </td>
                                     <td class="desktop-only">
-                                        % include('components/route_list', routes=record.routes)
+                                        % include('components/year_model', year_model=bus.year_model)
                                     </td>
-                                % else:
-                                    <td>
-                                        % include('components/route_list', routes=record.routes)
-                                    </td>
-                                % end
-                            </tr>
-                        % end
-                    </tbody>
-                </table>
+                                    % if not context.system:
+                                        <td class="non-mobile">{{ record.context }}</td>
+                                    % end
+                                    % if context.enable_blocks:
+                                        <td>
+                                            <div class="column stretch">
+                                                <div class="row space-between">
+                                                    % if record.is_available:
+                                                        % block = record.block
+                                                        <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
+                                                    % else:
+                                                        <span>{{ record.block_id }}</span>
+                                                    % end
+                                                    % include('components/record_warnings')
+                                                </div>
+                                                <div class="non-desktop">
+                                                    % include('components/route_list', routes=record.routes)
+                                                </div>
+                                            </div>
+                                        </td>
+                                        <td class="desktop-only">
+                                            % include('components/route_list', routes=record.routes)
+                                        </td>
+                                    % else:
+                                        <td>
+                                            % include('components/route_list', routes=record.routes)
+                                        </td>
+                                    % end
+                                </tr>
+                            % end
+                        </tbody>
+                    </table>
+                </div>
             % else:
                 <div class="placeholder">
                     % if not context.system:

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -123,140 +123,142 @@
                             <span>may be accidental logins.</span>
                         </p>
                     % end
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Bus</th>
-                                <th>Last Seen</th>
-                                % if not context.system:
-                                    <th class="non-mobile">System</th>
-                                % end
-                                % if context.enable_blocks:
-                                    <th>Block</th>
-                                    <th class="desktop-only">Routes</th>
-                                % else:
-                                    <th>Routes</th>
-                                % end
-                            </tr>
-                        </thead>
-                        <tbody>
-                            % if unknown_overviews:
-                                <tr class="header">
-                                    <td colspan="5">
-                                        <div class="row space-between">
-                                            <div>Unknown Year/Model</div>
-                                            <div>{{ len(unknown_overviews) }}</div>
-                                        </div>
-                                    </td>
+                    <div class="table-border-wrapper">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Bus</th>
+                                    <th>Last Seen</th>
+                                    % if not context.system:
+                                        <th class="non-mobile">System</th>
+                                    % end
+                                    % if context.enable_blocks:
+                                        <th>Block</th>
+                                        <th class="desktop-only">Routes</th>
+                                    % else:
+                                        <th>Routes</th>
+                                    % end
                                 </tr>
-                                <tr class="display-none"></tr>
-                                % for overview in unknown_overviews:
-                                    % record = overview.last_record
-                                    % bus = overview.bus
-                                    <tr>
-                                        <td>
-                                            % include('components/bus')
-                                        </td>
-                                        <td class="desktop-only">{{ record.date.format_long() }}</td>
-                                        <td class="non-desktop">
-                                            <div class="column">
-                                                {{ record.date.format_short() }}
-                                                % if not context.system:
-                                                    <span class="mobile-only smaller-font">{{ record.context }}</span>
-                                                % end
+                            </thead>
+                            <tbody>
+                                % if unknown_overviews:
+                                    <tr class="header">
+                                        <td colspan="5">
+                                            <div class="row space-between">
+                                                <div>Unknown Year/Model</div>
+                                                <div>{{ len(unknown_overviews) }}</div>
                                             </div>
                                         </td>
-                                        % if not context.system:
-                                            <td class="non-mobile">{{ record.context }}</td>
-                                        % end
-                                        % if context.enable_blocks:
+                                    </tr>
+                                    <tr class="display-none"></tr>
+                                    % for overview in unknown_overviews:
+                                        % record = overview.last_record
+                                        % bus = overview.bus
+                                        <tr>
                                             <td>
+                                                % include('components/bus')
+                                            </td>
+                                            <td class="desktop-only">{{ record.date.format_long() }}</td>
+                                            <td class="non-desktop">
                                                 <div class="column">
-                                                    <div class="row space-between">
-                                                        % if record.is_available:
-                                                            % block = record.block
-                                                            <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
-                                                        % else:
-                                                            <span>{{ record.block_id }}</span>
-                                                        % end
-                                                        % include('components/record_warnings')
-                                                    </div>
-                                                    <div class="non-desktop">
-                                                        % include('components/route_list', routes=record.routes)
-                                                    </div>
+                                                    {{ record.date.format_short() }}
+                                                    % if not context.system:
+                                                        <span class="mobile-only smaller-font">{{ record.context }}</span>
+                                                    % end
                                                 </div>
                                             </td>
-                                            <td class="desktop-only">
-                                                % include('components/route_list', routes=record.routes)
-                                            </td>
-                                        % else:
-                                            <td>
-                                                % include('components/route_list', routes=record.routes)
-                                            </td>
-                                        % end
-                                    </tr>
+                                            % if not context.system:
+                                                <td class="non-mobile">{{ record.context }}</td>
+                                            % end
+                                            % if context.enable_blocks:
+                                                <td>
+                                                    <div class="column">
+                                                        <div class="row space-between">
+                                                            % if record.is_available:
+                                                                % block = record.block
+                                                                <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
+                                                            % else:
+                                                                <span>{{ record.block_id }}</span>
+                                                            % end
+                                                            % include('components/record_warnings')
+                                                        </div>
+                                                        <div class="non-desktop">
+                                                            % include('components/route_list', routes=record.routes)
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                                <td class="desktop-only">
+                                                    % include('components/route_list', routes=record.routes)
+                                                </td>
+                                            % else:
+                                                <td>
+                                                    % include('components/route_list', routes=record.routes)
+                                                </td>
+                                            % end
+                                        </tr>
+                                    % end
                                 % end
-                            % end
-                            % for order in orders:
-                                % order_overviews = [o for o in known_overviews if o.bus.order_id == order.id]
-                                <tr class="header">
-                                    <td colspan="5">
-                                        <div class="row space-between">
-                                            <div>{{! order }}</div>
-                                            <div>{{ len(order_overviews) }}</div>
-                                        </div>
-                                    </td>
-                                </tr>
-                                <tr class="display-none"></tr>
-                                % for overview in order_overviews:
-                                    % record = overview.last_record
-                                    % bus = overview.bus
-                                    <tr>
-                                        <td>
-                                            % include('components/bus')
-                                        </td>
-                                        <td class="desktop-only">{{ record.date.format_long() }}</td>
-                                        <td class="non-desktop">
-                                            <div class="column">
-                                                {{ record.date.format_short() }}
-                                                % if not context.system:
-                                                    <span class="mobile-only smaller-font">{{ record.context }}</span>
-                                                % end
+                                % for order in orders:
+                                    % order_overviews = [o for o in known_overviews if o.bus.order_id == order.id]
+                                    <tr class="header">
+                                        <td colspan="5">
+                                            <div class="row space-between">
+                                                <div>{{! order }}</div>
+                                                <div>{{ len(order_overviews) }}</div>
                                             </div>
                                         </td>
-                                        % if not context.system:
-                                            <td class="non-mobile">{{ record.context }}</td>
-                                        % end
-                                        % if context.enable_blocks:
+                                    </tr>
+                                    <tr class="display-none"></tr>
+                                    % for overview in order_overviews:
+                                        % record = overview.last_record
+                                        % bus = overview.bus
+                                        <tr>
                                             <td>
-                                                <div class="column stretch">
-                                                    <div class="row space-between">
-                                                        % if record.is_available:
-                                                            % block = record.block
-                                                            <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
-                                                        % else:
-                                                            <span>{{ record.block_id }}</span>
-                                                        % end
-                                                        % include('components/record_warnings')
-                                                    </div>
-                                                    <div class="non-desktop">
-                                                        % include('components/route_list', routes=record.routes)
-                                                    </div>
+                                                % include('components/bus')
+                                            </td>
+                                            <td class="desktop-only">{{ record.date.format_long() }}</td>
+                                            <td class="non-desktop">
+                                                <div class="column">
+                                                    {{ record.date.format_short() }}
+                                                    % if not context.system:
+                                                        <span class="mobile-only smaller-font">{{ record.context }}</span>
+                                                    % end
                                                 </div>
                                             </td>
-                                            <td class="desktop-only">
-                                                % include('components/route_list', routes=record.routes)
-                                            </td>
-                                        % else:
-                                            <td>
-                                                % include('components/route_list', routes=record.routes)
-                                            </td>
-                                        % end
-                                    </tr>
+                                            % if not context.system:
+                                                <td class="non-mobile">{{ record.context }}</td>
+                                            % end
+                                            % if context.enable_blocks:
+                                                <td>
+                                                    <div class="column stretch">
+                                                        <div class="row space-between">
+                                                            % if record.is_available:
+                                                                % block = record.block
+                                                                <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
+                                                            % else:
+                                                                <span>{{ record.block_id }}</span>
+                                                            % end
+                                                            % include('components/record_warnings')
+                                                        </div>
+                                                        <div class="non-desktop">
+                                                            % include('components/route_list', routes=record.routes)
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                                <td class="desktop-only">
+                                                    % include('components/route_list', routes=record.routes)
+                                                </td>
+                                            % else:
+                                                <td>
+                                                    % include('components/route_list', routes=record.routes)
+                                                </td>
+                                            % end
+                                        </tr>
+                                    % end
                                 % end
-                            % end
-                        </tbody>
-                    </table>
+                            </tbody>
+                        </table>
+                    </div>
         
                     % include('components/top_button')
                 % else:

--- a/views/pages/nearby.tpl
+++ b/views/pages/nearby.tpl
@@ -38,56 +38,58 @@
                     <div class="placeholder">
                         <h3>Choose a system to see nearby stops</h3>
                     </div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>System</th>
-                                <th class="non-mobile align-right">Stops</th>
-                                <th>Service Days</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            % for region in regions:
-                                % region_systems = [s for s in systems if s.region == region]
-                                % if region_systems:
-                                    <tr class="header">
-                                        <td colspan="3">{{ region }}</td>
-                                    </tr>
-                                    <tr class="display-none"></tr>
-                                    % for system in sorted(region_systems):
-                                        % count = len(system.get_stops())
-                                        <tr>
-                                            <td>
-                                                <div class="row">
-                                                    % include('components/agency_logo', agency=system.agency)
-                                                    <div class="column">
-                                                        <a href="{{ get_url(system.context, *path) }}">{{ system }}</a>
-                                                        <span class="mobile-only smaller-font">
-                                                            % if system.gtfs_loaded:
-                                                                % if count == 1:
-                                                                    1 Stop
-                                                                % else:
-                                                                    {{ count }} Stops
-                                                                % end
-                                                            % end
-                                                        </span>
-                                                    </div>
-                                                </div>
-                                            </td>
-                                            % if system.gtfs_loaded:
-                                                <td class="non-mobile align-right">{{ count }}</td>
-                                                <td>
-                                                    % include('components/weekdays', schedule=system.schedule, compact=True)
-                                                </td>
-                                            % else:
-                                                <td class="lighter-text" colspan="2">Stops are loading...</td>
-                                            % end
+                    <div class="table-border-wrapper">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>System</th>
+                                    <th class="non-mobile align-right">Stops</th>
+                                    <th>Service Days</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                % for region in regions:
+                                    % region_systems = [s for s in systems if s.region == region]
+                                    % if region_systems:
+                                        <tr class="header">
+                                            <td colspan="3">{{ region }}</td>
                                         </tr>
+                                        <tr class="display-none"></tr>
+                                        % for system in sorted(region_systems):
+                                            % count = len(system.get_stops())
+                                            <tr>
+                                                <td>
+                                                    <div class="row">
+                                                        % include('components/agency_logo', agency=system.agency)
+                                                        <div class="column">
+                                                            <a href="{{ get_url(system.context, *path) }}">{{ system }}</a>
+                                                            <span class="mobile-only smaller-font">
+                                                                % if system.gtfs_loaded:
+                                                                    % if count == 1:
+                                                                        1 Stop
+                                                                    % else:
+                                                                        {{ count }} Stops
+                                                                    % end
+                                                                % end
+                                                            </span>
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                                % if system.gtfs_loaded:
+                                                    <td class="non-mobile align-right">{{ count }}</td>
+                                                    <td>
+                                                        % include('components/weekdays', schedule=system.schedule, compact=True)
+                                                    </td>
+                                                % else:
+                                                    <td class="lighter-text" colspan="2">Stops are loading...</td>
+                                                % end
+                                            </tr>
+                                        % end
                                     % end
                                 % end
-                            % end
-                        </tbody>
-                    </table>
+                            </tbody>
+                        </table>
+                    </div>
                 % end
             </div>
         </div>

--- a/views/pages/realtime/all.tpl
+++ b/views/pages/realtime/all.tpl
@@ -30,53 +30,55 @@
 % if positions:
     % known_positions = [p for p in positions if p.bus.order_id]
     % unknown_positions = sorted([p for p in positions if not p.bus.order_id])
-    <table>
-        <thead>
-            <tr>
-                <th>Bus</th>
-                % if not context.system:
-                    <th class="desktop-only">System</th>
-                % end
-                <th>Headsign</th>
-                % if context.enable_blocks:
-                    <th class="non-mobile">Block</th>
-                % end
-                <th class="non-mobile">Trip</th>
-                <th class="desktop-only">Next Stop</th>
-            </tr>
-        </thead>
-        <tbody>
-            % if unknown_positions:
-                <tr class="header">
-                    <td colspan="6">
-                        <div class="row space-between">
-                            <div>Unknown Year/Model</div>
-                            <div>{{ len(unknown_positions) }}</div>
-                        </div>
-                    </td>
+    <div class="table-border-wrapper">
+        <table>
+            <thead>
+                <tr>
+                    <th>Bus</th>
+                    % if not context.system:
+                        <th class="desktop-only">System</th>
+                    % end
+                    <th>Headsign</th>
+                    % if context.enable_blocks:
+                        <th class="non-mobile">Block</th>
+                    % end
+                    <th class="non-mobile">Trip</th>
+                    <th class="desktop-only">Next Stop</th>
                 </tr>
-                <tr class="display-none"></tr>
-                % for position in unknown_positions:
-                    % include('rows/realtime')
+            </thead>
+            <tbody>
+                % if unknown_positions:
+                    <tr class="header">
+                        <td colspan="6">
+                            <div class="row space-between">
+                                <div>Unknown Year/Model</div>
+                                <div>{{ len(unknown_positions) }}</div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr class="display-none"></tr>
+                    % for position in unknown_positions:
+                        % include('rows/realtime')
+                    % end
                 % end
-            % end
-            % for order in orders:
-                % order_positions = sorted([p for p in known_positions if p.bus.order_id == order.id])
-                <tr class="header">
-                    <td colspan="6">
-                        <div class="row space-between">
-                            <div>{{! order }}</div>
-                            <div>{{ len(order_positions) }}</div>
-                        </div>
-                    </td>
-                </tr>
-                <tr class="display-none"></tr>
-                % for position in order_positions:
-                    % include('rows/realtime')
+                % for order in orders:
+                    % order_positions = sorted([p for p in known_positions if p.bus.order_id == order.id])
+                    <tr class="header">
+                        <td colspan="6">
+                            <div class="row space-between">
+                                <div>{{! order }}</div>
+                                <div>{{ len(order_positions) }}</div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr class="display-none"></tr>
+                    % for position in order_positions:
+                        % include('rows/realtime')
+                    % end
                 % end
-            % end
-        </tbody>
-    </table>
+            </tbody>
+        </table>
+    </div>
     
     % include('components/top_button')
 % else:

--- a/views/pages/realtime/models.tpl
+++ b/views/pages/realtime/models.tpl
@@ -103,39 +103,41 @@
                                         % include('components/toggle')
                                     </div>
                                     <div class="content">
-                                        <table>
-                                            <thead>
-                                                <tr>
-                                                    <th>Bus</th>
-                                                    % if not context.system:
-                                                        <th class="desktop-only">System</th>
-                                                    % end
-                                                    <th>Headsign</th>
-                                                    % if context.enable_blocks:
-                                                        <th class="non-mobile">Block</th>
-                                                    % end
-                                                    <th class="non-mobile">Trip</th>
-                                                    <th class="desktop-only">Next Stop</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                % for order in model_orders:
-                                                    % order_positions = [p for p in model_positions if p.bus.order_id == order.id]
-                                                    <tr class="header">
-                                                        <td colspan="7">
-                                                            <div class="row space-between">
-                                                                <div>{{ order.years_string }}</div>
-                                                                <div>{{ len(order_positions) }}</div>
-                                                            </div>
-                                                        </td>
+                                        <div class="table-border-wrapper">
+                                            <table>
+                                                <thead>
+                                                    <tr>
+                                                        <th>Bus</th>
+                                                        % if not context.system:
+                                                            <th class="desktop-only">System</th>
+                                                        % end
+                                                        <th>Headsign</th>
+                                                        % if context.enable_blocks:
+                                                            <th class="non-mobile">Block</th>
+                                                        % end
+                                                        <th class="non-mobile">Trip</th>
+                                                        <th class="desktop-only">Next Stop</th>
                                                     </tr>
-                                                    <tr class="display-none"></tr>
-                                                    % for position in order_positions:
-                                                        % include('rows/realtime', position=position)
+                                                </thead>
+                                                <tbody>
+                                                    % for order in model_orders:
+                                                        % order_positions = [p for p in model_positions if p.bus.order_id == order.id]
+                                                        <tr class="header">
+                                                            <td colspan="6">
+                                                                <div class="row space-between">
+                                                                    <div>{{ order.years_string }}</div>
+                                                                    <div>{{ len(order_positions) }}</div>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        <tr class="display-none"></tr>
+                                                        % for position in order_positions:
+                                                            % include('rows/realtime', position=position)
+                                                        % end
                                                     % end
-                                                % end
-                                            </tbody>
-                                        </table>
+                                                </tbody>
+                                            </table>
+                                        </div>
                                     </div>
                                 </div>
                             % end

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -141,7 +141,7 @@
                     % include('components/toggle')
                 </div>
                 <div class="content">
-                    <table class="striped">
+                    <table>
                         <thead>
                             <tr>
                                 <th>Bus</th>

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -24,100 +24,102 @@
 </div>
 
 % if positions:
-    <table>
-        <thead>
-            <tr>
-                <th>Bus</th>
-                <th class="desktop-only">Model</th>
-                % if not context.system:
-                    <th class="desktop-only">System</th>
-                % end
-                <th class="desktop-only">Speed</th>
-                <th>Headsign</th>
-                % if context.enable_blocks:
-                    <th class="non-mobile">Block</th>
-                % end
-                <th class="non-mobile">Trip</th>
-                <th class="desktop-only">Next Stop</th>
-            </tr>
-        </thead>
-        <tbody>
-            % last_speed = None
-            % for position in sorted(positions, key=lambda p: p.speed, reverse=True):
-                % bus = position.bus
-                % trip = position.trip
-                % stop = position.stop
-                % same_speed = not last_speed or position.speed // 10 == last_speed
-                % last_speed = position.speed // 10
-                <tr class="{{'' if same_speed else 'divider'}}">
-                    <td>
-                        <div class="column">
-                            <div class="row">
-                                % include('components/bus')
-                                <div class="row gap-5">
-                                    % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
-                                    % include('components/adherence', adherence=position.adherence)
-                                </div>
-                            </div>
-                            <span class="non-desktop smaller-font">
-                                % include('components/year_model', year_model=bus.year_model)
-                            </span>
-                        </div>
-                    </td>
-                    <td class="desktop-only">
-                        % include('components/year_model', year_model=bus.year_model)
-                    </td>
+    <div class="table-border-wrapper">
+        <table>
+            <thead>
+                <tr>
+                    <th>Bus</th>
+                    <th class="desktop-only">Model</th>
                     % if not context.system:
-                        <td class="desktop-only">{{ position.context }}</td>
+                        <th class="desktop-only">System</th>
                     % end
-                    <td class="desktop-only no-wrap">{{ position.speed }} km/h</td>
-                    % if trip:
-                        % block = trip.block
+                    <th class="desktop-only">Speed</th>
+                    <th>Headsign</th>
+                    % if context.enable_blocks:
+                        <th class="non-mobile">Block</th>
+                    % end
+                    <th class="non-mobile">Trip</th>
+                    <th class="desktop-only">Next Stop</th>
+                </tr>
+            </thead>
+            <tbody>
+                % last_speed = None
+                % for position in sorted(positions, key=lambda p: p.speed, reverse=True):
+                    % bus = position.bus
+                    % trip = position.trip
+                    % stop = position.stop
+                    % same_speed = not last_speed or position.speed // 10 == last_speed
+                    % last_speed = position.speed // 10
+                    <tr class="{{'' if same_speed else 'divider'}}">
                         <td>
                             <div class="column">
-                                % include('components/headsign', departure=position.departure)
-                                <span class="non-desktop smaller-font no-wrap">{{ position.speed }} km/h</span>
-                                <div class="mobile-only smaller-font">
-                                    Trip:
-                                    % include('components/trip')
-                                </div>
-                                % if stop:
-                                    <div class="non-desktop smaller-font">
-                                        <span class="align-middle">Next Stop:</span>
-                                        % include('components/stop')
+                                <div class="row">
+                                    % include('components/bus')
+                                    <div class="row gap-5">
+                                        % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
+                                        % include('components/adherence', adherence=position.adherence)
                                     </div>
-                                % end
+                                </div>
+                                <span class="non-desktop smaller-font">
+                                    % include('components/year_model', year_model=bus.year_model)
+                                </span>
                             </div>
                         </td>
-                        % if context.enable_blocks:
+                        <td class="desktop-only">
+                            % include('components/year_model', year_model=bus.year_model)
+                        </td>
+                        % if not context.system:
+                            <td class="desktop-only">{{ position.context }}</td>
+                        % end
+                        <td class="desktop-only no-wrap">{{ position.speed }} km/h</td>
+                        % if trip:
+                            % block = trip.block
+                            <td>
+                                <div class="column">
+                                    % include('components/headsign', departure=position.departure)
+                                    <span class="non-desktop smaller-font no-wrap">{{ position.speed }} km/h</span>
+                                    <div class="mobile-only smaller-font">
+                                        Trip:
+                                        % include('components/trip')
+                                    </div>
+                                    % if stop:
+                                        <div class="non-desktop smaller-font">
+                                            <span class="align-middle">Next Stop:</span>
+                                            % include('components/stop')
+                                        </div>
+                                    % end
+                                </div>
+                            </td>
+                            % if context.enable_blocks:
+                                <td class="non-mobile">
+                                    <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
+                                </td>
+                            % end
                             <td class="non-mobile">
-                                <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
+                                % include('components/trip')
+                            </td>
+                        % else:
+                            <td colspan="3">
+                                <div class="column">
+                                    <span class="lighter-text">Not In Service</span>
+                                    <span class="non-desktop smaller-font no-wrap">{{ position.speed }} km/h</span>
+                                    % if stop:
+                                        <div class="non-desktop smaller-font">
+                                            <span class="align-middle">Next Stop:</span>
+                                            % include('components/stop')
+                                        </div>
+                                    % end
+                                </div>
                             </td>
                         % end
-                        <td class="non-mobile">
-                            % include('components/trip')
+                        <td class="desktop-only">
+                            % include('components/stop')
                         </td>
-                    % else:
-                        <td colspan="3">
-                            <div class="column">
-                                <span class="lighter-text">Not In Service</span>
-                                <span class="non-desktop smaller-font no-wrap">{{ position.speed }} km/h</span>
-                                % if stop:
-                                    <div class="non-desktop smaller-font">
-                                        <span class="align-middle">Next Stop:</span>
-                                        % include('components/stop')
-                                    </div>
-                                % end
-                            </div>
-                        </td>
-                    % end
-                    <td class="desktop-only">
-                        % include('components/stop')
-                    </td>
-                </tr>
-            % end
-        </tbody>
-    </table>
+                    </tr>
+                % end
+            </tbody>
+        </table>
+    </div>
     
     % include('components/top_button')
 % else:

--- a/views/pages/route/overview.tpl
+++ b/views/pages/route/overview.tpl
@@ -166,103 +166,105 @@
                                                 <span>are scheduled but may be swapped off.</span>
                                             </p>
                                         % end
-                                        <table>
-                                            <thead>
-                                                <tr>
-                                                    <th class="non-mobile">Start Time</th>
-                                                    <th class="mobile-only">Start</th>
-                                                    <th class="desktop-only">Headsign</th>
-                                                    % if context.enable_blocks:
-                                                        <th class="non-mobile">Block</th>
-                                                    % end
-                                                    <th>Trip</th>
-                                                    <th class="desktop-only">First Stop</th>
-                                                    % if context.realtime_enabled:
-                                                        <th>Bus</th>
-                                                        <th class="desktop-only">Model</th>
-                                                    % end
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                % last_start_time = None
-                                                % for trip in direction_trips:
-                                                    % first_stop = trip.first_stop
-                                                    % start_time = trip.start_time
-                                                    % if not start_time.is_unknown and not last_start_time:
-                                                        % last_start_time = start_time
-                                                    % end
-                                                    <tr class="{{'divider' if start_time.hour > last_start_time.hour else ''}}">
-                                                        <td>{{ trip.start_time.format_web(time_format) }}</td>
-                                                        <td class="desktop-only">
-                                                            % include('components/headsign')
-                                                        </td>
+                                        <div class="table-border-wrapper">
+                                            <table>
+                                                <thead>
+                                                    <tr>
+                                                        <th class="non-mobile">Start Time</th>
+                                                        <th class="mobile-only">Start</th>
+                                                        <th class="desktop-only">Headsign</th>
                                                         % if context.enable_blocks:
-                                                            <td class="non-mobile">
-                                                                % block = trip.block
-                                                                <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
-                                                            </td>
+                                                            <th class="non-mobile">Block</th>
                                                         % end
-                                                        <td>
-                                                            <div class="column">
-                                                                % include('components/trip')
-                                                                <span class="non-desktop smaller-font">
-                                                                    % include('components/headsign')
-                                                                </span>
-                                                            </div>
-                                                        </td>
-                                                        <td class="desktop-only">
-                                                            % include('components/stop', stop=first_stop)
-                                                        </td>
+                                                        <th>Trip</th>
+                                                        <th class="desktop-only">First Stop</th>
                                                         % if context.realtime_enabled:
-                                                            % if trip.id in recorded_today:
-                                                                % bus = recorded_today[trip.id]
-                                                                <td>
-                                                                    <div class="column">
-                                                                        <div class="row">
-                                                                            % include('components/bus')
-                                                                            % if trip.id in trip_positions:
-                                                                                % position = trip_positions[trip.id]
-                                                                                <div class="row gap-5">
-                                                                                    % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
-                                                                                    % include('components/adherence', adherence=position.adherence)
-                                                                                </div>
-                                                                            % end
-                                                                        </div>
-                                                                        <span class="non-desktop smaller-font">
-                                                                            % include('components/year_model', year_model=bus.year_model)
-                                                                        </span>
-                                                                    </div>
-                                                                </td>
-                                                                <td class="desktop-only">
-                                                                    % include('components/year_model', year_model=bus.year_model)
-                                                                </td>
-                                                            % elif (trip.context.system_id, trip.block_id) in assignments and trip.end_time.is_later:
-                                                                % assignment = assignments[(trip.context.system_id, trip.block_id)]
-                                                                % bus = assignment.bus
-                                                                <td>
-                                                                    <div class="column">
-                                                                        <div class="row">
-                                                                            % include('components/bus')
-                                                                            % include('components/scheduled')
-                                                                        </div>
-                                                                        <span class="non-desktop smaller-font">
-                                                                            % include('components/year_model', year_model=bus.year_model)
-                                                                        </span>
-                                                                    </div>
-                                                                </td>
-                                                                <td class="desktop-only">
-                                                                    % include('components/year_model', year_model=bus.year_model)
-                                                                </td>
-                                                            % else:
-                                                                <td class="desktop-only lighter-text" colspan="2">Unavailable</td>
-                                                                <td class="non-desktop lighter-text">Unavailable</td>
-                                                            % end
+                                                            <th>Bus</th>
+                                                            <th class="desktop-only">Model</th>
                                                         % end
                                                     </tr>
-                                                    % last_start_time = start_time
-                                                % end
-                                            </tbody>
-                                        </table>
+                                                </thead>
+                                                <tbody>
+                                                    % last_start_time = None
+                                                    % for trip in direction_trips:
+                                                        % first_stop = trip.first_stop
+                                                        % start_time = trip.start_time
+                                                        % if not start_time.is_unknown and not last_start_time:
+                                                            % last_start_time = start_time
+                                                        % end
+                                                        <tr class="{{'divider' if start_time.hour > last_start_time.hour else ''}}">
+                                                            <td>{{ trip.start_time.format_web(time_format) }}</td>
+                                                            <td class="desktop-only">
+                                                                % include('components/headsign')
+                                                            </td>
+                                                            % if context.enable_blocks:
+                                                                <td class="non-mobile">
+                                                                    % block = trip.block
+                                                                    <a href="{{ get_url(block.context, 'blocks', block) }}">{{ block.id }}</a>
+                                                                </td>
+                                                            % end
+                                                            <td>
+                                                                <div class="column">
+                                                                    % include('components/trip')
+                                                                    <span class="non-desktop smaller-font">
+                                                                        % include('components/headsign')
+                                                                    </span>
+                                                                </div>
+                                                            </td>
+                                                            <td class="desktop-only">
+                                                                % include('components/stop', stop=first_stop)
+                                                            </td>
+                                                            % if context.realtime_enabled:
+                                                                % if trip.id in recorded_today:
+                                                                    % bus = recorded_today[trip.id]
+                                                                    <td>
+                                                                        <div class="column">
+                                                                            <div class="row">
+                                                                                % include('components/bus')
+                                                                                % if trip.id in trip_positions:
+                                                                                    % position = trip_positions[trip.id]
+                                                                                    <div class="row gap-5">
+                                                                                        % include('components/occupancy', occupancy=position.occupancy, show_tooltip=True)
+                                                                                        % include('components/adherence', adherence=position.adherence)
+                                                                                    </div>
+                                                                                % end
+                                                                            </div>
+                                                                            <span class="non-desktop smaller-font">
+                                                                                % include('components/year_model', year_model=bus.year_model)
+                                                                            </span>
+                                                                        </div>
+                                                                    </td>
+                                                                    <td class="desktop-only">
+                                                                        % include('components/year_model', year_model=bus.year_model)
+                                                                    </td>
+                                                                % elif (trip.context.system_id, trip.block_id) in assignments and trip.end_time.is_later:
+                                                                    % assignment = assignments[(trip.context.system_id, trip.block_id)]
+                                                                    % bus = assignment.bus
+                                                                    <td>
+                                                                        <div class="column">
+                                                                            <div class="row">
+                                                                                % include('components/bus')
+                                                                                % include('components/scheduled')
+                                                                            </div>
+                                                                            <span class="non-desktop smaller-font">
+                                                                                % include('components/year_model', year_model=bus.year_model)
+                                                                            </span>
+                                                                        </div>
+                                                                    </td>
+                                                                    <td class="desktop-only">
+                                                                        % include('components/year_model', year_model=bus.year_model)
+                                                                    </td>
+                                                                % else:
+                                                                    <td class="desktop-only lighter-text" colspan="2">Unavailable</td>
+                                                                    <td class="non-desktop lighter-text">Unavailable</td>
+                                                                % end
+                                                            % end
+                                                        </tr>
+                                                        % last_start_time = start_time
+                                                    % end
+                                                </tbody>
+                                            </table>
+                                        </div>
                                     </div>
                                 </div>
                             % end

--- a/views/pages/routes/list.tpl
+++ b/views/pages/routes/list.tpl
@@ -67,55 +67,57 @@
 % else:
     <div class="placeholder">
         <p>Choose a system to see individual routes.</p>
-        <table>
-            <thead>
-                <tr>
-                    <th>System</th>
-                    <th class="non-mobile align-right">Routes</th>
-                    <th>Service Days</th>
-                </tr>
-            </thead>
-            <tbody>
-                % for region in regions:
-                    % region_systems = [s for s in systems if s.region == region]
-                    % if region_systems:
-                        <tr class="header">
-                            <td colspan="3">{{ region }}</td>
-                        </tr>
-                        <tr class="display-none"></tr>
-                        % for system in sorted(region_systems):
-                            % count = len(system.get_routes())
-                            <tr>
-                                <td>
-                                    <div class="row">
-                                        % include('components/agency_logo', agency=system.agency)
-                                        <div class="column">
-                                            <a href="{{ get_url(system.context, *path) }}">{{ system }}</a>
-                                            <span class="mobile-only smaller-font">
-                                                % if system.gtfs_loaded:
-                                                    % if count == 1:
-                                                        1 Route
-                                                    % else:
-                                                        {{ count }} Routes
-                                                    % end
-                                                % end
-                                            </span>
-                                        </div>
-                                    </div>
-                                </td>
-                                % if system.gtfs_loaded:
-                                    <td class="non-mobile align-right">{{ count }}</td>
-                                    <td>
-                                        % include('components/weekdays', schedule=system.schedule, compact=True)
-                                    </td>
-                                % else:
-                                    <td class="lighter-text" colspan="2">Routes are loading...</td>
-                                % end
+        <div class="table-border-wrapper">
+            <table>
+                <thead>
+                    <tr>
+                        <th>System</th>
+                        <th class="non-mobile align-right">Routes</th>
+                        <th>Service Days</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    % for region in regions:
+                        % region_systems = [s for s in systems if s.region == region]
+                        % if region_systems:
+                            <tr class="header">
+                                <td colspan="3">{{ region }}</td>
                             </tr>
+                            <tr class="display-none"></tr>
+                            % for system in sorted(region_systems):
+                                % count = len(system.get_routes())
+                                <tr>
+                                    <td>
+                                        <div class="row">
+                                            % include('components/agency_logo', agency=system.agency)
+                                            <div class="column">
+                                                <a href="{{ get_url(system.context, *path) }}">{{ system }}</a>
+                                                <span class="mobile-only smaller-font">
+                                                    % if system.gtfs_loaded:
+                                                        % if count == 1:
+                                                            1 Route
+                                                        % else:
+                                                            {{ count }} Routes
+                                                        % end
+                                                    % end
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </td>
+                                    % if system.gtfs_loaded:
+                                        <td class="non-mobile align-right">{{ count }}</td>
+                                        <td>
+                                            % include('components/weekdays', schedule=system.schedule, compact=True)
+                                        </td>
+                                    % else:
+                                        <td class="lighter-text" colspan="2">Routes are loading...</td>
+                                    % end
+                                </tr>
+                            % end
                         % end
                     % end
-                % end
-            </tbody>
-        </table>
+                </tbody>
+            </table>
+        </div>
     </div>
 % end

--- a/views/pages/stops/stops.tpl
+++ b/views/pages/stops/stops.tpl
@@ -239,57 +239,59 @@
 % else:
     <div class="placeholder">
         <p>Choose a system to see individual stops.</p>
-        <table>
-            <thead>
-                <tr>
-                    <th>System</th>
-                    <th class="non-mobile align-right">Stops</th>
-                    <th>Service Days</th>
-                </tr>
-            </thead>
-            <tbody>
-                % for region in regions:
-                    % region_systems = [s for s in systems if s.region == region]
-                    % if region_systems:
-                        <tr class="header">
-                            <td colspan="3">
-                                {{ region }}
-                            </td>
-                        </tr>
-                        <tr class="display-none"></tr>
-                        % for system in sorted(region_systems):
-                            % count = len(system.get_stops())
-                            <tr>
-                                <td>
-                                    <div class="row">
-                                        % include('components/agency_logo', agency=system.agency)
-                                        <div class="column">
-                                            <a href="{{ get_url(system.context, *path) }}">{{ system }}</a>
-                                            <span class="mobile-only smaller-font">
-                                                % if system.gtfs_loaded:
-                                                    % if count == 1:
-                                                        1 Stop
-                                                    % else:
-                                                        {{ count }} Stops
-                                                    % end
-                                                % end
-                                            </span>
-                                        </div>
-                                    </div>
+        <div class="table-border-wrapper">
+            <table>
+                <thead>
+                    <tr>
+                        <th>System</th>
+                        <th class="non-mobile align-right">Stops</th>
+                        <th>Service Days</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    % for region in regions:
+                        % region_systems = [s for s in systems if s.region == region]
+                        % if region_systems:
+                            <tr class="header">
+                                <td colspan="3">
+                                    {{ region }}
                                 </td>
-                                % if system.gtfs_loaded:
-                                    <td class="non-mobile align-right">{{ count }}</td>
-                                    <td>
-                                        % include('components/weekdays', schedule=system.schedule, compact=True)
-                                    </td>
-                                % else:
-                                    <td class="lighter-text" colspan="2">Stops are loading...</td>
-                                % end
                             </tr>
+                            <tr class="display-none"></tr>
+                            % for system in sorted(region_systems):
+                                % count = len(system.get_stops())
+                                <tr>
+                                    <td>
+                                        <div class="row">
+                                            % include('components/agency_logo', agency=system.agency)
+                                            <div class="column">
+                                                <a href="{{ get_url(system.context, *path) }}">{{ system }}</a>
+                                                <span class="mobile-only smaller-font">
+                                                    % if system.gtfs_loaded:
+                                                        % if count == 1:
+                                                            1 Stop
+                                                        % else:
+                                                            {{ count }} Stops
+                                                        % end
+                                                    % end
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </td>
+                                    % if system.gtfs_loaded:
+                                        <td class="non-mobile align-right">{{ count }}</td>
+                                        <td>
+                                            % include('components/weekdays', schedule=system.schedule, compact=True)
+                                        </td>
+                                    % else:
+                                        <td class="lighter-text" colspan="2">Stops are loading...</td>
+                                    % end
+                                </tr>
+                            % end
                         % end
                     % end
-                % end
-            </tbody>
-        </table>
+                </tbody>
+            </table>
+        </div>
     </div>
 % end

--- a/views/pages/systems.tpl
+++ b/views/pages/systems.tpl
@@ -5,108 +5,110 @@
     <h1>Systems</h1>
 </div>
 
-<table>
-    <thead>
-        <tr>
-            <th>System</th>
-            <th class="desktop-only">Online</th>
-            <th class="desktop-only align-right">In Service</th>
-            <th class="desktop-only align-right">Seen</th>
-            <th class="desktop-only align-right">Tracked</th>
-            <th class="desktop-only align-right">Routes</th>
-            <th class="desktop-only align-right">Stops</th>
-            <th class="desktop-only align-right">Blocks</th>
-            <th class="desktop-only align-right">Trips</th>
-            <th class="non-desktop">Details</th>
-            <th class="non-mobile">Service Days</th>
-        </tr>
-    </thead>
-    <tbody>
-        % for region in regions:
-            <tr class="header">
-                <td class="section" colspan="11">{{ region }}</td>
+<div class="table-border-wrapper">
+    <table>
+        <thead>
+            <tr>
+                <th>System</th>
+                <th class="desktop-only">Online</th>
+                <th class="desktop-only align-right">In Service</th>
+                <th class="desktop-only align-right">Seen</th>
+                <th class="desktop-only align-right">Tracked</th>
+                <th class="desktop-only align-right">Routes</th>
+                <th class="desktop-only align-right">Stops</th>
+                <th class="desktop-only align-right">Blocks</th>
+                <th class="desktop-only align-right">Trips</th>
+                <th class="non-desktop">Details</th>
+                <th class="non-mobile">Service Days</th>
             </tr>
-            <tr class="display-none"></tr>
-            % region_systems = sorted([s for s in systems if s.region == region])
-            % for system in sorted(region_systems):
-                <tr>
-                    <td>
-                        <div class="row">
-                            % include('components/agency_logo', agency=system.agency)
-                            <a href="{{ get_url(system.context) }}">{{ system }}</a>
-                        </div>
-                    </td>
-                    <td class="non-desktop">
-                        <div class="column">
-                            % if system.realtime_enabled and system.realtime_loaded:
-                                % positions = system.get_positions()
-                                % overviews = system.get_overviews()
-                                <div class="row gap-5">
-                                    <span class="bold">Online:</span>
-                                    {{ len(positions) }}
-                                </div>
-                                <div class="row gap-5">
-                                    <span class="bold">In Service:</span>
-                                    {{ len([p for p in positions if p.trip]) }}
-                                </div>
-                                <div class="row gap-5">
-                                    <span class="bold">Seen:</span>
-                                    {{ len(overviews) }}
-                                </div>
-                                <div class="row gap-5">
-                                    <span class="bold">Tracked:</span>
-                                    {{ len([o for o in overviews if o.last_record]) }}
-                                </div>
-                            % end
-                            % if system.gtfs_enabled and system.gtfs_loaded:
-                                <div class="row gap-5">
-                                    <span class="bold">Routes:</span>
-                                    {{ len(system.get_routes()) }}
-                                </div>
-                                <div class="row gap-5">
-                                    <span class="bold">Stops:</span>
-                                    {{ len(system.get_stops()) }}
-                                </div>
-                                <div class="row gap-5">
-                                    <span class="bold">Blocks:</span>
-                                    {{ len(system.get_blocks()) }}
-                                </div>
-                                <div class="row gap-5">
-                                    <span class="bold">Trips:</span>
-                                    {{ len(system.get_trips()) }}
-                                </div>
-                            % end
-                        </div>
-                    </td>
-                    % if system.realtime_enabled:
-                        % if system.realtime_loaded:
-                            <td class="desktop-only align-right">{{ len(positions) }}</td>
-                            <td class="desktop-only align-right">{{ len([p for p in positions if p.trip]) }}</td>
-                            <td class="desktop-only align-right">{{ len(overviews) }}</td>
-                            <td class="desktop-only align-right">{{ len([o for o in overviews if o.last_record]) }}</td>
-                        % else:
-                            <td class="lighter-text desktop-only" colspan="4">Data is loading</td>
-                        % end
-                    % else:
-                        <td class="lighter-text desktop-only" colspan="4">Unavailable</td>
-                    % end
-                    % if system.gtfs_enabled:
-                        % if system.gtfs_enabled:
-                            <td class="desktop-only align-right">{{ len(system.get_routes()) }}</td>
-                            <td class="desktop-only align-right">{{ len(system.get_stops()) }}</td>
-                            <td class="desktop-only align-right">{{ len(system.get_blocks()) }}</td>
-                            <td class="desktop-only align-right">{{ len(system.get_trips()) }}</td>
-                            <td class="non-mobile">
-                                % include('components/weekdays', schedule=system.schedule, compact=True)
-                            </td>
-                        % else:
-                            <td class="lighter-text non-mobile" colspan="5">Data is loading</td>
-                        % end
-                    % else:
-                        <td class="lighter-text non-mobile" colspan="5">Unavailable</td>
-                    % end
+        </thead>
+        <tbody>
+            % for region in regions:
+                <tr class="header">
+                    <td class="section" colspan="11">{{ region }}</td>
                 </tr>
+                <tr class="display-none"></tr>
+                % region_systems = sorted([s for s in systems if s.region == region])
+                % for system in sorted(region_systems):
+                    <tr>
+                        <td>
+                            <div class="row">
+                                % include('components/agency_logo', agency=system.agency)
+                                <a href="{{ get_url(system.context) }}">{{ system }}</a>
+                            </div>
+                        </td>
+                        <td class="non-desktop">
+                            <div class="column">
+                                % if system.realtime_enabled and system.realtime_loaded:
+                                    % positions = system.get_positions()
+                                    % overviews = system.get_overviews()
+                                    <div class="row gap-5">
+                                        <span class="bold">Online:</span>
+                                        {{ len(positions) }}
+                                    </div>
+                                    <div class="row gap-5">
+                                        <span class="bold">In Service:</span>
+                                        {{ len([p for p in positions if p.trip]) }}
+                                    </div>
+                                    <div class="row gap-5">
+                                        <span class="bold">Seen:</span>
+                                        {{ len(overviews) }}
+                                    </div>
+                                    <div class="row gap-5">
+                                        <span class="bold">Tracked:</span>
+                                        {{ len([o for o in overviews if o.last_record]) }}
+                                    </div>
+                                % end
+                                % if system.gtfs_enabled and system.gtfs_loaded:
+                                    <div class="row gap-5">
+                                        <span class="bold">Routes:</span>
+                                        {{ len(system.get_routes()) }}
+                                    </div>
+                                    <div class="row gap-5">
+                                        <span class="bold">Stops:</span>
+                                        {{ len(system.get_stops()) }}
+                                    </div>
+                                    <div class="row gap-5">
+                                        <span class="bold">Blocks:</span>
+                                        {{ len(system.get_blocks()) }}
+                                    </div>
+                                    <div class="row gap-5">
+                                        <span class="bold">Trips:</span>
+                                        {{ len(system.get_trips()) }}
+                                    </div>
+                                % end
+                            </div>
+                        </td>
+                        % if system.realtime_enabled:
+                            % if system.realtime_loaded:
+                                <td class="desktop-only align-right">{{ len(positions) }}</td>
+                                <td class="desktop-only align-right">{{ len([p for p in positions if p.trip]) }}</td>
+                                <td class="desktop-only align-right">{{ len(overviews) }}</td>
+                                <td class="desktop-only align-right">{{ len([o for o in overviews if o.last_record]) }}</td>
+                            % else:
+                                <td class="lighter-text desktop-only" colspan="4">Data is loading</td>
+                            % end
+                        % else:
+                            <td class="lighter-text desktop-only" colspan="4">Unavailable</td>
+                        % end
+                        % if system.gtfs_enabled:
+                            % if system.gtfs_enabled:
+                                <td class="desktop-only align-right">{{ len(system.get_routes()) }}</td>
+                                <td class="desktop-only align-right">{{ len(system.get_stops()) }}</td>
+                                <td class="desktop-only align-right">{{ len(system.get_blocks()) }}</td>
+                                <td class="desktop-only align-right">{{ len(system.get_trips()) }}</td>
+                                <td class="non-mobile">
+                                    % include('components/weekdays', schedule=system.schedule, compact=True)
+                                </td>
+                            % else:
+                                <td class="lighter-text non-mobile" colspan="5">Data is loading</td>
+                            % end
+                        % else:
+                            <td class="lighter-text non-mobile" colspan="5">Unavailable</td>
+                        % end
+                    </tr>
+                % end
             % end
-        % end
-	</tbody>
-</table>
+        </tbody>
+    </table>
+</div>

--- a/views/pages/trip/history.tpl
+++ b/views/pages/trip/history.tpl
@@ -63,49 +63,51 @@
                                 <span>may be accidental logins.</span>
                             </p>
                         % end
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>Date</th>
-                                    <th>Bus</th>
-                                    <th class="desktop-only">Model</th>
-                                    <th class="no-wrap non-mobile">First Seen</th>
-                                    <th class="no-wrap">Last Seen</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                % last_date = None
-                                % for record in records:
-                                    % bus = record.bus
-                                    % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
-                                        <tr class="header">
-                                            <td colspan="5">{{ record.date.format_month() }}</td>
-                                            <tr class="display-none"></tr>
+                        <div class="table-border-wrapper">
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th>Date</th>
+                                        <th>Bus</th>
+                                        <th class="desktop-only">Model</th>
+                                        <th class="no-wrap non-mobile">First Seen</th>
+                                        <th class="no-wrap">Last Seen</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    % last_date = None
+                                    % for record in records:
+                                        % bus = record.bus
+                                        % if not last_date or record.date.year != last_date.year or record.date.month != last_date.month:
+                                            <tr class="header">
+                                                <td colspan="5">{{ record.date.format_month() }}</td>
+                                                <tr class="display-none"></tr>
+                                            </tr>
+                                        % end
+                                        % last_date = record.date
+                                        <tr>
+                                            <td>{{ record.date.format_day() }}</td>
+                                            <td>
+                                                <div class="column stretch">
+                                                    <div class="row space-between">
+                                                        % include('components/bus')
+                                                        % include('components/record_warnings')
+                                                    </div>
+                                                    <span class="non-desktop smaller-font">
+                                                        % include('components/year_model', year_model=bus.year_model)
+                                                    </span>
+                                                </div>
+                                            </td>
+                                            <td class="desktop-only">
+                                                % include('components/year_model', year_model=bus.year_model)
+                                            </td>
+                                            <td class="non-mobile">{{ record.first_seen.format_web(time_format) }}</td>
+                                            <td>{{ record.last_seen.format_web(time_format) }}</td>
                                         </tr>
                                     % end
-                                    % last_date = record.date
-                                    <tr>
-                                        <td>{{ record.date.format_day() }}</td>
-                                        <td>
-                                            <div class="column stretch">
-                                                <div class="row space-between">
-                                                    % include('components/bus')
-                                                    % include('components/record_warnings')
-                                                </div>
-                                                <span class="non-desktop smaller-font">
-                                                    % include('components/year_model', year_model=bus.year_model)
-                                                </span>
-                                            </div>
-                                        </td>
-                                        <td class="desktop-only">
-                                            % include('components/year_model', year_model=bus.year_model)
-                                        </td>
-                                        <td class="non-mobile">{{ record.first_seen.format_web(time_format) }}</td>
-                                        <td>{{ record.last_seen.format_web(time_format) }}</td>
-                                    </tr>
-                                % end
-                            </tbody>
-                        </table>
+                                </tbody>
+                            </table>
+                        </div>
                     % else:
                         <div class="placeholder">
                             <h3>This trip doesn't have any recorded history</h3>

--- a/views/pages/trip/overview.tpl
+++ b/views/pages/trip/overview.tpl
@@ -226,78 +226,80 @@
                 </div>
                 <div class="content">
                     <p>This bus is currently assigned to this trip's block but may be swapped off before this trip runs.</p>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Bus</th>
-                                <th class="non-mobile">Model</th>
-                                <th>Current Headsign</th>
-                                <th class="desktop-only">Current Trip</th>
-                                <th class="non-mobile">Next Stop</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <div class="column">
-                                        <div class="row">
-                                            % include('components/bus')
-                                            % if position:
-                                                % include('components/adherence', adherence=position.adherence)
-                                            % end
-                                        </div>
-                                        <span class="mobile-only smaller-font">
-                                            % include('components/year_model', year_model=bus.year_model)
-                                        </span>
-                                    </div>
-                                </td>
-                                <td class="non-mobile">
-                                    % include('components/year_model', year_model=bus.year_model)
-                                </td>
-                                % if position:
-                                    % trip = position.trip
-                                    % stop = position.stop
-                                    % if trip:
-                                        <td>
-                                            <div class="column">
-                                                % include('components/headsign', departure=position.departure, trip=position.trip)
-                                                <div class="non-desktop smaller-font">
-                                                    Trip:
-                                                    % include('components/trip', include_tooltip=False, trip=position.trip)
-                                                </div>
-                                                % if stop:
-                                                    <div class="mobile-only smaller-font">
-                                                        <span class="align-middle">Next Stop:</span>
-                                                        % include('components/stop')
-                                                    </div>
+                    <div class="table-border-wrapper">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Bus</th>
+                                    <th class="non-mobile">Model</th>
+                                    <th>Current Headsign</th>
+                                    <th class="desktop-only">Current Trip</th>
+                                    <th class="non-mobile">Next Stop</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <div class="column">
+                                            <div class="row">
+                                                % include('components/bus')
+                                                % if position:
+                                                    % include('components/adherence', adherence=position.adherence)
                                                 % end
                                             </div>
-                                        </td>
-                                        <td class="desktop-only">
-                                            % include('components/trip', include_tooltip=False, trip=position.trip)
+                                            <span class="mobile-only smaller-font">
+                                                % include('components/year_model', year_model=bus.year_model)
+                                            </span>
+                                        </div>
+                                    </td>
+                                    <td class="non-mobile">
+                                        % include('components/year_model', year_model=bus.year_model)
+                                    </td>
+                                    % if position:
+                                        % trip = position.trip
+                                        % stop = position.stop
+                                        % if trip:
+                                            <td>
+                                                <div class="column">
+                                                    % include('components/headsign', departure=position.departure, trip=position.trip)
+                                                    <div class="non-desktop smaller-font">
+                                                        Trip:
+                                                        % include('components/trip', include_tooltip=False, trip=position.trip)
+                                                    </div>
+                                                    % if stop:
+                                                        <div class="mobile-only smaller-font">
+                                                            <span class="align-middle">Next Stop:</span>
+                                                            % include('components/stop')
+                                                        </div>
+                                                    % end
+                                                </div>
+                                            </td>
+                                            <td class="desktop-only">
+                                                % include('components/trip', include_tooltip=False, trip=position.trip)
+                                            </td>
+                                        % else:
+                                            <td colspan="2">
+                                                <div class="column">
+                                                    <div class="lighter-text">Not In Service</div>
+                                                    % if stop:
+                                                        <div class="mobile-only smaller-font">
+                                                            <span class="align-middle">Next Stop:</span>
+                                                            % include('components/stop')
+                                                        </div>
+                                                    % end
+                                                </div>
+                                            </td>
+                                        % end
+                                        <td class="non-mobile">
+                                            % include('components/stop')
                                         </td>
                                     % else:
-                                        <td colspan="2">
-                                            <div class="column">
-                                                <div class="lighter-text">Not In Service</div>
-                                                % if stop:
-                                                    <div class="mobile-only smaller-font">
-                                                        <span class="align-middle">Next Stop:</span>
-                                                        % include('components/stop')
-                                                    </div>
-                                                % end
-                                            </div>
-                                        </td>
+                                        <td class="lighter-text" colspan="3">Not In Service</td>
                                     % end
-                                    <td class="non-mobile">
-                                        % include('components/stop')
-                                    </td>
-                                % else:
-                                    <td class="lighter-text" colspan="3">Not In Service</td>
-                                % end
-                            </tr>
-                        </tbody>
-                    </table>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
         % end


### PR DESCRIPTION
On some browsers (notably Safari and Safari-based ones like Chrome on iOS), colspans that exceed the number of actual columns in the table can cause a visual bug where the table appears to be missing a border on the right side.

<img width="446" height="505" alt="Screenshot 2025-07-27 at 22 04 26" src="https://github.com/user-attachments/assets/d87ecace-fea4-4f03-809a-e888107b9595" />

To fix this, we can add a wrapper div around the table that has the border instead of the table itself.

<img width="403" height="498" alt="Screenshot 2025-07-27 at 22 10 28" src="https://github.com/user-attachments/assets/1ce9461d-3305-4385-b0e4-c053455e8889" />

Majority of the changes here are just indentation. There's some CSS changes to ensure the wrappers have the right layout behaviour, as well as adding a CSS variable for the table border colour.

In total 20/56 tables are modified. Basic criteria for changing is any table with colspans that has columns with visibility logic.