### PR TITLE
Search improvements

### DIFF
--- a/database.py
+++ b/database.py
@@ -186,6 +186,7 @@ class Database:
             self.connection.execute('PRAGMA foreign_keys = 1')
         else:
             self.connection.execute('PRAGMA foreign_keys = 0')
+        self.connection.execute('PRAGMA case_sensitive_like = 0')
         
         if run_scripts:
             for sql in SQL_SCRIPTS:
@@ -392,7 +393,11 @@ class Database:
                 value = filters[key]
                 if value is None:
                     continue
-                if type(value) is list:
+                if key == 'AND' or key == 'OR':
+                    nested_expression, nested_args = self.build_where(value, key)
+                    expressions.append(f'({nested_expression})')
+                    args += nested_args
+                elif type(value) is list:
                     args += value
                     args_string = ', '.join(['?'] * len(value))
                     expressions.append(f'{key} IN ({args_string})')

--- a/models/block.py
+++ b/models/block.py
@@ -130,4 +130,4 @@ class Block:
             message = f'Route {routes}'
         else:
             message = f'Routes {routes}'
-        return Match(f'Block {id}', message, 'block', f'blocks/{self.url_id}', value)
+        return Match(self.context, f'Block {id}', message, 'block', f'blocks/{self.url_id}', value)

--- a/models/context.py
+++ b/models/context.py
@@ -216,18 +216,23 @@ class Context:
     
     def search_placeholder_text(self):
         '''Search placeholder text to display for this context'''
+        values = []
+        if self.realtime_enabled:
+            values.append(self.vehicle_type_plural.lower())
+        values.append('routes')
+        values.append('stops')
+        if self.enable_blocks:
+            values.append('blocks')
         if self.system:
-            values = []
-            if self.realtime_enabled:
-                values.append(self.vehicle_type_plural.lower())
-            values.append('routes')
-            values.append('stops')
-            if self.enable_blocks:
-                values.append('blocks')
             if len(values) == 1:
                 return f'Search for {self} {values[0]}'
             if len(values) == 2:
                 return f'Search for {self} {values[0]} and {values[1]}'
             values_string = ', '.join(values[:-1])
             return f'Search for {self} {values_string}, and {values[-1]}'
-        return f'Search for {self.vehicle_type_plural.lower()} in all systems'
+        if len(values) == 1:
+            return f'Search for {values[0]} in all systems'
+        if len(values) == 2:
+            return f'Search for {values[0]} and {values[1]} in all systems'
+        values_string = ', '.join(values[:-1])
+        return f'Search for {values_string}, and {values[-1]} in all systems'

--- a/models/match.py
+++ b/models/match.py
@@ -1,10 +1,13 @@
 
 from dataclasses import dataclass
 
+from models.context import Context
+
 @dataclass(slots=True)
 class Match:
     '''A search result with a value indicating how closely it matches the query'''
     
+    context: Context
     name: str
     description: str
     icon: str
@@ -19,11 +22,12 @@ class Match:
             return self.name < other.name
         return self.value > other.value
     
-    def get_json(self, context, get_url):
+    def get_json(self, get_url):
         '''Returns a representation of this match in JSON-compatible format'''
         return {
+            'system_name': str(self.context),
             'name': self.name,
             'description': self.description,
             'icon': self.icon,
-            'url': get_url(context, self.path)
+            'url': get_url(self.context, self.path)
         }

--- a/models/route.py
+++ b/models/route.py
@@ -228,7 +228,7 @@ class Route:
             value += (len(query) / len(name)) * 100
             if name.startswith(query):
                 value += len(query)
-        return Match(f'Route {self.number}', self.name, 'route', f'routes/{self.url_id}', value)
+        return Match(self.context, f'Route {self.number}', self.name, 'route', f'routes/{self.url_id}', value)
     
     def is_variant(self, route):
         '''Checks if this route is a variant of another route'''

--- a/models/stop.py
+++ b/models/stop.py
@@ -149,7 +149,7 @@ class Stop:
         number = self.number.lower()
         name = self.name.lower()
         value = 0
-        if query in number:
+        if query in number and self.context.show_stop_number:
             value += (len(query) / len(number)) * 100
             if number.startswith(query):
                 value += len(query)
@@ -161,7 +161,7 @@ class Stop:
                 value -= 20
             else:
                 value = 1
