### PR TITLE
Show help text toggle

### DIFF
--- a/server.py
+++ b/server.py
@@ -201,6 +201,7 @@ class Server(Bottle):
                 theme = repositories.theme.find('bc-transit')
         theme_variant = self.query_cookie('theme_variant')
         high_contrast = self.query_cookie('high_contrast') == 'enabled'
+        show_help_text = self.query_cookie('show_help_text', 'yes') == 'yes'
         return template(f'pages/{name}',
             settings=settings.current,
             version=VERSION,
@@ -219,6 +220,7 @@ class Server(Bottle):
             theme=theme,
             theme_variant=theme_variant,
             high_contrast=high_contrast,
+            show_help_text=show_help_text,
             time_format=time_format,
             vehicle_marker_style=vehicle_marker_style,
             hide_systems=hide_systems,

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -451,7 +451,9 @@
                     % else:
                         All Transit Systems
                     % end
-                    <div class="tooltip right">Toggle Systems List</div>
+                    % if show_help_text:
+                        <div class="tooltip right">Toggle Systems List</div>
+                    % end
                     % if favourite_system_ids:
                         <div id="favourite-systems-dropdown">
                             % if context.system:

--- a/views/components/sheet_list.tpl
+++ b/views/components/sheet_list.tpl
@@ -9,7 +9,7 @@
 % has_no_service = any(s.has_no_service for s in sheets)
 
 <div class="sheet-list">
-    % if has_normal_service or has_modified_service or has_no_service:
+    % if (has_normal_service or has_modified_service or has_no_service) and show_help_text:
         <div class="legend">
             % if has_normal_service:
                 <div class="row gap-5">
@@ -67,7 +67,7 @@
             % end
         % end
     </div>
-    % if schedule_path:
+    % if schedule_path and show_help_text:
         <div class="footer">
             Click on a weekday or date to jump to the schedule for that day
         </div>

--- a/views/pages/block/history.tpl
+++ b/views/pages/block/history.tpl
@@ -50,7 +50,7 @@
                 </div>
                 <div class="content">
                     % if records:
-                        % if any(r.warnings for r in records):
+                        % if any(r.warnings for r in records) and show_help_text:
                             <p>
                                 <span>Entries with a</span>
                                 <span class="record-warnings">

--- a/views/pages/block/overview.tpl
+++ b/views/pages/block/overview.tpl
@@ -244,7 +244,9 @@
                     <h2>Scheduled {{ context.vehicle_type }}</h2>
                 </div>
                 <div class="content">
-                    <p>This {{ vehicle.type_generic_name.lower() }} is currently assigned to this block but may be swapped off.</p>
+                    % if show_help_text:
+                        <p>This {{ vehicle.type_generic_name.lower() }} is currently assigned to this block but may be swapped off.</p>
+                    % end
                     <div class="table-border-wrapper">
                         <table>
                             <thead>

--- a/views/pages/history/first_seen.tpl
+++ b/views/pages/history/first_seen.tpl
@@ -29,7 +29,7 @@
                         }
                     </script>
                 % end
-                % if any(a.first_record and a.first_record.warnings for a in allocations):
+                % if any(a.first_record and a.first_record.warnings for a in allocations) and show_help_text:
                     <p>
                         <span>Entries with a</span>
                         <span class="record-warnings">
@@ -38,7 +38,7 @@
                         <span>may be accidental logins.</span>
                     </p>
                 % end
-                % if context.system and any(not a.active for a in allocations):
+                % if context.system and any(not a.active for a in allocations) and show_help_text:
                     <p>
                         <span>Entries with a</span>
                         <span class="transfer">

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -128,7 +128,7 @@
                 % if allocations:
                     % known_allocations = [a for a in allocations if a.vehicle.order_id]
                     % unknown_allocations = [a for a in allocations if not a.vehicle.order_id]
-                    % if any(a.last_record and a.last_record.warnings for a in allocations):
+                    % if any(a.last_record and a.last_record.warnings for a in allocations) and show_help_text:
                         <p>
                             <span>Entries with a</span>
                             <span class="record-warnings">
@@ -137,7 +137,7 @@
                             <span>may be accidental logins.</span>
                         </p>
                     % end
-                    % if context.system and any(not a.active for a in allocations):
+                    % if context.system and any(not a.active for a in allocations) and show_help_text:
                         <p>
                             <span>Entries with a</span>
                             <span class="transfer">

