### PR TITLE
Favourite systems

### DIFF
--- a/server.py
+++ b/server.py
@@ -205,6 +205,11 @@ class Server(Bottle):
         time_format = self.query_cookie('time_format')
         vehicle_marker_style = self.query_cookie('vehicle_marker_style')
         hide_systems = self.query_cookie('hide_systems') != 'no'
+        favourite_systems = self.query_cookie('favourite_systems')
+        if favourite_systems:
+            favourite_system_ids = set(favourite_systems.split(','))
+        else:
+            favourite_system_ids = set()
         if context.system:
             last_updated = context.system.last_updated
             today = Date.today(context.timezone)
@@ -248,6 +253,7 @@ class Server(Bottle):
             time_format=time_format,
             vehicle_marker_style=vehicle_marker_style,
             hide_systems=hide_systems,
+            favourite_system_ids=favourite_system_ids,
             show_speed=request.get_cookie('speed') == '1994',
             show_random=request.get_cookie('random') == 'kumquat',
             today=today,

--- a/style/devices/desktop.css
+++ b/style/devices/desktop.css
@@ -151,10 +151,6 @@ table th {
 
 #system {
     align-self: stretch;
-    display: flex;
-    flex-direction: row;
-    gap: 5px;
-    align-items: center;
     cursor: pointer;
     padding: 10px 20px;
 }

--- a/style/devices/mobile.css
+++ b/style/devices/mobile.css
@@ -171,6 +171,7 @@ table th {
 
 #system {
     text-align: center;
+    align-self: center;
 }
 
 #system-menu {

--- a/style/main.css
+++ b/style/main.css
@@ -502,6 +502,7 @@ table tr.table-button {
 #system {
     font-weight: bold;
     font-size: 14pt;
+    --image-size: 20px;
 }
 
 #system-menu {
@@ -518,6 +519,7 @@ table tr.table-button {
     flex-direction: row;
     gap: 10px;
     align-items: center;
+    --image-size: 18px;
 }
 
 #system-menu .system-button.current {

--- a/style/main.css
+++ b/style/main.css
@@ -500,6 +500,10 @@ table tr.table-button {
 }
 
 #system {
+    display: flex;
+    flex-direction: row;
+    gap: 5px;
+    align-items: center;
     font-weight: bold;
     font-size: 14pt;
     --image-size: 20px;

--- a/style/themes/bc-ferries.dark.css
+++ b/style/themes/bc-ferries.dark.css
@@ -230,6 +230,7 @@ table tr.table-button:hover {
 
 #system-menu .system-button {
     color: #FFFFFF;
+    --image-color: #5CC3FF;
 }
 
 #system-menu .system-button:hover {

--- a/style/themes/bc-ferries.light.css
+++ b/style/themes/bc-ferries.light.css
@@ -221,6 +221,7 @@ table tr.table-button:hover {
 
 #system-menu .system-button {
     color: #000000;
+    --image-color: #003769;
 }
 
 #system-menu .system-button:hover {

--- a/style/themes/bc-hydro.css
+++ b/style/themes/bc-hydro.css
@@ -215,6 +215,7 @@ table tr.table-button:hover {
 
 #system-menu .system-button {
     color: #000000;
+    --image-color: #249B9B;
 }
 
 #system-menu .system-button:hover {

--- a/style/themes/bc-transit-classic.css
+++ b/style/themes/bc-transit-classic.css
@@ -219,6 +219,7 @@ table tr.table-button:hover {
 
 #system-menu .system-button {
     color: #000000;
+    --image-color: #E20000;
 }
 
 #system-menu .system-button:hover {

--- a/style/themes/bc-transit.dark.css
+++ b/style/themes/bc-transit.dark.css
@@ -228,6 +228,7 @@ table tr.table-button:hover {
 
 #system-menu .system-button {
     color: #FFFFFF;
+    --image-color: #5CC3FF;
 }
 
 #system-menu .system-button:hover {

