### PR TITLE
Add GTFS cutoff date

### DIFF
--- a/models/service.py
+++ b/models/service.py
@@ -45,7 +45,7 @@ class Service:
     '''A set of dates when a transit service is operating'''
     
     system: System
-    id: int
+    id: str
     schedule: Schedule
     
     @classmethod

--- a/models/sheet.py
+++ b/models/sheet.py
@@ -46,7 +46,7 @@ class Sheet:
     
     system: System
     schedule: Schedule
-    services: list[Service]
+    services: set[Service]
     service_groups: list[ServiceGroup]
     modifications: set[Date]
     copies: dict[tuple, Self]
@@ -117,7 +117,7 @@ class Sheet:
     
     def copy(self, services):
         '''Returns a duplicate of this sheet, restricted to the given services'''
-        services = [s for s in self.services if s in services]
+        services = {s for s in self.services if s in services}
         key = tuple(sorted(services))
         if key in self.copies:
             return self.copies[key]

--- a/models/system.py
+++ b/models/system.py
@@ -33,6 +33,7 @@ class System:
     timezone: pytz.BaseTzInfo = DEFAULT_TIMEZONE
     colour_routes: str | None = None
     enable_force_gtfs: bool = True
+    gtfs_cutoff: str | None = None
     
     gtfs_downloaded: bool | None = field(default=None, init=False)
     gtfs_loaded: bool = field(default=False, init=False)

--- a/services/impl/gtfs.py
+++ b/services/impl/gtfs.py
@@ -36,11 +36,6 @@ class GTFSService:
             self.download(context)
             update_db = True
         
-        if update_db:
-            self.update_database(context)
-        
-        print(f'Loading GTFS data for {context}')
-        
         exceptions = read_csv(context, 'calendar_dates', lambda r: ServiceException.from_csv(r, context))
         service_exceptions = {}
         for exception in exceptions:
@@ -58,6 +53,22 @@ class GTFSService:
             services = read_csv(context, 'calendar', lambda r: Service.from_csv(r, context, service_exceptions, feed_date_range))
         except:
             services = [Service.combine(context, service_id, exceptions) for (service_id, exceptions) in service_exceptions.items()]
+        
+        gtfs_cutoff = context.system.gtfs_cutoff
+        if gtfs_cutoff:
+            cutoff_date = Date.parse(gtfs_cutoff, context.timezone)
+            if cutoff_date > Date.today(context.timezone):
+                services = [s for s in services if s.schedule.date_range.start <= cutoff_date]
+                filter_service_ids = {s.id for s in services}
+            else:
+                filter_service_ids = set()
+        else:
+            filter_service_ids = set()
+        
+        if update_db:
+            self.update_database(context, filter_service_ids)
+        
+        print(f'Loading GTFS data for {context}')
         
         context.system.services = {s.id: s for s in services}
         context.system.sheets = combine_sheets(context, services)
@@ -107,7 +118,7 @@ class GTFSService:
             zip.extractall(data_path)
         context.system.gtfs_downloaded = True
     
-    def update_database(self, context: Context):
+    def update_database(self, context: Context, filter_service_ids: set[str]):
         '''Updates cached GTFS data for the given system'''
         print(f'Updating database with GTFS data for {context}')
         
@@ -119,8 +130,13 @@ class GTFSService:
         
         apply_csv(context, 'routes', repositories.route.create)
         apply_csv(context, 'stops', repositories.stop.create)
-        apply_csv(context, 'trips', repositories.trip.create)
-        apply_csv(context, 'stop_times', repositories.departure.create)
+        if filter_service_ids:
+            filtered_rows = apply_csv(context, 'trips', repositories.trip.create, filter=lambda r: r['service_id'] in filter_service_ids)
+            filtered_trip_ids = {r['trip_id'] for r in filtered_rows}
+            apply_csv(context, 'stop_times', repositories.departure.create, filter=lambda r: r['trip_id'] in filtered_trip_ids)
+        else:
+            apply_csv(context, 'trips', repositories.trip.create)
+            apply_csv(context, 'stop_times', repositories.departure.create)
         apply_csv(context, 'shapes', repositories.point.create)
         
         self.database.commit()
@@ -143,15 +159,21 @@ def read_csv(context: Context, name, initializer):
         columns = next(reader)
         return [initializer(dict(zip(columns, row))) for row in reader]
 
-def apply_csv(context: Context, name, function):
+def apply_csv(context: Context, name, function, filter=None):
     '''Opens a CSV file and applies a function to each row'''
     with open(f'./data/gtfs/{context.system_id}/{name}.txt', 'r', encoding='utf-8-sig') as file:
         reader = csv.reader(file)
         columns = next(reader)
+        filtered_rows = []
         for row in reader:
-            function(context, dict(zip(columns, row)))
+            data = dict(zip(columns, row))
+            if not filter or filter(data):
+                function(context, data)
+                if filter:
+                    filtered_rows.append(data)
+        return filtered_rows
 
