### PR TITLE
Show livery icon next to order

### DIFF
--- a/models/livery.py
+++ b/models/livery.py
@@ -17,3 +17,6 @@ class Livery:
     
     def __eq__(self, other):
         return self.agency_id == other.agency_id and self.id == other.id
+    
+    def __lt__(self, other):
+        return self.name < other.name

--- a/models/order.py
+++ b/models/order.py
@@ -5,6 +5,8 @@ from models.agency import Agency
 from models.model import Model
 from models.vehicle import Vehicle
 
+import repositories
+
 @dataclass(slots=True)
 class Order:
     '''A set of vehicles of a specific model'''
@@ -30,6 +32,12 @@ class Order:
                 return str(self.years[0])
             return f'{self.years[0]}-{self.years[-1]}'
         return 'Unknown Year'
+    
+    @property
+    def liveries(self):
+        livery_ids = {v.livery for v in self.vehicles if v.livery}
+        liveries = {repositories.livery.find(self.agency.id, id) for id in livery_ids}
+        return sorted(l for l in liveries if l)
     
     def __post_init__(self):
         self.key = min([b.key for b in self.vehicles])

--- a/style/main.css
+++ b/style/main.css
@@ -130,6 +130,10 @@ table tr {
     border-bottom-color: var(--table-border);
 }
 
+table tr:last-child {
+    border-bottom-width: 0px;
+}
+
 table tr.divider {
     border-top-width: 4px;
     border-top-style: solid;
@@ -1014,6 +1018,12 @@ table tr.table-button {
     height: 40px;
     overflow: hidden;
     border-radius: 5px;
+}
+
+.livery-row .livery {
+    width: 16px;
+    height: 16px;
+    border-radius: 3px;
 }
 
 .log-line {

--- a/views/components/livery_row.tpl
+++ b/views/components/livery_row.tpl
@@ -1,0 +1,8 @@
+
+% if liveries:
+    <div class="row gap-5 livery-row">
+        % for livery in liveries:
+            <img class="livery" src="/img/liveries/{{ livery.id }}.png" />
+        % end
+    </div>
+% end

--- a/views/pages/block/history.tpl
+++ b/views/pages/block/history.tpl
@@ -28,7 +28,10 @@
                                 % for order in orders:
                                     % percentage = (sum(1 for r in records if r.vehicle.order_id == order.id) / len(records)) * 100
                                     <div class="row space-between">
-                                        <div>{{! order }}</div>
+                                        <div class="row">
+                                            % include('components/livery_row', liveries=order.liveries)
+                                            {{! order }}
+                                        </div>
                                         <div class="lighter-text">{{ round(percentage) }}%</div>
                                     </div>
                                 % end

--- a/views/pages/fleet.tpl
+++ b/views/pages/fleet.tpl
@@ -115,7 +115,10 @@
                                                                 <tr class="header">
                                                                     <td colspan="5">
                                                                         <div class="row space-between">
-                                                                            <div>{{ order.years_string }}</div>
+                                                                            <div class="row">
+                                                                                % include('components/livery_row', liveries=order.liveries)
+                                                                                {{ order.years_string }}
+                                                                            </div>
                                                                             <div>{{ len(order.vehicles) }}</div>
                                                                         </div>
                                                                     </td>

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -242,7 +242,10 @@
                                     <tr class="header">
                                         <td colspan="5">
                                             <div class="row space-between">
-                                                <div>{{! order }}</div>
+                                                <div class="row">
+                                                    % include('components/livery_row', liveries=order.liveries)
+                                                    {{! order }}
+                                                </div>
                                                 <div>{{ len(order_allocations) }} / {{ len(order.vehicles) }}</div>
                                             </div>
                                         </td>

--- a/views/pages/realtime/all.tpl
+++ b/views/pages/realtime/all.tpl
@@ -64,7 +64,10 @@
                     <tr class="header">
                         <td colspan="6">
                             <div class="row space-between">
-                                <div>{{! order }}</div>
+                                <div class="row">
+                                    % include('components/livery_row', liveries=order.liveries)
+                                    {{! order }}
+                                </div>
                                 <div>{{ len(order_positions) }} / {{ len(order.vehicles) }}</div>
                             </div>
                         </td>

--- a/views/pages/realtime/models.tpl
+++ b/views/pages/realtime/models.tpl
@@ -123,7 +123,10 @@
                                                         <tr class="header">
                                                             <td colspan="6">
                                                                 <div class="row space-between">
-                                                                    <div>{{ order.years_string }}</div>
+                                                                    <div class="row">
+                                                                        % include('components/livery_row', liveries=order.liveries)
+                                                                        {{ order.years_string }}
+                                                                    </div>
                                                                     <div>{{ len(order_positions) }} / {{ len(order.vehicles) }}</div>
                                                                 </div>
                                                             </td>

--- a/views/pages/trip/history.tpl
+++ b/views/pages/trip/history.tpl
@@ -35,7 +35,10 @@
                                 % for order in orders:
                                     % percentage = (sum(1 for r in records if r.vehicle.order_id == order.id) / len(records)) * 100
                                     <div class="row space-between">
-                                        <div>{{! order }}</div>
+                                        <div class="row">
+                                            % include('components/livery_row', liveries=order.liveries)
+                                            {{! order }}
+                                        </div>
                                         <div class="lighter-text">{{ round(percentage) }}%</div>
                                     </div>
                                 % end


### PR DESCRIPTION
Table headers and other places now show livery (or liveries) as a small icon next to the order year/model.

This is done in the following places:
- Realtime (All)
- Realtime (By Model)
- History (Last Seen)
- Fleet
- Block History
- Trip History

<img width="899" height="767" alt="Screenshot 2026-04-25 at 11 01 35" src="https://github.com/user-attachments/assets/d73a8066-e9cc-4a55-ad0f-87ee9534d832" />

<img width="1259" height="734" alt="Screenshot 2026-04-25 at 11 01 48" src="https://github.com/user-attachments/assets/4fd1d065-354b-4397-84fd-bde2989ecd37" />

<img width="1040" height="555" alt="Screenshot 2026-04-25 at 12 09 19" src="https://github.com/user-attachments/assets/8f2d0761-514a-4c35-9839-ce26b30acc5b" />