--- a/views/pages/nearby.tpl
+++ b/views/pages/nearby.tpl
@@ -98,7 +98,7 @@
                                     </div>
                                     <div class="content">
                                         % if upcoming_departures:
-                                            % if context.realtime_enabled:
+                                            % if context.realtime_enabled and show_help_text:
                                                 <p>
                                                     <span>{{ context.vehicle_type_plural }} with a</span>
                                                     <span class="scheduled">

--- a/views/pages/personalize.tpl
+++ b/views/pages/personalize.tpl
@@ -129,20 +129,19 @@
         </div>
         <div class="section">
             <div class="header" onclick="toggleSection(this)">
-                <h2>Show Help Text</h2>
+                <h2>Hide Help Text</h2>
                 % include('components/toggle')
             </div>
             <div class="content">
-                <p>
-                    This includes stuff like the meaning of some icons in tables and the colours for schedule indicators.
-                    If you're a regular on the site and know how it all works, you can disable this to reduce a bit of clutter.
-                </p>
+                <p>Reduces visual clutter by hiding explanatory text across the site.</p>
+                <p>For example, it hides the text explaining what times in brackets mean for upcoming trips, or the text explaining what the accidental login icon means.</p>
+                <p>This is intended for regular users of the site who already know how everything works.</p>
                 <div class="options-container">
                     <div class="option" onclick="setHelpText('{{ show_help_text }}' !== 'True')">
-                        <div class="checkbox {{ 'selected' if show_help_text else '' }}">
+                        <div class="checkbox {{ '' if show_help_text else 'selected' }}">
                             % include('components/svg', name='status/check')
                         </div>
-                        <div>Show Help Text</div>
+                        <div>Hide Help Text</div>
                     </div>
                 </div>
             </div>

--- a/views/pages/personalize.tpl
+++ b/views/pages/personalize.tpl
@@ -127,6 +127,26 @@
                 </div>
             </div>
         </div>
+        <div class="section">
+            <div class="header" onclick="toggleSection(this)">
+                <h2>Show Help Text</h2>
+                % include('components/toggle')
+            </div>
+            <div class="content">
+                <p>
+                    This includes stuff like the meaning of some icons in tables and the colours for schedule indicators.
+                    If you're a regular on the site and know how it all works, you can disable this to reduce a bit of clutter.
+                </p>
+                <div class="options-container">
+                    <div class="option" onclick="setHelpText('{{ show_help_text }}' !== 'True')">
+                        <div class="checkbox {{ 'selected' if show_help_text else '' }}">
+                            % include('components/svg', name='status/check')
+                        </div>
+                        <div>Show Help Text</div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
     <div class="container flex-1">
         <div class="section">
@@ -187,6 +207,14 @@
             window.location = "?high_contrast=enabled";
         } else {
             window.location = "?high_contrast=disabled";
+        }
+    }
+    
+    function setHelpText(enabled) {
+        if (enabled) {
+            window.location = "?show_help_text=yes";
+        } else {
+            window.location = "?show_help_text=no";
         }
     }
     

--- a/views/pages/route/overview.tpl
+++ b/views/pages/route/overview.tpl
@@ -161,7 +161,7 @@
                                         % include('components/toggle')
                                     </div>
                                     <div class="content">
-                                        % if context.realtime_enabled:
+                                        % if context.realtime_enabled and show_help_text:
                                             <p>
                                                 <span>{{ context.vehicle_type_plural }} with a</span>
                                                 <span class="scheduled">

--- a/views/pages/stop/overview.tpl
+++ b/views/pages/stop/overview.tpl
@@ -144,7 +144,7 @@
                     </div>
                     <div class="content">
                         % if upcoming_departures:
-                            % if context.realtime_enabled:
+                            % if context.realtime_enabled and show_help_text:
                                 <p>
                                     <span>{{ context.vehicle_type_plural }} with a</span>
                                     <span class="scheduled">
@@ -199,7 +199,7 @@
                         % upcoming_count = 3 + floor(len(routes) / 3)
                         % upcoming_departures = [d for d in departures if d.time.is_now or d.time.is_later][:upcoming_count]
                         % if upcoming_departures:
-                            % if context.realtime_enabled:
+                            % if context.realtime_enabled and show_help_text:
                                 <p>
                                     <span>{{ context.vehicle_type_plural }} with a</span>
                                     <span class="scheduled">