-def combine_sheets(context: Context, services):
+def combine_sheets(context: Context, services: list[Service]):
     '''Returns a list of sheets made from services with overlapping start/end dates'''
     if not services:
         return []
@@ -164,7 +186,8 @@ def combine_sheets(context: Context, services):
     sorted_dates = sorted(dates)[1:-1]
     i = iter(sorted_dates)
     
-    sheets = []
+    sheets: list[Sheet] = []
+    previous_date_range_services = set()
     for (start_date, end_date) in zip(i, i):
         date_range = DateRange(start_date, end_date)
         date_range_services = {s for s in services if s.schedule.date_range.overlaps(date_range)}
@@ -172,7 +195,7 @@ def combine_sheets(context: Context, services):
             continue
         if sheets:
             previous_sheet = sheets[-1]
-            if previous_sheet.services.issubset(date_range_services) or date_range_services.issubset(previous_sheet.services):
+            if previous_date_range_services.issubset(date_range_services) or date_range_services.issubset(previous_date_range_services):
                 date_range = DateRange.combine([previous_sheet.schedule.date_range, date_range])
                 new_services = {s for s in services if s.schedule.date_range.overlaps(date_range)}
                 sheets[-1] = Sheet(context.system, new_services, date_range)
@@ -180,6 +203,7 @@ def combine_sheets(context: Context, services):
                 sheets.append(Sheet(context.system, date_range_services, date_range))
         else:
             sheets.append(Sheet(context.system, date_range_services, date_range))
+        previous_date_range_services = date_range_services
     final_sheets = []
     for sheet in sheets:
         if final_sheets:

--- a/static/systems.json
+++ b/static/systems.json
@@ -39,7 +39,7 @@
             "victoria": {
                 "name": "Victoria",
                 "remote_id": 48,
-                "enable_force_gtfs": false
+                "gtfs_cutoff": "2025-12-07"
             },
             "west-coast": {
                 "name": "West Coast",


### PR DESCRIPTION
A (hopeful) solution to the Victoria GTFS performance issues. This allows us to specify a date to limit our data to. This limit gets applied to both the services stored in memory as well as data being put into the database, which ensures that the site UI remains consistent and the DB isn't full of unused data that slows down operations. Note that the cutoff date applies to the _start_ of a sheet rather than the end, so if you specify a cutoff of Feb 1 then a sheet running Jan 1 to Feb 2 would still be shown, but a sheet starting Feb 2 would not. If the current date passes the cutoff date then the filter is not applied, to ensure that cutoffs accidentally left in won't just cause all the data to disappear.

There's a minor efficiency decrease when updating the database GTFS because of the filtering, but all things considered this is one of the most efficient implementations we've had in general - previous versions have done a lot of extra iteration and processing, whereas this is built in to existing loops. Most of the inefficiency is also only found in the database update, so normal server launches won't see any impact at all. Likewise any system that doesn't have a cutoff date isn't impacted.

For Victoria specifically, I've removed the force update disabler so the GTFS can once again be updated, and added a cutoff date of Dec 7th to prevent the holiday service from being loaded. From a quick look at the DB this seems to result in about half as many departures being stored, which should hopefully mean we don't see any performance issues. If there's still problems, we can adjust the date to Sept 1 to keep the same data that the site currently shows.

A few minor changes besides the cutoff date:
- Added/fixed a few type hints
- Fixed a case of sheet services being a list instead of a set
- Made a slight change to sheet combination logic, which fixes a display issue with Victoria but creates issues in other systems. Unfortunately this seems to be a situation where we can't really have our cake and eat it. IMO with this change in place things are better overall; because of the way the dates are defined sheet changes are always gonna be a bit awkward and weird looking, however without the fix then some mid-sheet special service days also look a bit weird and I think it's better to have those looking normal when possible.

Before the sheet logic change: around the end of the sheet, they are still defined as two separate sheets, however the holiday service in Victoria causes it to be broken into multiple sheets.
<img width="390" height="646" alt="Screenshot 2025-08-19 at 22 49 24" src="https://github.com/user-attachments/assets/bf05d252-2d9d-497f-a49f-2fe4c4e61c58" />
<img width="387" height="815" alt="Screenshot 2025-08-19 at 22 49 16" src="https://github.com/user-attachments/assets/33c38a25-0e3f-40b4-afcc-494b1349c5e0" />

After the sheet logic change: the end of the sheet is now treated as modified service for the next sheet, but the holiday service in Victoria appears properly
<img width="396" height="601" alt="Screenshot 2025-08-19 at 22 48 23" src="https://github.com/user-attachments/assets/7f1901af-2f6d-45ed-8a4f-07f1641fe0f8" />
<img width="391" height="667" alt="Screenshot 2025-08-19 at 22 48 31" src="https://github.com/user-attachments/assets/1eee4e53-acb5-4bf3-9d91-cd19cec5cdcb" />

If you think we're better off with the old way let me know, otherwise I'd inclined to say the new way is better.