--- a/style/themes/bc-transit.light.css
+++ b/style/themes/bc-transit.light.css
@@ -219,6 +219,7 @@ table tr.table-button:hover {
 
 #system-menu .system-button {
     color: #000000;
+    --image-color: #0040FF;
 }
 
 #system-menu .system-button:hover {

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -215,6 +215,7 @@ table tr.table-button:hover {
 
 #system-menu .system-button {
     color: #000000;
+    --image-color: #165ABE;
 }
 
 #system-menu .system-button:hover {

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -221,6 +221,7 @@ table tr.table-button:hover {
 
 #system-menu .system-button {
     color: #000000;
+    --image-color: #69BB65;
 }
 
 #system-menu .system-button:hover {

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -204,6 +204,7 @@ table tr.table-button:hover {
 
 #system-menu .system-button {
     color: #000000;
+    --image-color: #AAAAAA;
 }
 
 #system-menu .system-button:hover {

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -228,6 +228,7 @@ table tr.table-button:hover {
 
 #system-menu .system-button {
     color: #FFFFFF;
+    --image-color: #E56100;
 }
 
 #system-menu .system-button:hover {

--- a/style/themes/pride.dark.css
+++ b/style/themes/pride.dark.css
@@ -217,6 +217,7 @@ table tr.table-button:hover {
 
 #system-menu .system-button {
     color: #FFFFFF;
+    --image-color: rgba(255, 255, 255, 0.7);
 }
 
 #system-menu .system-button:hover {

