### PR TITLE
Fix query to delete stale trip records

### DIFF
--- a/repositories/impl/record.py
+++ b/repositories/impl/record.py
@@ -197,12 +197,9 @@ class RecordRepository:
                 FROM trip_record
                 JOIN record ON record.record_id = trip_record.record_id
                 JOIN allocation ON allocation.allocation_id = record.allocation_id
+                LEFT JOIN trip ON trip.trip_id = trip_record.trip_id
+                LEFT JOIN download ON download.download_id = trip.download_id AND download.agency_id = allocation.agency_id AND download.system_id = allocation.system_id
                 WHERE record.date < ?
-                AND NOT EXISTS (
-                    SELECT 1
-                    FROM trip
-                    WHERE trip.trip_id = trip_record.trip_id
-                        AND trip.system_id = allocation.system_id
-                )
+                    AND download.download_id IS NULL;
             )
         ''', [date.format_db()])


### PR DESCRIPTION
Issue 1: Query referenced `trip.system_id` which has been removed, causing the script to error out (trickle down causing backups to not run)

Issue 2: Query was pretty inefficient with the nested `SELECT` getting run for every result (potentially many thousands)

I've rewritten part of the query to address these issues; it will now attempt to `LEFT JOIN` the trip and download tables based on the record's trip ID. The records will be marked for deletion if the download doesn't exist, which may happen either because the trip ID isn't in the trip table, or the download agency/system don't match the vehicle's allocation (which catches cases where the same trip ID is used across multiple systems/agencies). Overall much more efficient and gives us the same result.

Note: The existing `<` on the date comparison will ensure that deletions that were missed because of the error will be properly removed next time the script runs