### PR TITLE
Add date range to bus history pages

### DIFF
--- a/views/pages/bus/history.tpl
+++ b/views/pages/bus/history.tpl
@@ -80,10 +80,7 @@
                         % include('components/paging')
                         
                         % dates = {r.date for r in records}
-                        % min_date = min(dates)
-                        % max_date = max(dates)
-                        <h3 class="non-mobile">{{ min_date.format_long() }} - {{ max_date.format_long() }}</h3>
-                        <h3 class="mobile-only">{{ min_date.format_short() }} - {{ max_date.format_short() }}</h3>
+                        <h3>{{ min(dates).format_long() }} - {{ max(dates).format_long() }}</h3>
                         
                         % if [r for r in records if r.warnings]:
                             <p>


### PR DESCRIPTION
A common use case for going back through a bus' history is seeing what it was doing during a particular date or date range. While going back through the pages, the only way to know what dates you're actually looking at is to check the row at the top of the page and scroll down to the row at the bottom. This can be frustrating and time consuming.

This can be made easier by including the date range for the page right at the top, so there's no need to scroll on every page to see if you need to go to the next.

<img width="997" height="636" alt="Screenshot 2025-08-01 at 23 57 14" src="https://github.com/user-attachments/assets/4c020b5a-7036-45d2-b958-f83f22178270" />

<img width="988" height="629" alt="Screenshot 2025-08-01 at 23 50 14" src="https://github.com/user-attachments/assets/1582ea06-3d4f-483e-a29a-f9833356f496" />

(Note: for demonstrative purposes the page size has been set to 10 rows in these pictures but the normal is still 100 rows)