--- a/style/themes/pride.light.css
+++ b/style/themes/pride.light.css
@@ -216,6 +216,7 @@ table tr.table-button:hover {
 
 #system-menu .system-button {
     color: #FFFFFF;
+    --image-color: rgba(255, 255, 255, 0.7);
 }
 
 #system-menu .system-button:hover {

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -293,6 +293,7 @@ table tr.table-button:hover {
     text-decoration: none;
     text-shadow: 0 1px 0 #FFFFFF;
     background-image: linear-gradient(#FFFFFF, #F1F1F1);
+    --image-color: #000000;
 }
 
 #system-menu .system-button:hover {

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -215,6 +215,7 @@ table tr.table-button:hover {
 
 #system-menu .system-button {
     color: #000000;
+    --image-color: #C7743B;
 }
 
 #system-menu .system-button:hover {

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -430,12 +430,10 @@
             <div class="details">
                 <div id="system" class="tooltip-anchor" onclick="toggleSystemMenuDesktop()">
                     % if context.system:
-                        <div class="row">
-                            {{ context }}
-                            % if context.system_id in favourite_system_ids:
-                                % include('components/svg', name='action/favourite')
-                            % end
-                        </div>
+                        {{ context }}
+                        % if context.system_id in favourite_system_ids:
+                            % include('components/svg', name='action/favourite')
+                        % end
                     % else:
                         All Transit Systems
                     % end

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -430,7 +430,12 @@
             <div class="details">
                 <div id="system" class="tooltip-anchor" onclick="toggleSystemMenuDesktop()">
                     % if context.system:
-                        {{ context }}
+                        <div class="row">
+                            {{ context }}
+                            % if context.system_id in favourite_system_ids:
+                                % include('components/svg', name='action/favourite')
+                            % end
+                        </div>
                     % else:
                         All Transit Systems
                     % end
@@ -457,6 +462,25 @@
                 % else:
                     <span class="system-button current all-systems">All Transit Systems</span>
                 % end
+                % if favourite_system_ids:
+                    <div class="header">Favourites</div>
+                    % favourite_systems = sorted([s for s in systems if s.id in favourite_system_ids], key=lambda s: s.name)
+                    % for system in favourite_systems:
+                        % if system == context.system:
+                            <div class="system-button current">
+                                % include('components/agency_logo', agency=system.agency)
+                                <div class="flex-1">{{ system }}</div>
+                                % include('components/svg', name='action/favourite')
+                            </div>
+                        % else:
+                            <a href="{{ get_url(system.context, *path, **path_args) }}" class="system-button">
+                                % include('components/agency_logo', agency=system.agency)
+                                <div class="flex-1">{{ system }}</div>
+                                % include('components/svg', name='action/favourite')
+                            </a>
+                        % end
+                    % end
+                % end
                 % for region in regions:
                     % region_systems = [s for s in systems if s.region == region]
                     % if region_systems:
@@ -465,12 +489,18 @@
                             % if system == context.system:
                                 <div class="system-button current">
                                     % include('components/agency_logo', agency=system.agency)
-                                    <div>{{ system }}</div>
+                                    <div class="flex-1">{{ system }}</div>
+                                    % if system.id in favourite_system_ids:
+                                        % include('components/svg', name='action/favourite')
+                                    % end
                                 </div>
                             % else:
                                 <a href="{{ get_url(system.context, *path, **path_args) }}" class="system-button">
                                     % include('components/agency_logo', agency=system.agency)
-                                    <div>{{ system }}</div>
+                                    <div class="flex-1">{{ system }}</div>
+                                    % if system.id in favourite_system_ids:
+                                        % include('components/svg', name='action/favourite')
+                                    % end
                                 </a>
                             % end
                         % end

--- a/views/pages/home.tpl
+++ b/views/pages/home.tpl
@@ -6,11 +6,40 @@
 <div id="page-header">
     <h1>Welcome to BCTracker!</h1>
     % if context.system:
-        % if context.realtime_enabled:
-            <h2>{{ context }} Transit Schedules and {{ context.vehicle_type }} Tracking</h2>
-        % else:
-            <h2>{{ context }} Transit Schedules</h2>
-        % end
+        <div class="row">
+            % if context.realtime_enabled:
+                <h2>{{ context }} Transit Schedules and {{ context.vehicle_type }} Tracking</h2>
+            % else:
+                <h2>{{ context }} Transit Schedules</h2>
+            % end
+            % if len(favourite_system_ids) >= 5 and context.system_id not in favourite_system_ids:
+                <div class="favourite disabled tooltip-anchor">
+                    % include('components/svg', name='action/non-favourite')
+                    <div class="tooltip right">You can only have 5 favourite systems at a time</div>
+                </div>
+            % else:
+                % new_favourite_systems = set(favourite_system_ids)
+                % if context.system_id in favourite_system_ids:
+                    <div class="favourite tooltip-anchor" onclick="updateFavouriteSystems()">
+                        % include('components/svg', name='action/favourite')
+                        <div class="tooltip right">Remove favourite system</div>
+                    </div>
+                    % new_favourite_systems.remove(context.system_id)
+                % else:
+                    <div class="favourite tooltip-anchor" onclick="updateFavouriteSystems()">
+                        % include('components/svg', name='action/non-favourite')
+                        <div class="tooltip right">Add favourite system</div>
+                    </div>
+                    % new_favourite_systems.add(context.system_id)
+                % end
+                % new_favourite_systems_string = ','.join(sorted(new_favourite_systems))
+                <script>
+                    function updateFavouriteSystems() {
+                        window.location = "?favourite_systems={{ new_favourite_systems_string }}";
+                    }
+                </script>
+            % end
+        </div>
     % else:
         <h2>British Columbia Transit Schedules and {{ context.vehicle_type }} Tracking</h2>
     % end


### PR DESCRIPTION
Adds the ability to have favourite systems. These are shown at the top of the systems list, and have a star next to them in both the list and the status bar. The goal is to make it easier to swap to systems you use most often, particularly ones that are further down the list and harder to access.

Currently there is a maximum of 5 favourites; this is somewhat arbitrary to make sure the list doesn't get too long, and is easy to change if people request more.

Favourite systems can be added/removed from the Home page. Originally I considered having it doable directly from the systems menu, but that adds complexity and makes the UI trickier; it's also an action that I suspect needs to be done fairly infrequently. Having it in the page header on the Home page makes it more familiar since it more closely matches the style of normal favourites. There are also tooltips to help explain the functionality.

<img width="1338" height="870" alt="Screenshot 2026-04-12 at 23 54 34" src="https://github.com/user-attachments/assets/b089854c-8bc1-4b30-b503-89fd84487677" />

<img width="1338" height="873" alt="Screenshot 2026-04-12 at 23 54 50" src="https://github.com/user-attachments/assets/8acfe76a-b631-48fc-9331-d287d2bed2c9" />

<img width="1345" height="874" alt="Screenshot 2026-04-12 at 23 55 31" src="https://github.com/user-attachments/assets/1a14d30d-75d2-40c6-909b-a79e2b74e5a5" />

<img width="354" height="770" alt="Screenshot 2026-04-12 at 23 56 03" src="https://github.com/user-attachments/assets/743569f7-cb7d-465d-86de-d7ec2e9315a2" />