-        return Match(f'Stop {self.number}', self.name, 'stop', f'stops/{self.url_id}', value)
+        return Match(self.context, f'Stop {self.number}', self.name, 'stop', f'stops/{self.url_id}', value)
     
     def is_near(self, lat, lon, accuracy=0.001):
         '''Checks if this stop is near the given latitude and longitude'''

--- a/repositories/impl/order.py
+++ b/repositories/impl/order.py
@@ -98,5 +98,5 @@ class OrderRepository:
                 name += f' {decoration}'
             if title_prefix:
                 name = f'{title_prefix} {name}'
-            matches.append(Match(name, year_model, model_icon, f'bus/{vehicle.url_id}', value))
+            matches.append(Match(context, name, year_model, model_icon, f'bus/{vehicle.url_id}', value))
         return matches

--- a/repositories/impl/route.py
+++ b/repositories/impl/route.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from database import Database
 
 from models.context import Context
+from models.match import Match
 from models.route import Route
 
 @dataclass(slots=True)
@@ -108,6 +109,36 @@ class RouteRepository:
             limit=limit,
             initializer=Route.from_db
         )
+    
+    def find_matches(self, context: Context, query: str) -> list[Match]:
+        routes = self.database.select(
+            table='route',
+            columns=[
+                # 'agency_id',
+                'system_id',
+                'route_id',
+                'number',
+                'name',
+                'colour',
+                'text_colour',
+                'type',
+                'sort_order'
+            ],
+            filters={
+                # 'agency_id': context.agency_id,
+                'system_id': context.system_id,
+                'OR': {
+                    'number': {
+                        'LIKE': f'%{query}%'
+                    },
+                    'name': {
+                        'LIKE': f'%{query}%'
+                    }
+                }
+            },
+            initializer=Route.from_db
+        )
+        return [r.get_match(query) for r in routes]
     
     def delete_all(self, context: Context):
         '''Deletes all routes for the given context from the database'''

--- a/repositories/impl/stop.py
+++ b/repositories/impl/stop.py
@@ -5,6 +5,7 @@ from database import Database
 
 from models.area import Area
 from models.context import Context
+from models.match import Match
 from models.stop import Stop, StopType
 
 @dataclass(slots=True)
@@ -96,6 +97,36 @@ class StopRepository:
             limit=limit,
             initializer=Stop.from_db
         )
+    
+    def find_matches(self, context: Context, query: str) -> list[Match]:
+        stops = self.database.select(
+            table='stop',
+            columns=[
+                # 'agency_id',
+                'system_id',
+                'stop_id',
+                'number',
+                'name',
+                'lat',
+                'lon',
+                'parent_id',
+                'type'
+            ],
+            filters={
+                # 'agency_id': context.agency_id,
+                'system_id': context.system_id,
+                'OR': {
+                    'number': {
+                        'LIKE': f'%{query}%'
+                    },
+                    'name': {
+                        'LIKE': f'%{query}%'
+                    }
+                }
+            },
+            initializer=Stop.from_db
+        )
+        return [s.get_match(query) for s in stops]
     
     def find_area(self, context: Context) -> Area | None:
         '''Returns the area of all stops for the given context'''

--- a/repositories/impl/trip.py
+++ b/repositories/impl/trip.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from database import Database
 
 from models.context import Context
+from models.match import Match
 from models.trip import Trip
 
 @dataclass(slots=True)
@@ -80,6 +81,32 @@ class TripRepository:
             limit=limit,
             initializer=Trip.from_db
         )
+    
+    def find_block_matches(self, context: Context, query: str) -> list[Match]:
+        rows = self.database.select(
+            table='trip',
+            columns=[
+                # 'agency_id',
+                'system_id',
+                'block_id'
+            ],
+            distinct=True,
+            filters={
+                # 'agency_id': context.agency_id,
+                'system_id': context.system_id,
+                'block_id': {
+                    'LIKE': f'%{query}%'
+                }
+            }
+        )
+        matches = []
+        for row in rows:
+            context = row.context()
+            if context.system:
+                block = context.system.get_block(row['block_id'])
+                if block:
+                    matches.append(block.get_match(query))
+        return matches
     
     def delete_all(self, context: Context):
         '''Deletes all trips for the given context from the database'''

