### PR TITLE
Blockless records (ABTracker)

### DIFF
--- a/models/record.py
+++ b/models/record.py
@@ -29,14 +29,16 @@ class Record:
     def from_db(cls, row: Row):
         '''Returns a record initialized from the given database row'''
         id = row['id']
+        if id is None:
+            raise ValueError()
         allocation_id = row['allocation_id']
         context = row.context()
         vehicle = context.find_vehicle(row['vehicle_id'])
         date = Date.parse(row['date'], context.timezone)
         block_id = row['block_id']
-        if 'route_numbers' in row:
+        try:
             route_numbers = [n.strip() for n in row['route_numbers'].split(',')]
-        else:
+        except:
             route_numbers = []
         start_time = Time.parse(row['start_time'], context.timezone, context.accurate_seconds)
         end_time = Time.parse(row['end_time'], context.timezone, context.accurate_seconds)
@@ -66,7 +68,7 @@ class Record:
     @property
     def is_available(self):
         '''Checks if this record has an associated block'''
-        return self.block is not None
+        return self.block_id is None or self.block is not None
     
     @property
     def routes(self):

--- a/models/trip.py
+++ b/models/trip.py
@@ -26,7 +26,7 @@ class Trip:
     id: str
     route_id: str
     service_id: str
-    block_id: str
+    block_id: str | None
     direction_id: int
     shape_id: str
     headsign: str
@@ -72,7 +72,9 @@ class Trip:
     @property
     def block(self):
         '''Returns the block associated with this trip'''
-        return self.system.get_block(self.block_id)
+        if self.block_id:
+            return self.system.get_block(self.block_id)
+        return None
     
     @property
     def service(self):

--- a/repositories/impl/record.py
+++ b/repositories/impl/record.py
@@ -9,6 +9,7 @@ from models.context import Context
 from models.date import Date
 from models.record import Record
 from models.time import Time
+from models.trip import Trip
 from models.vehicle import Vehicle
 
 @dataclass(slots=True)
@@ -34,6 +35,23 @@ class RecordRepository:
         self.create_trip(record_id, trip_id)
         return record_id
     
+    def create_from_trip(self, allocation_id: int, date: Date, trip: Trip, time: Time):
+        '''Inserts a new record into the database based on a single trip'''
+        record_id = self.database.insert(
+            table='record',
+            values={
+                'allocation_id': allocation_id,
+                'date': date.format_db(),
+                'route_numbers': trip.route.number if trip.route else None,
+                'start_time': trip.start_time.format_db(),
+                'end_time': trip.end_time.format_db(),
+                'first_seen': time.format_db(),
+                'last_seen': time.format_db()
+            }
+        )
+        self.create_trip(record_id, trip.id)
+        return record_id
+    
     def create_trip(self, record_id: int, trip_id: str):
         '''Inserts a new trip record into the database'''
         self.database.insert(
@@ -56,6 +74,30 @@ class RecordRepository:
             }
         )
     
