### PR TITLE
Show next stop on map vehicle positions

### DIFF
--- a/models/position.py
+++ b/models/position.py
@@ -168,6 +168,9 @@ class Position:
         else:
             data['headsign'] = 'Not In Service'
             data['route_number'] = 'NIS'
+        stop = self.stop
+        if stop:
+            data['stop_name'] = str(stop).replace("'", '&apos;')
         occupancy = self.occupancy
         if occupancy:
             data['occupancy_name'] = occupancy.value,

--- a/server.py
+++ b/server.py
@@ -19,7 +19,7 @@ import services
 import settings
 
 # Increase the version to force CSS reload
-VERSION = 69
+VERSION = 70
 
 random = Random()
 

--- a/style/main.css
+++ b/style/main.css
@@ -1091,6 +1091,7 @@ table tr.table-button {
     flex-direction: column;
     align-items: center;
     gap: 2px;
+    --image-size: 12px;
 }
 
 .marker .details .content .adherence-indicator {

--- a/style/themes/bc-ferries.dark.css
+++ b/style/themes/bc-ferries.dark.css
@@ -358,6 +358,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #ABABAB;
+    --image-color: #ABABAB;
 }
 
 .marker .details {

--- a/style/themes/bc-ferries.light.css
+++ b/style/themes/bc-ferries.light.css
@@ -350,6 +350,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #666666;
+    --image-color: #666666;
 }
 
 .marker .details {

--- a/style/themes/bc-hydro.css
+++ b/style/themes/bc-hydro.css
@@ -344,6 +344,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #666666;
+    --image-color: #666666;
 }
 
 .marker .details {

--- a/style/themes/bc-transit-classic.css
+++ b/style/themes/bc-transit-classic.css
@@ -348,6 +348,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #666666;
+    --image-color: #666666;
 }
 
 .marker .details {

--- a/style/themes/bc-transit-green.dark.css
+++ b/style/themes/bc-transit-green.dark.css
@@ -369,6 +369,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #ABABAB;
+    --image-color: #ABABAB;
 }
 
 .marker .details {

--- a/style/themes/bc-transit-green.light.css
+++ b/style/themes/bc-transit-green.light.css
@@ -361,6 +361,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #666666;
+    --image-color: #666666;
 }
 
 .marker .details {

--- a/style/themes/bc-transit.dark.css
+++ b/style/themes/bc-transit.dark.css
@@ -356,6 +356,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #ABABAB;
+    --image-color: #ABABAB;
 }
 
 .marker .details {

--- a/style/themes/bc-transit.light.css
+++ b/style/themes/bc-transit.light.css
@@ -348,6 +348,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #666666;
+    --image-color: #666666;
 }
 
 .marker .details {

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -328,6 +328,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #666666;
+    --image-color: #666666;
 }
 
 .marker .details {

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -350,6 +350,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #666666;
+    --image-color: #666666;
 }
 
 .marker .details {

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -333,6 +333,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #888888;
+    --image-color: #888888;
 }
 
 .marker .details {

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -356,6 +356,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #ABABAB;
+    --image-color: #ABABAB;
 }
 
 .marker .details {

--- a/style/themes/pride.dark.css
+++ b/style/themes/pride.dark.css
@@ -346,6 +346,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #ABABAB;
+    --image-color: #ABABAB;
 }
 
 .marker .details {

--- a/style/themes/pride.light.css
+++ b/style/themes/pride.light.css
@@ -345,6 +345,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #2F2F2F;
+    --image-color: #2F2F2F;
 }
 
 .marker .details {

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -499,6 +499,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #666666;
+    --image-color: #666666;
 }
 
 .marker .details {

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -344,6 +344,7 @@ table tr.table-button:hover {
 
 .lighter-text {
     color: #666666;
+    --image-color: #666666;
 }
 
 .marker .details {

--- a/views/components/map.tpl
+++ b/views/components/map.tpl
@@ -251,6 +251,13 @@
                 content.appendChild(headsign);
             }
             
+            if (position.stop_name) {
+                const stopElement = document.createElement("div");
+                stopElement.className = "row gap-2 lighter-text";
+                stopElement.innerHTML = getSVG("stop") + "<span>" + position.stop_name + "</span>";
+                content.appendChild(stopElement);
+            }
+            
             const footer = document.createElement("div");
             footer.className = "lighter-text";
             content.appendChild(footer);

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -331,7 +331,14 @@
                 }
                 content.appendChild(headsign);
             }
-        
+            
+            if (position.stop_name) {
+                const stopElement = document.createElement("div");
+                stopElement.className = "row gap-2 lighter-text";
+                stopElement.innerHTML = getSVG("stop") + "<span>" + position.stop_name + "</span>";
+                content.appendChild(stopElement);
+            }
+            
             const footer = document.createElement("div");
             footer.className = "lighter-text";
             content.appendChild(footer);


### PR DESCRIPTION
User-requested feature: vehicle positions on maps will now show the next stop, if available.

Minor styling updates to properly show small stop icon next to the stop name, to clarify what it means. Also toyed with just explicit "Next stop:" prefix but the icon is more compact.

<img width="297" height="235" alt="Screenshot 2026-06-07 at 23 49 54" src="https://github.com/user-attachments/assets/3eb7164c-e5ad-4139-b0f4-a2b969b25d08" />

<img width="298" height="217" alt="Screenshot 2026-06-07 at 23 50 07" src="https://github.com/user-attachments/assets/83211363-ece7-41ee-945a-a8c692203ada" />