--- a/server.py
+++ b/server.py
@@ -1500,18 +1500,17 @@ class Server(Bottle):
             if context.realtime_enabled and include_vehicles:
                 vehicle_ids = repositories.allocation.find_vehicle_ids(context)
                 matches += repositories.order.find_matches(context, query, vehicle_ids)
-            if context.system:
-                if include_blocks and context.enable_blocks:
-                    matches += context.system.search_blocks(query)
-                if include_routes:
-                    matches += context.system.search_routes(query)
-                if include_stops:
-                    matches += context.system.search_stops(query)
+            if include_blocks and context.enable_blocks and len(query) >= 5:
+                matches += repositories.trip.find_block_matches(context, query)
+            if include_routes:
+                matches += repositories.route.find_matches(context, query)
+            if include_stops:
+                matches += repositories.stop.find_matches(context, query)
         matches = sorted([m for m in matches if m.value > 0])
         min = page * count
         max = min + count
         return {
-            'results': [m.get_json(context, self.get_url) for m in matches[min:max]],
+            'results': [m.get_json(self.get_url) for m in matches[min:max]],
             'total': len(matches)
         }
     

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -525,31 +525,29 @@
                     <div id="search-bar">
                         <input type="text" id="search-input" placeholder="Search" oninput="searchInputChanged()">
                     </div>
-                    % if context.system:
-                        <div id="search-filters">
-                            <div class="flex-1">Filters:</div>
-                            % if context.realtime_enabled:
-                                <div id="search-filter-vehicle" class="button tooltip-anchor" onclick="toggleSearchVehicleFilter()">
-                                    % include('components/svg', name=context.filter_vehicles_image_name)
-                                    <div class="tooltip left">Include {{ context.vehicle_type_plural }}</div>
-                                </div>
-                            % end
-                            <div id="search-filter-route" class="button tooltip-anchor" onclick="toggleSearchRouteFilter()">
-                                % include('components/svg', name='route')
-                                <div class="tooltip left">Include Routes</div>
+                    <div id="search-filters">
+                        <div class="flex-1">Filters:</div>
+                        % if context.realtime_enabled:
+                            <div id="search-filter-vehicle" class="button tooltip-anchor" onclick="toggleSearchVehicleFilter()">
+                                % include('components/svg', name=context.filter_vehicles_image_name)
+                                <div class="tooltip left">Include {{ context.vehicle_type_plural }}</div>
                             </div>
-                            <div id="search-filter-stop" class="button tooltip-anchor" onclick="toggleSearchStopFilter()">
-                                % include('components/svg', name='stop')
-                                <div class="tooltip left">Include Stops</div>
-                            </div>
-                            % if context.enable_blocks:
-                                <div id="search-filter-block" class="button tooltip-anchor" onclick="toggleSearchBlockFilter()">
-                                    % include('components/svg', name='block')
-                                    <div class="tooltip left">Include Blocks</div>
-                                </div>
-                            % end
+                        % end
+                        <div id="search-filter-route" class="button tooltip-anchor" onclick="toggleSearchRouteFilter()">
+                            % include('components/svg', name='route')
+                            <div class="tooltip left">Include Routes</div>
                         </div>
-                    % end
+                        <div id="search-filter-stop" class="button tooltip-anchor" onclick="toggleSearchStopFilter()">
+                            % include('components/svg', name='stop')
+                            <div class="tooltip left">Include Stops</div>
+                        </div>
+                        % if context.enable_blocks:
+                            <div id="search-filter-block" class="button tooltip-anchor" onclick="toggleSearchBlockFilter()">
+                                % include('components/svg', name='block')
+                                <div class="tooltip left">Include Blocks</div>
+                            </div>
+                        % end
+                    </div>
                 </div>
                 <div id="search-placeholder">{{ context.search_placeholder_text() }}</div>
                 <div id="search-results" class="display-none">
@@ -684,9 +682,16 @@
         details.classList.add("details");
         
         const name = document.createElement("div");
-        name.classList.add("name")
+        name.classList.add("name");
         name.innerHTML = result.name;
         details.appendChild(name);
+        
+        if (currentSystemID === null) {
+            const systemName = document.createElement("div");
+            systemName.classList.add("description");
+            systemName.innerHTML = result.system_name;
+            details.appendChild(systemName);
+        }
         
         const description = document.createElement("div");
         description.classList.add("description");