+    def merge(self, record: Record, trip: Trip, time: Time):
+        '''Updates a non-block record based on a trip'''
+        route_numbers = record.route_numbers
+        if trip.route and trip.route.number not in route_numbers:
+            route_numbers.append(trip.route.number)
+        start_time = record.start_time
+        if not trip.start_time.is_unknown and (start_time.is_unknown or trip.start_time < start_time):
+            start_time = trip.start_time
+        end_time = record.end_time
+        if not trip.end_time.is_unknown and (end_time.is_unknown or trip.end_time > end_time):
+            end_time = trip.end_time
+        self.database.update(
+            table='record',
+            values={
+                'route_numbers': ', '.join(route_numbers),
+                'start_time': start_time.format_db(),
+                'end_time': end_time.format_db(),
+                'last_seen': time.format_db()
+            },
+            filters={
+                'record_id': record.id
+            }
+        )
+    
     def find_all(self, context: Context = Context(), vehicle_id: str | None = None, block_id: str | None = None, trip_id: str | None = None, limit: int | None = None, page: int | None = None) -> list[Record]:
         '''Returns all records that match the given context, vehicle, block, and trip'''
         joins = {
@@ -75,7 +117,7 @@ class RecordRepository:
             }
             filters['trip_record.trip_id'] = trip_id
         return self.database.select(
-            table='record', 
+            table='record',
             columns={
                 'allocation.agency_id': 'agency_id',
                 'allocation.vehicle_id': 'vehicle_id',

--- a/repositories/impl/trip.py
+++ b/repositories/impl/trip.py
@@ -14,21 +14,19 @@ class TripRepository:
     
     def create(self, context: Context, row: dict):
         '''Inserts a new trip into the database'''
-        trip_id = row['trip_id']
-        block_id = row.get('block_id', trip_id)
-        if 'direction_id' in row:
+        try:
             direction_id = int(row['direction_id'])
-        else:
+        except:
             direction_id = 0
         self.database.insert(
             table='trip',
             values={
                 # 'agency_id': context.agency_id,
                 'system_id': context.system_id,
-                'trip_id': trip_id,
+                'trip_id': row['trip_id'],
                 'route_id': row['route_id'],
                 'service_id': row['service_id'],
-                'block_id': block_id,
+                'block_id': row.get('block_id'),
                 'direction_id': direction_id,
                 'shape_id': row['shape_id'],
                 'headsign': row['trip_headsign']

--- a/services/impl/gtfs.py
+++ b/services/impl/gtfs.py
@@ -80,15 +80,15 @@ class GTFSService:
         trips = repositories.trip.find_all(context)
         context.system.trips = {t.id: t for t in trips}
         
-        block_trips = {}
-        for trip in trips:
-            block_trips.setdefault(trip.block_id, []).append(trip)
-        
         routes = repositories.route.find_all(context)
         context.system.routes = {r.id: r for r in routes}
         context.system.routes_by_number = {r.number: r for r in routes}
         
-        context.system.blocks = {id: Block(context.agency, context.system, id, trips) for id, trips in block_trips.items()}
+        if context.enable_blocks:
+            block_trips = {}
+            for trip in trips:
+                block_trips.setdefault(trip.block_id, []).append(trip)
+            context.system.blocks = {id: Block(context.agency, context.system, id, trips) for id, trips in block_trips.items()}
         
         context.system.gtfs_loaded = True
         context.system.reset_caches()

--- a/services/impl/realtime.py
+++ b/services/impl/realtime.py
@@ -98,21 +98,39 @@ class RealtimeService:
                     first_record = None
                     last_record = None
                 
-                if position.trip and position.block_id and position.block:
-                    assignment = repositories.assignment.find(position.block_id, allocation_id, date)
-                    if not assignment or assignment.allocation_id != allocation_id:
-                        repositories.assignment.delete_all(block_id=position.block_id)
-                        repositories.assignment.delete_all(allocation_id=allocation_id)
-                        repositories.assignment.create(position.block_id, allocation_id, date)
-                    
-                    if last_record and last_record.date == date and last_record.block_id == position.block_id:
+                if context.enable_blocks:
+                    if position.trip and position.block_id and position.block:
+                        assignment = repositories.assignment.find(position.block_id, allocation_id, date)
+                        if not assignment or assignment.allocation_id != allocation_id:
+                            repositories.assignment.delete_all(block_id=position.block_id)
+                            repositories.assignment.delete_all(allocation_id=allocation_id)
+                            repositories.assignment.create(position.block_id, allocation_id, date)
+                        
+                        if last_record and last_record.date == date and last_record.block_id == position.block_id:
+                            record_id = last_record.id
+                            repositories.record.update(last_record.id, time)
+                            trip_ids = repositories.record.find_trip_ids(last_record.id)
+                            if position.trip_id not in trip_ids:
+                                repositories.record.create_trip(last_record.id, position.trip_id)
+                        else:
+                            record_id = repositories.record.create(allocation_id, date, position.block, time, position.trip_id)
+                        
+                        if not first_record:
+                            repositories.allocation.set_first_record(allocation_id, record_id)
+                        if not last_record or last_record.id != record_id:
+                            repositories.allocation.set_last_record(allocation_id, record_id)
+                elif position.trip:
+                    trip = position.trip
+                    if last_record and last_record.date == date:
                         record_id = last_record.id
-                        repositories.record.update(last_record.id, time)
                         trip_ids = repositories.record.find_trip_ids(last_record.id)
-                        if position.trip_id not in trip_ids:
+                        if position.trip_id in trip_ids:
+                            repositories.record.update(last_record.id, time)
+                        else:
+                            repositories.record.merge(last_record, trip, time)
                             repositories.record.create_trip(last_record.id, position.trip_id)
                     else:
-                        record_id = repositories.record.create(allocation_id, date, position.block, time, position.trip_id)
+                        record_id = repositories.record.create_from_trip(allocation_id, date, trip, time)
                     
                     if not first_record:
                         repositories.allocation.set_first_record(allocation_id, record_id)

--- a/static/agencies.json
+++ b/static/agencies.json
@@ -38,7 +38,8 @@
         "realtime_url": "https://medicinehat.tmix.se/gtfs-realtime/vehicleupdates.pb",
         "vehicle_name_length": 3,
         "prefix_headsigns": true,
-        "distance_scale": 1000
+        "distance_scale": 1000,
+        "enable_blocks": false
     },
     "red-deer-transit": {
         "name": "Red Deer Transit",
@@ -57,6 +58,7 @@
         "prefer_stop_id": true,
         "show_stop_number": false,
         "distance_scale": 1000,
+        "enable_blocks": false,
         "invalid_realtime_percentage": 0.5
     },
     "woosh": {

--- a/utilities/migrate-blockless-records.py
+++ b/utilities/migrate-blockless-records.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+import sys
+import os
+
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+
+from database import Database
+
+from models.date import Date
+from models.daterange import DateRange
+from models.time import Time
+
+from constants import DEFAULT_TIMEZONE
+
+database = Database()
+database.connect()
+
+date_range = DateRange(Date(2025, 3, 30, DEFAULT_TIMEZONE), Date.today())
+# date_range = DateRange(Date(2025, 4, 1, DEFAULT_TIMEZONE), Date(2025, 4, 1, DEFAULT_TIMEZONE))
+
+def update_records(agency_id):
+    ACCURATE_SECONDS = agency_id == 'medicine-hat-transit'
+    for date in date_range:
+        print(f'Updating {agency_id} for {date.format_long()}')
+        rows = database.select(
+            table='record',
+            columns={
+                'allocation.agency_id': 'agency_id',
+                'allocation.vehicle_id': 'vehicle_id',
+                'allocation.system_id': 'system_id',
+                'allocation_record.first_record_id': 'first_record_id',
+                'allocation_record.last_record_id': 'last_record_id',
+                'record.record_id': 'id',
+                'record.allocation_id': 'allocation_id',
+                'record.date': 'date',
+                'record.block_id': 'block_id',
+                'record.route_numbers': 'route_numbers',
+                'record.start_time': 'start_time',
+                'record.end_time': 'end_time',
+                'record.first_seen': 'first_seen',
+                'record.last_seen': 'last_seen'
+            },
+            joins={
+                'allocation': {
+                    'allocation.allocation_id': 'record.allocation_id'
+                },
+                'allocation_record': {
+                    'allocation_record.allocation_id': 'record.allocation_id'
+                }
+            },
+            filters={
+                'allocation.agency_id': agency_id,
+                'record.date': date.format_db()
+            }
+        )
+        if len(rows) == 0:
+            continue
+        vehicle_rows = {}
+        for row in rows:
+            vehicle_rows.setdefault(row['vehicle_id'], []).append(row)
+        
+        for (vehicle_id, rows) in vehicle_rows.items():
+            print(' -', vehicle_id)
+            record_id = rows[0]['id']
+            first_record_id = rows[0]['first_record_id']
+            last_record_id = rows[0]['last_record_id']
+            allocation_id = rows[0]['allocation_id']
+            unused_record_ids = {r['id'] for r in rows[1:]}
+            
+            all_route_numbers = [r['route_numbers'] for r in rows]
+            seen_route_numbers = set()
+            seen_add = seen_route_numbers.add
+            route_numbers = [n for n in all_route_numbers if not (n in seen_route_numbers or seen_add(n))]
+            
+            start_times = [Time.parse(r['start_time'], accurate_seconds=ACCURATE_SECONDS) for r in rows]
+            end_times = [Time.parse(r['end_time'], accurate_seconds=ACCURATE_SECONDS) for r in rows]
+            first_seen_times = [Time.parse(r['first_seen'], accurate_seconds=ACCURATE_SECONDS) for r in rows]
+            last_seen_times = [Time.parse(r['last_seen'], accurate_seconds=ACCURATE_SECONDS) for r in rows]
+            
+            start_time = min(start_times)
+            end_time = max(end_times)
+            first_seen = min(first_seen_times)
+            last_seen = max(last_seen_times)
+            
+            if first_record_id in unused_record_ids:
+                database.update(
+                    table='allocation_record',
+                    values={
+                        'first_record_id': record_id
+                    },
+                    filters={
+                        'allocation_id': allocation_id
+                    }
+                )
+            if last_record_id in unused_record_ids:
+                database.update(
+                    table='allocation_record',
+                    values={
+                        'last_record_id': record_id
+                    },
+                    filters={
+                        'allocation_id': allocation_id
+                    }
+                )
+            database.update(
+                table='trip_record',
+                values={
+                    'record_id': record_id
+                },
+                filters={
+                    'record_id': unused_record_ids
+                }
+            )
+            database.delete(
+                table='record',
+                filters={
+                    'record_id': unused_record_ids
+                }
+            )
+            database.update(
+                table='record',
+                values={
+                    'block_id': None,
+                    'route_numbers': ', '.join(route_numbers),
+                    'start_time': start_time.format_db(),
+                    'end_time': end_time.format_db(),
+                    'first_seen': first_seen.format_db(),
+                    'last_seen': last_seen.format_db()
+                },
+                filters={
+                    'record_id': record_id
+                }
+            )
+
+update_records('roam')
+update_records('medicine-hat-transit')
+
+database.commit()
+database.disconnect()

--- a/utilities/migrate-blockless-records.py
+++ b/utilities/migrate-blockless-records.py
@@ -17,7 +17,6 @@ database = Database()
 database.connect()
 
 date_range = DateRange(Date(2025, 3, 30, DEFAULT_TIMEZONE), Date.today())
-# date_range = DateRange(Date(2025, 4, 1, DEFAULT_TIMEZONE), Date(2025, 4, 1, DEFAULT_TIMEZONE))
 
 def update_records(agency_id):
     ACCURATE_SECONDS = agency_id == 'medicine-hat-transit'

--- a/views/components/realtime_row.tpl
+++ b/views/components/realtime_row.tpl
@@ -22,7 +22,6 @@
         <td class="desktop-only">{{ position.context }}</td>
     % end
     % if trip:
-        % block = trip.block
         <td>
             <div class="column">
                 % include('components/headsign', departure=position.departure)
@@ -39,8 +38,11 @@
             </div>
         </td>
         % if context.enable_blocks:
+            % block = trip.block
             <td class="non-mobile">
-                <a href="{{ block.url() }}">{{ block.id }}</a>
+                % if block:
+                    <a href="{{ block.url() }}">{{ block.id }}</a>
+                % end
             </td>
         % end
         <td class="non-mobile">

--- a/views/components/realtime_row.tpl
+++ b/views/components/realtime_row.tpl
@@ -49,7 +49,7 @@
             % include('components/trip')
         </td>
     % else:
-        <td colspan="3">
+        <td colspan="{{ '3' if context.enable_blocks else '2' }}">
             <div class="column">
                 <div class="lighter-text">Not In Service</div>
                 % if stop:

--- a/views/components/route_list.tpl
+++ b/views/components/route_list.tpl
@@ -1,5 +1,5 @@
 <div class="route-list">
-    % for route in routes:
+    % for route in sorted(routes):
         % include('components/route', include_link=True, include_tooltip=True, compact=True)
     % end
 </div>

--- a/views/components/route_list.tpl
+++ b/views/components/route_list.tpl
@@ -1,5 +1,5 @@
 <div class="route-list">
-    % for route in sorted(routes):
+    % for route in sorted([r for r in routes if r]):
         % include('components/route', include_link=True, include_tooltip=True, compact=True)
     % end
 </div>

--- a/views/pages/history/first_seen.tpl
+++ b/views/pages/history/first_seen.tpl
@@ -113,15 +113,17 @@
                                         % if record:
                                             <td>
                                                 <div class="column stretch">
-                                                    <div class="row space-between">
-                                                        % if record.is_available:
-                                                            % block = record.block
-                                                            <a href="{{ block.url() }}">{{ block.id }}</a>
-                                                        % else:
-                                                            <span>{{ record.block_id }}</span>
-                                                        % end
-                                                        % include('components/record_warnings')
-                                                    </div>
+                                                    % if record.block_id:
+                                                        <div class="row space-between">
+                                                            % if record.is_available:
+                                                                % block = record.block
+                                                                <a href="{{ block.url() }}">{{ block.id }}</a>
+                                                            % else:
+                                                                <span>{{ record.block_id }}</span>
+                                                            % end
+                                                            % include('components/record_warnings')
+                                                        </div>
+                                                    % end
                                                     <div class="non-desktop">
                                                         % include('components/route_list', routes=record.routes)
                                                     </div>

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -285,15 +285,17 @@
                                                 % if record:
                                                     <td>
                                                         <div class="column stretch">
-                                                            <div class="row space-between">
-                                                                % if record.is_available:
-                                                                    % block = record.block
-                                                                    <a href="{{ block.url() }}">{{ block.id }}</a>
-                                                                % else:
-                                                                    <span>{{ record.block_id }}</span>
-                                                                % end
-                                                                % include('components/record_warnings')
-                                                            </div>
+                                                            % if record.block_id:
+                                                                <div class="row space-between">
+                                                                    % if record.is_available:
+                                                                        % block = record.block
+                                                                        <a href="{{ block.url() }}">{{ block.id }}</a>
+                                                                    % else:
+                                                                        <span>{{ record.block_id }}</span>
+                                                                    % end
+                                                                    % include('components/record_warnings')
+                                                                </div>
+                                                            % end
                                                             <div class="non-desktop">
                                                                 % include('components/route_list', routes=record.routes)
                                                             </div>

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -252,6 +252,9 @@
                                     </tr>
                                     <tr class="display-none"></tr>
                                     % for allocation in order_allocations:
+                                        % if allocation.last_date is None:
+                                            % print(allocation.last_record is None)
+                                        % end
                                         % vehicle = allocation.vehicle
                                         % record = allocation.last_record
                                         <tr>

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -95,7 +95,6 @@
                                         % include('components/year_model', year_model=vehicle.year_model)
                                     </td>
                                     % trip = position.trip
-                                    % block = trip.block
                                     % stop = position.stop
                                     <td>
                                         <div class="column">
@@ -113,8 +112,11 @@
                                         </div>
                                     </td>
                                     % if context.enable_blocks:
+                                        % block = trip.block
                                         <td class="non-mobile">
-                                            <a href="{{ block.url() }}">{{ block.id }}</a>
+                                            % if block:
+                                                <a href="{{ block.url() }}">{{ block.id }}</a>
+                                            % end
                                         </td>
                                     % end
                                     <td class="non-mobile">

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -71,7 +71,6 @@
                         % end
                         <td class="desktop-only no-wrap">{{ position.speed }} km/h</td>
                         % if trip:
-                            % block = trip.block
                             <td>
                                 <div class="column">
                                     % include('components/headsign', departure=position.departure)
@@ -89,8 +88,11 @@
                                 </div>
                             </td>
                             % if context.enable_blocks:
+                                % block = trip.block
                                 <td class="non-mobile">
-                                    <a href="{{ block.url() }}">{{ block.id }}</a>
+                                    % if block:
+                                        <a href="{{ block.url() }}">{{ block.id }}</a>
+                                    % end
                                 </td>
                             % end
                             <td class="non-mobile">

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -99,7 +99,7 @@
                                 % include('components/trip')
                             </td>
                         % else:
-                            <td colspan="3">
+                            <td colspan="{{ '3' if context.enable_blocks else '2' }}">
                                 <div class="column">
                                     <span class="lighter-text">Not In Service</span>
                                     <span class="non-desktop smaller-font no-wrap">{{ position.speed }} km/h</span>


### PR DESCRIPTION
- Disabled blocks for Banff and Medicine Hat
- Updated logic for bus records in agencies without blocks
  - Only one record is created per bus per day (instead of one record per trip)
  - Block ID is not stored with the record (already optional in the DB)
  - Route numbers and times are updated as the bus does additional trips
- Small UI fixes for realtime vehicles without blocks
- Added utility migration script to update existing bus logs
  - Should be pretty quick to run, but like with some other bigger migrations in the past the best option might be to download the DB file, run the script locally, and re-upload the updated DB

Before - lots of records for individual trips make bus history overwhelming
<img width="1385" height="799" alt="Screenshot 2026-05-14 at 21 45 49" src="https://github.com/user-attachments/assets/abbcf381-6c94-4cee-bbfc-ee5e2b8cd3bb" />

After - much easier to understand (note that this is local data so it's kinda sparse for the last half year)
<img width="1353" height="799" alt="Screenshot 2026-05-14 at 21 46 01" src="https://github.com/user-attachments/assets/6865eb25-99bf-4aba-b850-f732f95136d4" />

