### PR TITLE
Add GTFS download table

### DIFF
--- a/database.py
+++ b/database.py
@@ -96,9 +96,18 @@ SQL_SCRIPTS = [
         )
     ''',
     '''
-        CREATE TABLE IF NOT EXISTS route (
+        CREATE TABLE IF NOT EXISTS download (
+            download_id INTEGER PRIMARY KEY ASC,
             agency_id TEXT NOT NULL,
             system_id TEXT NOT NULL,
+            date TEXT NOT NULL,
+            time TEXT NOT NULL,
+            trigger TEXT NOT NULL
+        )
+    ''',
+    '''
+        CREATE TABLE IF NOT EXISTS route (
+            download_id TEXT NOT NULL,
             route_id TEXT NOT NULL,
             number TEXT NOT NULL,
             name TEXT NOT NULL,
@@ -106,13 +115,12 @@ SQL_SCRIPTS = [
             text_colour TEXT,
             type TEXT,
             sort_order INTEGER,
-            PRIMARY KEY (agency_id, system_id, route_id)
+            PRIMARY KEY (download_id, route_id)
         )
     ''',
     '''
         CREATE TABLE IF NOT EXISTS stop (
-            agency_id TEXT NOT NULL,
-            system_id TEXT NOT NULL,
+            download_id TEXT NOT NULL,
             stop_id TEXT NOT NULL,
             number TEXT NOT NULL,
             name TEXT NOT NULL,
@@ -120,13 +128,12 @@ SQL_SCRIPTS = [
             lon REAL NOT NULL,
             parent_id TEXT,
             type TEXT,
-            PRIMARY KEY (agency_id, system_id, stop_id)
+            PRIMARY KEY (download_id, stop_id)
         )
     ''',
     '''
         CREATE TABLE IF NOT EXISTS trip (
-            agency_id TEXT NOT NULL,
-            system_id TEXT NOT NULL,
+            download_id TEXT NOT NULL,
             trip_id TEXT NOT NULL,
             route_id TEXT NOT NULL,
             service_id TEXT NOT NULL,
@@ -134,14 +141,13 @@ SQL_SCRIPTS = [
             direction_id INTEGER,
             shape_id TEXT,
             headsign TEXT NOT NULL,
-            PRIMARY KEY (agency_id, system_id, trip_id),
-            FOREIGN KEY (agency_id, system_id, route_id) REFERENCES route (agency_id, system_id, route_id)
+            PRIMARY KEY (download_id, trip_id),
+            FOREIGN KEY (download_id, route_id) REFERENCES route (download_id, route_id)
         )
     ''',
     '''
         CREATE TABLE IF NOT EXISTS departure (
-            agency_id TEXT NOT NULL,
-            system_id TEXT NOT NULL,
+            download_id TEXT NOT NULL,
             trip_id TEXT NOT NULL,
             sequence INTEGER NOT NULL,
             stop_id TEXT NOT NULL,
@@ -151,20 +157,19 @@ SQL_SCRIPTS = [
             timepoint INTEGER NOT NULL,
             distance REAL,
             headsign TEXT,
-            PRIMARY KEY (agency_id, system_id, trip_id, sequence),
-            FOREIGN KEY (agency_id, system_id, trip_id) REFERENCES trip (agency_id, system_id, trip_id),
-            FOREIGN KEY (agency_id, system_id, stop_id) REFERENCES stop (agency_id, system_id, stop_id)
+            PRIMARY KEY (download_id, trip_id, sequence),
+            FOREIGN KEY (download_id, trip_id) REFERENCES trip (download_id, trip_id),
+            FOREIGN KEY (download_id, stop_id) REFERENCES stop (download_id, stop_id)
         )
     ''',
     '''
         CREATE TABLE IF NOT EXISTS point (
-            agency_id TEXT NOT NULL,
-            system_id TEXT NOT NULL,
+            download_id TEXT NOT NULL,
             shape_id TEXT NOT NULL,
             sequence INTEGER NOT NULL,
             lat REAL NOT NULL,
             lon REAL NOT NULL,
-            PRIMARY KEY (agency_id, system_id, shape_id, sequence)
+            PRIMARY KEY (download_id, shape_id, sequence)
         )
     ''',
     'CREATE INDEX IF NOT EXISTS allocation_agency_vehicle ON allocation (agency_id, vehicle_id)',

--- a/models/download.py
+++ b/models/download.py
@@ -1,0 +1,10 @@
+
+from enum import Enum
+
+class DownloadTrigger(Enum):
+    WEEKLY = 'weekly'
+    ADMIN = 'admin'
+    LAUNCH_FLAG = 'launch_flag'
+    NEAR_END_DATE = 'near_end_date'
+    INVALID_POSITIONS = 'invalid_positions'
+    MISSING = 'missing'

--- a/repositories/__init__.py
+++ b/repositories/__init__.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     from .impl.assignment import AssignmentRepository
     from .impl.decoration import DecorationRepository
     from .impl.departure import DepartureRepository
+    from .impl.download import DownloadRepository
     from .impl.livery import LiveryRepository
     from .impl.model import ModelRepository
     from .impl.order import OrderRepository
@@ -27,6 +28,7 @@ allocation: AllocationRepository
 assignment: AssignmentRepository
 decoration: DecorationRepository
 departure: DepartureRepository
+download: DownloadRepository
 livery: LiveryRepository
 model: ModelRepository
 order: OrderRepository

--- a/repositories/impl/__init__.py
+++ b/repositories/impl/__init__.py
@@ -4,6 +4,7 @@ from .allocation import AllocationRepository
 from .assignment import AssignmentRepository
 from .decoration import DecorationRepository
 from .departure import DepartureRepository
+from .download import DownloadRepository
 from .livery import LiveryRepository
 from .model import ModelRepository
 from .order import OrderRepository

--- a/repositories/impl/assignment.py
+++ b/repositories/impl/assignment.py
@@ -97,17 +97,19 @@ class AssignmentRepository:
             'assignment.date': context.today.format_db()
         }
         if trip_id or route_id or stop_id:
+            joins['download'] = {
+                'download.agency_id': 'allocation.agency_id',
+                'download.system_id': 'allocation.system_id'
+            }
             joins['trip'] = {
-                'trip.agency_id': 'allocation.agency_id',
-                'trip.system_id': 'allocation.system_id',
+                'trip.download_id': 'download.download_id',
                 'trip.block_id': 'assignment.block_id'
             }
             filters['trip.trip_id'] = trip_id
             filters['trip.route_id'] = route_id
             if stop_id:
                 joins['departure'] = {
-                    'departure.agency_id': 'trip.agency_id',
-                    'departure.system_id': 'trip.system_id',
+                    'departure.download_id': 'trip.download_id',
                     'departure.trip_id': 'trip.trip_id'
                 }
                 filters['departure.stop_id'] = stop_id

--- a/repositories/impl/departure.py
+++ b/repositories/impl/departure.py
@@ -11,7 +11,7 @@ class DepartureRepository:
     
     database: Database
     
-    def create(self, context: Context, row: dict):
+    def create(self, download_id: int, context: Context, row: dict):
         '''Inserts a new departure into the database'''
         try:
             pickup_type = PickupType(row['pickup_type'])
@@ -36,8 +36,7 @@ class DepartureRepository:
         self.database.insert(
             table='departure',
             values={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
+                'download_id': download_id,
                 'trip_id': row['trip_id'],
                 'sequence': int(row['stop_sequence']),
                 'stop_id': row['stop_id'],
@@ -69,18 +68,21 @@ class DepartureRepository:
             ]
         else:
             order_by = None
-        joins = {}
+        joins = {
+            'download': {
+                'download.download_id': 'departure.download_id'
+            }
+        }
         if route_id or block_id:
             joins['trip'] = {
-                'trip.agency_id': 'departure.agency_id',
-                'trip.system_id': 'departure.system_id',
+                'trip.download_id': 'departure.download_id',
                 'trip.trip_id': 'departure.trip_id'
             }
         return self.database.select(
             table='departure',
             columns={
-                'departure.agency_id': 'agency_id',
-                'departure.system_id': 'system_id',
+                'download.agency_id': 'agency_id',
+                'download.system_id': 'system_id',
                 'departure.trip_id': 'trip_id',
                 'departure.sequence': 'sequence',
                 'departure.stop_id': 'stop_id',
@@ -93,8 +95,8 @@ class DepartureRepository:
             },
             joins=joins,
             filters={
-                'departure.agency_id': context.agency_id,
-                'departure.system_id': context.system_id,
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id,
                 'departure.trip_id': trip_id,
                 'departure.sequence': sequence,
                 'departure.stop_id': stop_id,
@@ -110,28 +112,33 @@ class DepartureRepository:
         '''Returns all departures on a trip from the given sequence number onwards'''
         return self.database.select(
             table='departure',
-            columns=[
-                'agency_id',
-                'system_id',
-                'trip_id',
-                'sequence',
-                'stop_id',
-                'time',
-                'pickup_type',
-                'dropoff_type',
-                'timepoint',
-                'distance',
-                'headsign'
-            ],
+            columns={
+                'download.agency_id': 'agency_id',
+                'download.system_id': 'system_id',
+                'departure.trip_id': 'trip_id',
+                'departure.sequence': 'sequence',
+                'departure.stop_id': 'stop_id',
+                'departure.time': 'time',
+                'departure.pickup_type': 'pickup_type',
+                'departure.dropoff_type': 'dropoff_type',
+                'departure.timepoint': 'timepoint',
+                'departure.distance': 'distance',
+                'departure.headsign': 'headsign'
+            },
+            joins={
+                'download': {
+                    'download.download_id': 'departure.download_id'
+                }
+            },
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
-                'trip_id': trip_id,
-                'sequence': {
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id,
+                'departure.trip_id': trip_id,
+                'departure.sequence': {
                     '>=': sequence
                 }
             },
-            order_by='sequence',
+            order_by='departure.sequence',
             limit=limit,
             initializer=Departure.from_db
         )
@@ -142,22 +149,24 @@ class DepartureRepository:
             table='departure',
             columns='trip.*',
             joins={
+                'download': {
+                    'download.download_id': 'departure.download_id'
+                },
                 'trip': {
-                    'trip.agency_id': 'departure.agency_id',
-                    'trip.system_id': 'departure.system_id',
+                    'trip.download_id': 'departure.download_id',
                     'trip.trip_id': 'departure.trip_id'
                 }
             },
             filters={
-                'departure.agency_id': context.agency_id,
-                'departure.system_id': context.system_id,
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id,
                 'departure.stop_id': stop_id
             })
         return self.database.select(
             table='stop_trip',
             columns={
-                'departure.agency_id': 'agency_id',
-                'departure.system_id': 'system_id',
+                'download.agency_id': 'agency_id',
+                'download.system_id': 'system_id',
                 'departure.trip_id': 'trip_id',
                 'departure.sequence': 'sequence',
                 'departure.stop_id': 'stop_id',
@@ -172,9 +181,11 @@ class DepartureRepository:
                 'stop_trip': cte
             },
             joins={
+                'download': {
+                    'download.download_id': 'stop_trip.download_id'
+                },
                 'departure': {
-                    'departure.agency_id': 'stop_trip.agency_id',
-                    'departure.system_id': 'stop_trip.system_id',
+                    'departure.download_id': 'stop_trip.download_id',
                     'departure.trip_id': 'stop_trip.trip_id'
                 }
             },
@@ -190,28 +201,33 @@ class DepartureRepository:
     def find_with_previous(self, context: Context, trip_id: str, sequence: int) -> tuple[Departure | None, Departure | None]:
         departures = self.database.select(
             table='departure',
-            columns=[
-                'agency_id',
-                'system_id',
-                'trip_id',
-                'sequence',
-                'stop_id',
-                'time',
-                'pickup_type',
-                'dropoff_type',
-                'timepoint',
-                'distance',
-                'headsign'
-            ],
+            columns={
+                'download.agency_id': 'agency_id',
+                'download.system_id': 'system_id',
+                'departure.trip_id': 'trip_id',
+                'departure.sequence': 'sequence',
+                'departure.stop_id': 'stop_id',
+                'departure.time': 'time',
+                'departure.pickup_type': 'pickup_type',
+                'departure.dropoff_type': 'dropoff_type',
+                'departure.timepoint': 'timepoint',
+                'departure.distance': 'distance',
+                'departure.headsign': 'headsign'
+            },
+            joins={
+                'download': {
+                    'download.download_id': 'departure.download_id'
+                }
+            },
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
-                'trip_id': trip_id,
-                'sequence': {
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id,
+                'departure.trip_id': trip_id,
+                'departure.sequence': {
                     '<=': sequence
                 }
             },
-            order_by='sequence DESC',
+            order_by='departure.sequence DESC',
             limit=2,
             initializer=Departure.from_db
         )
@@ -223,10 +239,30 @@ class DepartureRepository:
     
     def delete_all(self, context: Context):
         '''Deletes all departures for the given context from the database'''
+        download_ids = self.database.select(
+            table='departure',
+            columns={
+                'departure.download_id': 'download_id'
+            },
+            distinct=True,
+            joins={
+                'download': {
+                    'download.download_id': 'departure.download_id'
+                }
+            },
+            filters={
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id
+            },
+            initializer=lambda r: r['download_id']
+        )
+        if not download_ids:
+            return
+        if len(download_ids) == 1:
+            download_ids = download_ids[0]
         self.database.delete(
             table='departure',
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id
+                'download_id': download_ids
             }
         )

--- a/repositories/impl/download.py
+++ b/repositories/impl/download.py
@@ -1,0 +1,27 @@
+
+from dataclasses import dataclass
+
+from database import Database
+
+from models.context import Context
+from models.date import Date
+from models.download import DownloadTrigger
+from models.time import Time
+
+@dataclass(slots=True)
+class DownloadRepository:
+    
+    database: Database
+    
+    def create(self, context: Context, date: Date, time: Time, trigger: DownloadTrigger):
+        '''Inserts a new download into the database'''
+        return self.database.insert(
+            table='download',
+            values={
+                'agency_id': context.agency_id,
+                'system_id': context.system_id,
+                'date': date.format_db(),
+                'time': time.format_db(),
+                'trigger': trigger.value
+            }
+        )

--- a/repositories/impl/point.py
+++ b/repositories/impl/point.py
@@ -11,13 +11,12 @@ class PointRepository:
     
     database: Database
     
-    def create(self, context: Context, row: dict):
+    def create(self, download_id: int, context: Context, row: dict):
         '''Inserts a new point into the database'''
         self.database.insert(
             table='point',
             values={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
+                'download_id': download_id,
                 'shape_id': row['shape_id'],
                 'sequence': int(row['shape_pt_sequence']),
                 'lat': float(row['shape_pt_lat']),
@@ -29,18 +28,23 @@ class PointRepository:
         '''Returns all points that match the given context and shape'''
         return self.database.select(
             table='point',
-            columns=[
-                'agency_id',
-                'system_id',
-                'shape_id',
-                'sequence',
-                'lat',
-                'lon'
-            ],
+            columns={
+                'download.agency_id': 'agency_id',
+                'download.system_id': 'system_id',
+                'point.shape_id': 'shape_id',
+                'point.sequence': 'sequence',
+                'point.lat': 'lat',
+                'point.lon': 'lon'
+            },
+            joins={
+                'download': {
+                    'download.download_id': 'point.download_id'
+                }
+            },
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
-                'shape_id': shape_id
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id,
+                'point.shape_id': shape_id
             },
             order_by='point.sequence ASC',
             initializer=Point.from_db
@@ -48,10 +52,30 @@ class PointRepository:
     
     def delete_all(self, context: Context):
         '''Deletes all points for the given context from the database'''
+        download_ids = self.database.select(
+            table='point',
+            columns={
+                'point.download_id': 'download_id'
+            },
+            distinct=True,
+            joins={
+                'download': {
+                    'download.download_id': 'point.download_id'
+                }
+            },
+            filters={
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id
+            },
+            initializer=lambda r: r['download_id']
+        )
+        if not download_ids:
+            return
+        if len(download_ids) == 1:
+            download_ids = download_ids[0]
         self.database.delete(
             table='point',
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id
+                'download_id': download_ids
             }
         )

--- a/repositories/impl/route.py
+++ b/repositories/impl/route.py
@@ -12,7 +12,7 @@ class RouteRepository:
     
     database: Database
     
-    def create(self, context: Context, row: dict):
+    def create(self, download_id: int, context: Context, row: dict):
         '''Inserts a new route into the database'''
         try:
             colour = row['route_color']
@@ -46,8 +46,7 @@ class RouteRepository:
         self.database.insert(
             table='route',
             values={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
+                'download_id': download_id,
                 'route_id': route_id,
                 'number': number,
                 'name': row['route_long_name'],
@@ -62,22 +61,27 @@ class RouteRepository:
         '''Returns the route with the given context and route ID'''
         routes = self.database.select(
             table='route',
-            columns=[
-                'agency_id',
-                'system_id',
-                'route_id',
-                'number',
-                'name',
-                'colour',
-                'text_colour',
-                'type',
-                'sort_order'
-            ],
+            columns={
+                'download.agency_id': 'agency_id',
+                'download.system_id': 'system_id',
+                'route.route_id': 'route_id',
+                'route.number': 'number',
+                'route.name': 'name',
+                'route.colour': 'colour',
+                'route.text_colour': 'text_colour',
+                'route.type': 'type',
+                'route.sort_order': 'sort_order'
+            },
+            joins={
+                'download': {
+                    'download.download_id': 'route.download_id'
+                }
+            },
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
-                'route_id': route_id,
-                'number': number
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id,
+                'route.route_id': route_id,
+                'route.number': number
             },
             limit=1,
             initializer=Route.from_db
@@ -91,21 +95,26 @@ class RouteRepository:
         '''Returns all routes that match the given context'''
         return self.database.select(
             table='route',
-            columns=[
-                'agency_id',
-                'system_id',
-                'route_id',
-                'number',
-                'name',
-                'colour',
-                'text_colour',
-                'type',
-                'sort_order'
-            ],
+            columns={
+                'download.agency_id': 'agency_id',
+                'download.system_id': 'system_id',
+                'route.route_id': 'route_id',
+                'route.number': 'number',
+                'route.name': 'name',
+                'route.colour': 'colour',
+                'route.text_colour': 'text_colour',
+                'route.type': 'type',
+                'route.sort_order': 'sort_order'
+            },
+            joins={
+                'download': {
+                    'download.download_id': 'route.download_id'
+                }
+            },
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
-                'number': route_number
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id,
+                'route.number': route_number
             },
             limit=limit,
             initializer=Route.from_db
@@ -114,25 +123,30 @@ class RouteRepository:
     def find_matches(self, context: Context, query: str) -> list[Match]:
         routes = self.database.select(
             table='route',
-            columns=[
-                'agency_id',
-                'system_id',
-                'route_id',
-                'number',
-                'name',
-                'colour',
-                'text_colour',
-                'type',
-                'sort_order'
-            ],
+            columns={
+                'download.agency_id': 'agency_id',
+                'download.system_id': 'system_id',
+                'route.route_id': 'route_id',
+                'route.number': 'number',
+                'route.name': 'name',
+                'route.colour': 'colour',
+                'route.text_colour': 'text_colour',
+                'route.type': 'type',
+                'route.sort_order': 'sort_order'
+            },
+            joins={
+                'download': {
+                    'download.download_id': 'route.download_id'
+                }
+            },
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id,
                 'OR': {
-                    'number': {
+                    'route.number': {
                         'LIKE': f'%{query}%'
                     },
-                    'name': {
+                    'route.name': {
                         'LIKE': f'%{query}%'
                     }
                 }
@@ -143,10 +157,30 @@ class RouteRepository:
     
     def delete_all(self, context: Context):
         '''Deletes all routes for the given context from the database'''
+        download_ids = self.database.select(
+            table='route',
+            columns={
+                'route.download_id': 'download_id'
+            },
+            distinct=True,
+            joins={
+                'download': {
+                    'download.download_id': 'route.download_id'
+                }
+            },
+            filters={
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id
+            },
+            initializer=lambda r: r['download_id']
+        )
+        if not download_ids:
+            return
+        if len(download_ids) == 1:
+            download_ids = download_ids[0]
         self.database.delete(
             table='route',
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id
+                'download_id': download_ids
             }
         )

--- a/repositories/impl/stop.py
+++ b/repositories/impl/stop.py
@@ -13,7 +13,7 @@ class StopRepository:
     
     database: Database
     
-    def create(self, context: Context, row):
+    def create(self, download_id: int, context: Context, row):
         '''Inserts a new stop into the database'''
         stop_id = row['stop_id']
         number = row['stop_code']
@@ -22,8 +22,7 @@ class StopRepository:
         self.database.insert(
             table='stop',
             values={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
+                'download_id': download_id,
                 'stop_id': stop_id,
                 'number': number,
                 'name': row['stop_name'],
@@ -38,22 +37,27 @@ class StopRepository:
         '''Returns the stop with the given context and stop ID'''
         stops = self.database.select(
             table='stop',
-            columns=[
-                'agency_id',
-                'system_id',
-                'stop_id',
-                'number',
-                'name',
-                'lat',
-                'lon',
-                'parent_id',
-                'type'
-            ],
+            columns={
+                'download.agency_id': 'agency_id',
+                'download.system_id': 'system_id',
+                'stop.stop_id': 'stop_id',
+                'stop.number': 'number',
+                'stop.name': 'name',
+                'stop.lat': 'lat',
+                'stop.lon': 'lon',
+                'stop.parent_id': 'parent_id',
+                'stop.type': 'type'
+            },
+            joins={
+                'download': {
+                    'download.download_id': 'stop.download_id'
+                }
+            },
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
-                'stop_id': stop_id,
-                'number': number
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id,
+                'stop.stop_id': stop_id,
+                'stop.number': number
             },
             limit=1,
             initializer=Stop.from_db
@@ -66,34 +70,39 @@ class StopRepository:
     def find_all(self, context: Context, stop_number: str | None = None, limit: int | None = None, lat: float | None = None, lon: float | None = None, size: float = 0.01, parent_id: str | None = None, type: StopType | None = None) -> list[Stop]:
         '''Returns all stops that match the given context'''
         filters = {
-            'agency_id': context.agency_id,
-            'system_id': context.system_id,
-            'number': stop_number,
-            'parent_id': parent_id,
-            'type': type.value if type else None
+            'download.agency_id': context.agency_id,
+            'download.system_id': context.system_id,
+            'stop.number': stop_number,
+            'stop.parent_id': parent_id,
+            'stop.type': type.value if type else None
         }
         if (lat is not None and lon is not None):
-            filters['lat'] = {
+            filters['stop.lat'] = {
                 '>=': lat,
                 '<=': lat + size
             }
-            filters['lon'] = {
+            filters['stop.lon'] = {
                 '>=': lon,
                 '<=': lon + size
             }
         return self.database.select(
             table='stop',
-            columns=[
-                'agency_id',
-                'system_id',
-                'stop_id',
-                'number',
-                'name',
-                'lat',
-                'lon',
-                'parent_id',
-                'type'
-            ],
+            columns={
+                'download.agency_id': 'agency_id',
+                'download.system_id': 'system_id',
+                'stop.stop_id': 'stop_id',
+                'stop.number': 'number',
+                'stop.name': 'name',
+                'stop.lat': 'lat',
+                'stop.lon': 'lon',
+                'stop.parent_id': 'parent_id',
+                'stop.type': 'type'
+            },
+            joins={
+                'download': {
+                    'download.download_id': 'stop.download_id'
+                }
+            },
             filters=filters,
             limit=limit,
             initializer=Stop.from_db
@@ -102,25 +111,30 @@ class StopRepository:
     def find_matches(self, context: Context, query: str) -> list[Match]:
         stops = self.database.select(
             table='stop',
-            columns=[
-                'agency_id',
-                'system_id',
-                'stop_id',
-                'number',
-                'name',
-                'lat',
-                'lon',
-                'parent_id',
-                'type'
-            ],
+            columns={
+                'download.agency_id': 'agency_id',
+                'download.system_id': 'system_id',
+                'stop.stop_id': 'stop_id',
+                'stop.number': 'number',
+                'stop.name': 'name',
+                'stop.lat': 'lat',
+                'stop.lon': 'lon',
+                'stop.parent_id': 'parent_id',
+                'stop.type': 'type'
+            },
+            joins={
+                'download': {
+                    'download.download_id': 'stop.download_id'
+                }
+            },
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id,
                 'OR': {
-                    'number': {
+                    'stop.number': {
                         'LIKE': f'%{query}%'
                     },
-                    'name': {
+                    'stop.name': {
                         'LIKE': f'%{query}%'
                     }
                 }
@@ -134,18 +148,23 @@ class StopRepository:
         areas = self.database.select(
             table='stop',
             columns={
-                'MIN(lat)': 'min_lat',
-                'MAX(lat)': 'max_lat',
-                'MIN(lon)': 'min_lon',
-                'MAX(lon)': 'max_lon'
+                'MIN(stop.lat)': 'min_lat',
+                'MAX(stop.lat)': 'max_lat',
+                'MIN(stop.lon)': 'min_lon',
+                'MAX(stop.lon)': 'max_lon'
+            },
+            joins={
+                'download': {
+                    'download.download_id': 'stop.download_id'
+                }
             },
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
-                'lat': {
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id,
+                'stop.lat': {
                     '!=': 0
                 },
-                'lon': {
+                'stop.lon': {
                     '!=': 0
                 }
             },
@@ -158,10 +177,30 @@ class StopRepository:
     
     def delete_all(self, context: Context):
         '''Deletes all stops for the given context from the database'''
+        download_ids = self.database.select(
+            table='stop',
+            columns={
+                'stop.download_id': 'download_id'
+            },
+            distinct=True,
+            joins={
+                'download': {
+                    'download.download_id': 'stop.download_id'
+                }
+            },
+            filters={
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id
+            },
+            initializer=lambda r: r['download_id']
+        )
+        if not download_ids:
+            return
+        if len(download_ids) == 1:
+            download_ids = download_ids[0]
         self.database.delete(
             table='stop',
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id
+                'download_id': download_ids
             }
         )

--- a/repositories/impl/trip.py
+++ b/repositories/impl/trip.py
@@ -12,15 +12,14 @@ class TripRepository:
     
     database: Database
     
-    def create(self, context: Context, row: dict):
+    def create(self, download_id: int, context: Context, row: dict):
         '''Inserts a new trip into the database'''
         if not row:
             return
         self.database.insert(
             table='trip',
             values={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
+                'download_id': download_id,
                 'trip_id': row['trip_id'],
                 'route_id': row['route_id'],
                 'service_id': row['service_id'],
@@ -35,21 +34,26 @@ class TripRepository:
         '''Returns the trip with the given context and trip ID'''
         trips = self.database.select(
             table='trip',
-            columns=[
-                'agency_id',
-                'system_id',
-                'trip_id',
-                'route_id',
-                'service_id',
-                'block_id',
-                'direction_id',
-                'shape_id',
-                'headsign'
-            ],
+            columns={
+                'download.agency_id': 'agency_id',
+                'download.system_id': 'system_id',
+                'trip_id': 'trip_id',
+                'route_id': 'route_id',
+                'service_id': 'service_id',
+                'block_id': 'block_id',
+                'direction_id': 'direction_id',
+                'shape_id': 'shape_id',
+                'headsign': 'headsign'
+            },
+            joins={
+                'download': {
+                    'download.download_id': 'trip.download_id'
+                }
+            },
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
-                'trip_id': trip_id
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id,
+                'trip.trip_id': trip_id
             },
             limit=1,
             initializer=Trip.from_db
@@ -63,23 +67,28 @@ class TripRepository:
         '''Returns all trips that match the given context, route, and block'''
         return self.database.select(
             table='trip',
-            columns=[
-                'agency_id',
-                'system_id',
-                'trip_id',
-                'route_id',
-                'service_id',
-                'block_id',
-                'direction_id',
-                'shape_id',
-                'headsign'
-            ],
+            columns={
+                'download.agency_id': 'agency_id',
+                'download.system_id': 'system_id',
+                'trip_id': 'trip_id',
+                'route_id': 'route_id',
+                'service_id': 'service_id',
+                'block_id': 'block_id',
+                'direction_id': 'direction_id',
+                'shape_id': 'shape_id',
+                'headsign': 'headsign'
+            },
+            joins={
+                'download': {
+                    'download.download_id': 'trip.download_id'
+                }
+            },
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
-                'trip_id': trip_id,
-                'route_id': route_id,
-                'block_id': block_id
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id,
+                'trip.trip_id': trip_id,
+                'trip.route_id': route_id,
+                'trip.block_id': block_id
             },
             limit=limit,
             initializer=Trip.from_db
@@ -88,16 +97,21 @@ class TripRepository:
     def find_block_matches(self, context: Context, query: str) -> list[Match]:
         rows = self.database.select(
             table='trip',
-            columns=[
-                'agency_id',
-                'system_id',
-                'block_id'
-            ],
+            columns={
+                'download.agency_id': 'agency_id',
+                'download.system_id': 'system_id',
+                'trip.block_id': 'block_id'
+            },
             distinct=True,
+            joins={
+                'download': {
+                    'download.download_id': 'trip.download_id'
+                }
+            },
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id,
-                'block_id': {
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id,
+                'trip.block_id': {
                     'LIKE': f'%{query}%'
                 }
             }
@@ -113,10 +127,30 @@ class TripRepository:
     
     def delete_all(self, context: Context):
         '''Deletes all trips for the given context from the database'''
+        download_ids = self.database.select(
+            table='trip',
+            columns={
+                'trip.download_id': 'download_id'
+            },
+            distinct=True,
+            joins={
+                'download': {
+                    'download.download_id': 'trip.download_id'
+                }
+            },
+            filters={
+                'download.agency_id': context.agency_id,
+                'download.system_id': context.system_id
+            },
+            initializer=lambda r: r['download_id']
+        )
+        if not download_ids:
+            return
+        if len(download_ids) == 1:
+            download_ids = download_ids[0]
         self.database.delete(
             table='trip',
             filters={
-                'agency_id': context.agency_id,
-                'system_id': context.system_id
+                'download_id': download_ids
             }
         )

--- a/server.py
+++ b/server.py
@@ -9,6 +9,7 @@ from database import Database
 
 from models.context import Context
 from models.date import Date
+from models.download import DownloadTrigger
 from models.event import Event
 from models.favourite import Favourite, FavouriteSet
 from models.log import LogLevel
@@ -146,9 +147,9 @@ class Server(Bottle):
             context = system.context
             if self.running:
                 try:
-                    services.gtfs.load(context, args.reload, args.updatedb)
+                    services.gtfs.load(context, DownloadTrigger.LAUNCH_FLAG, args.reload, args.updatedb)
                     if not services.gtfs.validate(context):
-                        services.gtfs.load(context, system.enable_force_gtfs)
+                        services.gtfs.load(context, DownloadTrigger.NEAR_END_DATE, system.enable_force_gtfs)
                     services.realtime.update(context)
                 except Exception as e:
                     services.log.error(f'Error loading data for {context}: {e}')
@@ -1809,9 +1810,9 @@ class Server(Bottle):
             context = system.context
             if self.running:
                 try:
-                    services.gtfs.load(context)
+                    services.gtfs.load(context, DownloadTrigger.ADMIN)
                     if not services.gtfs.validate(context):
-                        services.gtfs.load(context, system.enable_force_gtfs)
+                        services.gtfs.load(context, DownloadTrigger.NEAR_END_DATE, system.enable_force_gtfs)
                     services.realtime.update(context)
                 except Exception as e:
                     services.log.error(f'Error loading data for {context}: {e}')
@@ -1851,7 +1852,7 @@ class Server(Bottle):
             return 'Invalid system'
         context = system.context
         try:
-            services.gtfs.load(context, True)
+            services.gtfs.load(context, DownloadTrigger.ADMIN, True)
             services.realtime.update(context)
             services.realtime.update_records()
             if not system.gtfs_downloaded or not services.realtime.validate(context):

--- a/services/impl/cron.py
+++ b/services/impl/cron.py
@@ -7,6 +7,7 @@ from crontab import CronTab
 from database import Database
 
 from models.date import Date
+from models.download import DownloadTrigger
 from models.time import Time
 from models.weekday import Weekday
 
@@ -53,7 +54,11 @@ class CronService:
             if self.running:
                 try:
                     if context.today.weekday == Weekday.MON or not services.gtfs.validate(context):
-                        services.gtfs.load(context, system.enable_force_gtfs)
+                        if context.today.weekday == Weekday.MON:
+                            trigger = DownloadTrigger.WEEKLY
+                        else:
+                            trigger = DownloadTrigger.NEAR_END_DATE
+                        services.gtfs.load(context, trigger, system.enable_force_gtfs)
                 except Exception as e:
                     services.log.error(f'Error loading GTFS data for {context}: {e}')
         if self.running:
@@ -75,7 +80,7 @@ class CronService:
                 try:
                     if system.reload_backoff.check():
                         system.reload_backoff.increase_target()
-                        services.gtfs.load(context, system.enable_force_gtfs)
+                        services.gtfs.load(context, DownloadTrigger.INVALID_POSITIONS, system.enable_force_gtfs)
                     services.realtime.update(context)
                 except Exception as e:
                     services.log.error(f'Error loading data for {context}: {e}')

--- a/services/impl/gtfs.py
+++ b/services/impl/gtfs.py
@@ -14,8 +14,10 @@ from models.block import Block
 from models.context import Context
 from models.date import Date
 from models.daterange import DateRange
+from models.download import DownloadTrigger
 from models.service import Service, ServiceException
 from models.sheet import Sheet
+from models.time import Time
 
 import repositories
 import services
@@ -26,12 +28,14 @@ class GTFSService:
     
     database: Database
     
-    def load(self, context: Context, force_download=False, update_db=False):
+    def load(self, context: Context, trigger: DownloadTrigger, force_download=False, update_db=False):
         '''Loads the GTFS for the given context into memory'''
         if not context.system.gtfs_enabled:
             return
         
         context.system.gtfs_downloaded = path.exists(f'data/gtfs/{context.system_id}')
+        if not context.system.gtfs_downloaded:
+            trigger = DownloadTrigger.MISSING
         if not context.system.gtfs_downloaded or force_download:
             self.download(context)
             update_db = True
@@ -66,7 +70,7 @@ class GTFSService:
             filter_service_ids = set()
         
         if update_db:
-            self.update_database(context, filter_service_ids)
+            self.update_database(context, trigger, filter_service_ids)
         
         services.log.info(f'Loading GTFS data for {context}')
         
@@ -118,7 +122,7 @@ class GTFSService:
             zip.extractall(data_path)
         context.system.gtfs_downloaded = True
     
-    def update_database(self, context: Context, filter_service_ids: set[str]):
+    def update_database(self, context: Context, trigger: DownloadTrigger, filter_service_ids: set[str]):
         '''Updates cached GTFS data for the given system'''
         services.log.info(f'Updating database with GTFS data for {context}')
         
@@ -128,16 +132,21 @@ class GTFSService:
         repositories.route.delete_all(context)
         repositories.point.delete_all(context)
         
-        apply_csv(context, 'routes', repositories.route.create)
-        apply_csv(context, 'stops', repositories.stop.create)
+        date = Date.today()
+        time = Time.now()
+        
+        download_id = repositories.download.create(context, date, time, trigger)
+        
+        apply_csv(download_id, context, 'routes', repositories.route.create)
+        apply_csv(download_id, context, 'stops', repositories.stop.create)
         if filter_service_ids:
-            filtered_rows = apply_csv(context, 'trips', repositories.trip.create, filter=lambda r: r['service_id'] in filter_service_ids)
+            filtered_rows = apply_csv(download_id, context, 'trips', repositories.trip.create, filter=lambda r: r['service_id'] in filter_service_ids)
             filtered_trip_ids = {r['trip_id'] for r in filtered_rows}
-            apply_csv(context, 'stop_times', repositories.departure.create, filter=lambda r: r['trip_id'] in filtered_trip_ids)
+            apply_csv(download_id, context, 'stop_times', repositories.departure.create, filter=lambda r: r['trip_id'] in filtered_trip_ids)
         else:
-            apply_csv(context, 'trips', repositories.trip.create)
-            apply_csv(context, 'stop_times', repositories.departure.create)
-        apply_csv(context, 'shapes', repositories.point.create)
+            apply_csv(download_id, context, 'trips', repositories.trip.create)
+            apply_csv(download_id, context, 'stop_times', repositories.departure.create)
+        apply_csv(download_id, context, 'shapes', repositories.point.create)
         
         self.database.commit()
     
@@ -159,7 +168,7 @@ def read_csv(context: Context, name, initializer):
         columns = next(reader)
         return [initializer(dict(zip(columns, row))) for row in reader]
 
-def apply_csv(context: Context, name, function, filter=None):
+def apply_csv(download_id: int, context: Context, name, function, filter=None):
     '''Opens a CSV file and applies a function to each row'''
     with open(f'./data/gtfs/{context.system_id}/{name}.txt', 'r', encoding='utf-8-sig') as file:
         reader = csv.reader(file)
@@ -168,7 +177,7 @@ def apply_csv(context: Context, name, function, filter=None):
         for row in reader:
             data = dict(zip(columns, row))
             if not filter or filter(data):
-                function(context, data)
+                function(download_id, context, data)
                 if filter:
                     filtered_rows.append(data)
         return filtered_rows

--- a/start.py
+++ b/start.py
@@ -32,6 +32,7 @@ if __name__ == '__main__':
     repositories.allocation = AllocationRepository(database)
     repositories.assignment = AssignmentRepository(database)
     repositories.departure = DepartureRepository(database)
+    repositories.download = DownloadRepository(database)
     repositories.point = PointRepository(database)
     repositories.position = PositionRepository(database)
     repositories.record = RecordRepository(database)

--- a/utilities/drop-gtfs-tables.py
+++ b/utilities/drop-gtfs-tables.py
@@ -15,6 +15,7 @@ database.execute("DROP TABLE departure")
 database.execute("DROP TABLE trip")
 database.execute("DROP TABLE stop")
 database.execute("DROP TABLE route")
+database.execute("VACUUM")
 
 database.commit()
 database.disconnect()


### PR DESCRIPTION
New rows are added to the download table whenever we update the GTFS. The other GTFS tables (departure, point, route, stop, and trip) now refer to the associated download instead of the agency/system IDs directly. This matches the changes we made to realtime a while ago, in which records are associated with an allocation instead of agency/system/vehicle. Overall we should see less data usage and better performance since the agency and system IDs are no longer duplicated across hundreds of thousands of rows (and this should hopefully fix the daily website status warnings from the discord bot). There is a slight tradeoff that all selects now need to join on to the download table in order to fetch/filter by agency and system, but overall I think it's worth the extra hassle. There's also slightly more complicated behaviour for deleting rows since we can't directly join in a delete statement - instead I now have a fetch for the download ID(s) that need to be deleted, and filter based on that. (Note that the download rows themselves are not deleted so we can keep info about the downloads - see next paragraph)

Along with the agency and system IDs, the download table also tracks some metadata about the download - the date, time, and trigger. Triggers include stuff like the weekly download, forced updates from the launch flags or admin panel, and auto updates from either approaching the end of the GTFS service span, or too many vehicles with invalid positions. Currently this metadata isn't exposed anywhere, but in the future we can potentially update the admin page to be able to view this stuff and see trends/insights into download frequencies and reasons.

**NOTE:** When deploying, we'll need to run the existing migration to drop all GTFS tables again. As usual, since these tables are ephemeral and can simply be repopulated from the ZIPs, there is no issue with doing this.