### PR TITLE
Enable realtime by route for all systems

### DIFF
--- a/views/pages/realtime/all.tpl
+++ b/views/pages/realtime/all.tpl
@@ -6,9 +6,7 @@
     <h2>Currently active {{ context.vehicle_type_plural.lower() }}</h2>
     <div class="tab-button-bar">
         <span class="tab-button current">All {{ context.vehicle_type_plural }}</span>
-        % if context.system:
-            <a href="{{ get_url(context, 'realtime', 'routes') }}" class="tab-button">By Route</a>
-        % end
+        <a href="{{ get_url(context, 'realtime', 'routes') }}" class="tab-button">By Route</a>
         <a href="{{ get_url(context, 'realtime', 'models') }}" class="tab-button">By Model</a>
         % if show_speed:
             <a href="{{ get_url(context, 'realtime', 'speed') }}" class="tab-button">By Speed</a>

--- a/views/pages/realtime/models.tpl
+++ b/views/pages/realtime/models.tpl
@@ -6,9 +6,7 @@
     <h2>Currently active {{ context.vehicle_type_plural.lower() }}</h2>
     <div class="tab-button-bar">
         <a href="{{ get_url(context, 'realtime') }}" class="tab-button">All {{ context.vehicle_type_plural }}</a>
-        % if context.system:
-            <a href="{{ get_url(context, 'realtime', 'routes') }}" class="tab-button">By Route</a>
-        % end
+        <a href="{{ get_url(context, 'realtime', 'routes') }}" class="tab-button">By Route</a>
         <span class="tab-button current">By Model</span>
         % if show_speed:
             <a href="{{ get_url(context, 'realtime', 'speed') }}" class="tab-button">By Speed</a>

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -25,13 +25,11 @@
     </div>
 </div>
 
-% if context.system and positions:
+% if positions:
+    % routes = {p.trip.route for p in positions if p.trip and p.route}
     <div class="container">
-        % for route in context.system.get_routes():
+        % for route in sorted(routes):
             % route_positions = [p for p in positions if p.trip and p.trip.route == route]
-            % if not route_positions:
-                % continue
-            % end
             <div class="section">
                 <div class="header" onclick="toggleSection(this)">
                     <div class="column">
@@ -39,7 +37,13 @@
                             % include('components/route')
                             <div>{{! route.display_name }}</div>
                         </h2>
-                        <a href="{{ get_url(route.context, 'routes', route) }}">View schedule and details</a>
+                        <div class="row">
+                            % if not context.system:
+                                <div class="lighter-text">{{ route.context }}</div>
+                                <div class="lighter-text">•</div>
+                            % end
+                            <a href="{{ get_url(route.context, 'routes', route) }}">View schedule and details</a>
+                        </div>
                     </div>
                     % include('components/toggle')
                 </div>
@@ -49,9 +53,6 @@
                             <tr>
                                 <th>{{ context.vehicle_type }}</th>
                                 <th class="desktop-only">Model</th>
-                                % if not context.system:
-                                    <th class="desktop-only">System</th>
-                                % end
                                 <th>Headsign</th>
                                 % if context.enable_blocks:
                                     <th class="non-mobile">Block</th>
@@ -93,9 +94,6 @@
                                     <td class="desktop-only">
                                         % include('components/year_model', year_model=vehicle.year_model)
                                     </td>
-                                    % if not context.system:
-                                        <td class="desktop-only">{{ position.context }}</td>
-                                    % end
                                     % trip = position.trip
                                     % block = trip.block
                                     % stop = position.stop
@@ -199,8 +197,17 @@
 % else:
     <div class="placeholder">
         % if not context.system:
-            <h3>Realtime routes can only be viewed for individual systems.</h3>
-            <p>Please choose a system.</p>
+            % if show_nis:
+                <h3>There are no {{ context.vehicle_type_plural.lower() }} out right now</h3>
+                <p>
+                    None of our current agencies operate late night service, so this should be the case overnight.
+                    If you look out your window and the sun is shining, there may be an issue getting up-to-date info.
+                </p>
+                <p>Please check again later!</p>
+            % else:
+                <h3>There are no {{ context.vehicle_type_plural.lower() }} in service right now</h3>
+                <p>You can see all active {{ context.vehicle_type_plural.lower() }}, including ones not in service, by selecting the <b>Show NIS {{ context.vehicle_type_plural }}</b> checkbox.</p>
+            % end
         % elif not context.realtime_enabled:
             <h3>{{ context }} realtime information is not supported</h3>
             <p>You can browse schedule data using the links above, or choose a different system.</p>

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -6,9 +6,7 @@
     <h2>Currently active {{ context.vehicle_type_plural.lower() }}</h2>
     <div class="tab-button-bar">
         <a href="{{ get_url(context, 'realtime') }}" class="tab-button">All {{ context.vehicle_type_plural }}</a>
-        % if context.system:
-            <a href="{{ get_url(context, 'realtime', 'routes') }}" class="tab-button">By Route</a>
-        % end
+        <a href="{{ get_url(context, 'realtime', 'routes') }}" class="tab-button">By Route</a>
         <a href="{{ get_url(context, 'realtime', 'models') }}" class="tab-button">By Model</a>
         <span class="tab-button current">By Speed</span>
     </div>


### PR DESCRIPTION
Currently the Realtime By Route page is limited to when a system is selected. When looking at all systems, the tab button is hidden, and if the user manages to get to it anyways (eg by selecting a system, going to that page, and then selecting all systems) an error is shown telling the user that it isn't supported.

However, there isn't really any true restriction for this aside from that it's potentially odd to be showing multiple of "the same route" in the same place. IMO there's nothing stopping us from just enabling this anyways, so that's what I've done here. When viewing all systems, the tab button is now visible and vehicles are shown for routes in all systems. There's minor changes to show which system the route is for, and remove the system from the table. The appearance when a system _is_ selected remains unchanged.

<img width="1116" height="879" alt="Screenshot 2026-04-12 at 22 35 22" src="https://github.com/user-attachments/assets/2bb9a314-ac3b-4112-89be-a69e59332b1a" />

<img width="1217" height="869" alt="Screenshot 2026-04-12 at 22 35 36" src="https://github.com/user-attachments/assets/616c2077-e4fe-48af-ae36-926e8715f062" />