@@ -254,7 +254,7 @@
                 </div>
                 <div class="content">
                     % if departures:
-                        % if context.realtime_enabled:
+                        % if context.realtime_enabled and show_help_text:
                             <p>
                                 <span>{{ context.vehicle_type_plural }} with a</span>
                                 <span class="scheduled">

--- a/views/pages/trip/history.tpl
+++ b/views/pages/trip/history.tpl
@@ -57,7 +57,7 @@
                 </div>
                 <div class="content">
                     % if records:
-                        % if any(r.warnings for r in records):
+                        % if any(r.warnings for r in records) and show_help_text:
                             <p>
                                 <span>Entries with a</span>
                                 <span class="record-warnings">

--- a/views/pages/trip/overview.tpl
+++ b/views/pages/trip/overview.tpl
@@ -227,7 +227,9 @@
                     % include('components/toggle')
                 </div>
                 <div class="content">
-                    <p>This {{ vehicle.type_generic_name.lower() }} is currently assigned to this trip's block but may be swapped off before this trip runs.</p>
+                    % if show_help_text:
+                        <p>This {{ vehicle.type_generic_name.lower() }} is currently assigned to this trip's block but may be swapped off before this trip runs.</p>
+                    % end
                     <div class="table-border-wrapper">
                         <table>
                             <thead>

--- a/views/pages/trip/overview.tpl
+++ b/views/pages/trip/overview.tpl
@@ -312,7 +312,7 @@
                 % include('components/toggle')
             </div>
             <div class="content">
-                % if any(d.timepoint for d in departures):
+                % if any(d.timepoint for d in departures) and show_help_text:
                     <p>Departures in <span class="timing-point">bold</span> are timing points.</p>
                 % end
                 % last_headsign = None

--- a/views/pages/vehicle/history.tpl
+++ b/views/pages/vehicle/history.tpl
@@ -89,7 +89,7 @@
                         % dates = {r.date for r in records}
                         <h3>{{ min(dates).format_long() }} - {{ max(dates).format_long() }}</h3>
                         
-                        % if any(r.warnings for r in records):
+                        % if any(r.warnings for r in records) and show_help_text:
                             <p>
                                 <span>Entries with a</span>
                                 <span class="record-warnings">

--- a/views/pages/vehicle/overview.tpl
+++ b/views/pages/vehicle/overview.tpl
@@ -51,17 +51,19 @@
                         % include('components/map', map_position=position)
                     % end
                 % else:
-                    % if last_position:
-                        <div class="warning-box">
-                            % include('components/svg', name='status/warning')
-                            <p>Offline — showing last known location</p>
-                        </div>
-                        % include('components/map', map_position=last_position, offline=True)
-                    % else:
-                        <div class="warning-box">
-                            % include('components/svg', name='status/warning')
-                            <p>Offline — last known location not available</p>
-                        </div>
+                    % if show_help_text:
+                        % if last_position:
+                            <div class="warning-box">
+                                % include('components/svg', name='status/warning')
+                                <p>Offline — showing last known location</p>
+                            </div>
+                            % include('components/map', map_position=last_position, offline=True)
+                        % else:
+                            <div class="warning-box">
+                                % include('components/svg', name='status/warning')
+                                <p>Offline — last known location not available</p>
+                            </div>
+                        % end
                     % end
                     % trip = None
                 % end
@@ -293,11 +295,13 @@
                     % include('components/toggle')
                 </div>
                 <div class="content">
-                    % if any(d.timepoint for d in upcoming_departures):
-                        <p>Departures in <span class="timing-point">bold</span> are timing points.</p>
-                    % end
-                    % if position.adherence and position.adherence.value != 0 and not position.adherence.layover:
-                        <p>Times in brackets are estimates based on current location.</p>
+                    % if show_help_text:
+                        % if any(d.timepoint for d in upcoming_departures):
+                            <p>Departures in <span class="timing-point">bold</span> are timing points.</p>
+                        % end
+                        % if position.adherence and position.adherence.value != 0 and not position.adherence.layover:
+                            <p>Times in brackets are estimates based on current location.</p>
+                        % end
                     % end
                     <table>
                         <thead>
@@ -344,7 +348,7 @@
             </div>
             <div class="content">
                 % if records:
-                    % if any(r.warnings for r in records):
+                    % if any(r.warnings for r in records) and show_help_text:
                         <p>
                             <span>Entries with a</span>
                             <span class="record-warnings">

--- a/views/pages/vehicle/overview.tpl
+++ b/views/pages/vehicle/overview.tpl
@@ -51,19 +51,17 @@
                         % include('components/map', map_position=position)
                     % end
                 % else:
-                    % if show_help_text:
-                        % if last_position:
-                            <div class="warning-box">
-                                % include('components/svg', name='status/warning')
-                                <p>Offline — showing last known location</p>
-                            </div>
-                            % include('components/map', map_position=last_position, offline=True)
-                        % else:
-                            <div class="warning-box">
-                                % include('components/svg', name='status/warning')
-                                <p>Offline — last known location not available</p>
-                            </div>
-                        % end
+                    % if last_position:
+                        <div class="warning-box">
+                            % include('components/svg', name='status/warning')
+                            <p>Offline — showing last known location</p>
+                        </div>
+                        % include('components/map', map_position=last_position, offline=True)
+                    % elif show_help_text:
+                        <div class="warning-box">
+                            % include('components/svg', name='status/warning')
+                            <p>Offline — last known location not available</p>
+                        </div>
                     % end
                     % trip = None
                 % end


### PR DESCRIPTION
Adds a toggle on the Personalize page for hiding/showing help text around the site. When disabled, some of the generic labels that are meant to help newcomers are no longer shown, reducing clutter. By default this setting is enabled.

Currently controls the following things:
- Schedule indicator headers (meaning for the different colours)
- Schedule indicator footers ("Click on a weekday or date..." text)
- Accidental logins icon text
- Assigned/scheduled but may be swapped off text
- Transferred elsewhere text
- Timing points text
- Time estimates text
- Toggle Systems List tooltip
  - In general I ignored tooltips for this since they don't really add clutter, even if they're giving somewhat redundant info. I made an exception for this case because I've been finding it a bit weird when hovering over the button shows both the dropdown below and the tooltip to the side. I think it's worth keeping the tooltip when this setting is disabled to make sure users know what it does, but is unnecessary for pros
- Offline warnings for bus last known positions
  - For buses that have never been seen before I think this is totally fine, could possibly even be removed permanently tbh
  - For buses that are currently offline but have a last known position I think it's a bit iffier as there's a higher chance a user could get confused and think it's the bus' actual current location. I think for people who use the site regularly and actually disable this setting they should be savvy enough to know, but if you think this is a bad idea I can revert this one

One small caveat for consideration: If we ever add new help text when new features are added, users who have disabled this setting already may not get to see it. There's a few potential workarounds including:
- Add a versioning system that gets bumped when we add new help text, so essentially the setting gets reset and the user has to disable it again
- Initially the new help text is _not_ hidden even when this setting is disabled, so that all users have an opportunity to see it, and then we make it hideable later

IMO the second option is probably a reasonable choice, but I also think it's something we don't need to be too concerned about until it actually comes up.

Example of a page with help text shown:
<img width="1458" height="796" alt="Screenshot 2026-04-27 at 21 11 59" src="https://github.com/user-attachments/assets/5830f1e9-f94f-47ab-8226-bf541ce80590" />

Example of the same page without help text shown:
<img width="1432" height="795" alt="Screenshot 2026-04-27 at 21 12 32" src="https://github.com/user-attachments/assets/05702418-7b2b-4b39-a49d-f527357ba079" />

A few other examples of pages without help text:
<img width="1426" height="799" alt="Screenshot 2026-04-27 at 20 47 38" src="https://github.com/user-attachments/assets/8a1e20c9-bca3-48a7-8458-bcec989e7701" />

<img width="1278" height="690" alt="Screenshot 2026-04-27 at 20 55 09" src="https://github.com/user-attachments/assets/4e8ad4e0-05b6-4897-8e80-a12ba9973ea3" />

<img width="1681" height="792" alt="Screenshot 2026-04-27 at 20 50 56" src="https://github.com/user-attachments/assets/7456ed03-c39a-4474-910c-41e15bdeb253" />

Updated Personalize page:
<img width="1706" height="786" alt="Screenshot 2026-04-27 at 20 53 51" src="https://github.com/user-attachments/assets/dd096abc-7275-4cd7-9fc4-d60937a982c2" />