@@ -699,6 +704,7 @@
     }
     
     function updateSearchView(results, total, message) {
+        const inputElement = document.getElementById("search-input");
         const placeholderElement = document.getElementById("search-placeholder");
         const pagingElement = document.getElementById("search-paging");
         const countElement = document.getElementById("search-count");
@@ -710,6 +716,9 @@
         if (total === 0) {
             placeholderElement.classList.remove("display-none");
             placeholderElement.innerHTML = message;
+            if (inputElement.value !== "" && inputElement.value.length < 5 && searchIncludeBlocks) {
+                placeholderElement.innerHTML += "<div class='smaller-font'>Note: blocks are only shown after typing 5 or more characters</div>";
+            }
             pagingElement.classList.add("display-none");
             countElement.innerHTML = "";
             resultsElement.classList.add("display-none");

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -582,6 +582,7 @@
     let loadingResults = false;
     let enterPending = false;
     let lastSearchTimestamp = Date.now();
+    let cachedResponses = {};
     
     let searchIncludeVehicles = true;
     let searchIncludeRoutes = true;
@@ -617,6 +618,16 @@
         if (query === undefined || query === null || query === "") {
             updateSearchView([], 0, "{{ context.search_placeholder_text() }}");
         } else {
+            const cacheKey = query + "_" + searchPage;
+            if (cacheKey in cachedResponses) {
+                const response = cachedResponses[cacheKey];
+                const results = response.results;
+                const total = response.total;
+                
+                updateSearchView(results, total, total === 0 ? "No Results" : "Results");
+                return;
+            }
+            
             loadingResults = true;
             if (searchResults.length === 0) {
                 placeholderElement.innerHTML = "Loading...";
@@ -625,6 +636,7 @@
             request.open("POST", "{{ get_url(context, 'api', 'search') }}", true);
             request.responseType = "json";
             request.onload = function() {
+                cachedResponses[cacheKey] = request.response;
                 if (timestamp !== lastSearchTimestamp) {
                     // Discard outdated results
                     return;
@@ -858,6 +870,7 @@
         } else {
             element.classList.add("inactive");
         }
+        cachedResponses = {};
         searchPage = 0;
         search();
     }


### PR DESCRIPTION
- Routes, stops, and blocks can now be searched in the global context without having to select a system
  - When looking at all systems, the system associated with the match is shown in the UI
- Various efficiency improvements
  - Matches are now initially discovered through `LIKE` queries on the database rather than iterating through all possible values in memory (particularly beneficial for non-system-specific searches)
  - Blocks are only searched after the user has typed 5+ characters - blocks are probably the least efficient thing to query since they aren't stored in their own DB table, so this restriction should speed things up a fair bit
  - Responses are cached on the client end
    - If the same query is made multiple times, only the first will make a request to the server
    - Caches are only stored in memory, so navigating elsewhere/refreshing/etc will reset it
    - Changing filters will clear the cache (but paging through results is fine)

Overall - the global search for routes/stops/blocks have the potential to become less efficient due to the higher number of results, but I'm hoping that the other efficiency improvements will offset that. On my local computer everything seems snappy, but since prod is definitely slower I don't think we'll know for sure until this is deployed. We can always revert it if it ends up being real bad.

<img width="276" height="316" alt="Screenshot 2026-04-12 at 11 39 33" src="https://github.com/user-attachments/assets/ccf801b2-676e-4b4f-a682-038cebf8c54d" />

<img width="278" height="809" alt="Screenshot 2026-04-12 at 11 40 07" src="https://github.com/user-attachments/assets/60646032-c086-4995-9dca-48252e7dab24" />

<img width="275" height="396" alt="Screenshot 2026-04-12 at 11 40 44" src="https://github.com/user-attachments/assets/d1f945c2-e073-4d08-8c68-2b0c19161ec4" />

<img width="276" height="347" alt="Screenshot 2026-04-12 at 11 40 57" src="https://github.com/user-attachments/assets/d69c977a-89ab-40c8-83ee-9232d279e0cc" />

<img width="275" height="812" alt="Screenshot 2026-04-12 at 11 41 08" src="https://github.com/user-attachments/assets/4b8a0fa6-42fa-4fe5-81e6-aa8f17172c4f" />

<img width="272" height="712" alt="Screenshot 2026-04-12 at 11 42 37" src="https://github.com/user-attachments/assets/f008efba-0fab-4ce4-87f1-f35a7b5067b2" />
