### PR TITLE
Support for blockless records

### DIFF
--- a/models/record.py
+++ b/models/record.py
@@ -29,14 +29,16 @@ class Record:
     def from_db(cls, row: Row):
         '''Returns a record initialized from the given database row'''
         id = row['id']
+        if id is None:
+            raise ValueError()
         allocation_id = row['allocation_id']
         context = row.context()
         vehicle = context.find_vehicle(row['vehicle_id'])
         date = Date.parse(row['date'], context.timezone)
         block_id = row['block_id']
-        if 'route_numbers' in row:
+        try:
             route_numbers = [n.strip() for n in row['route_numbers'].split(',')]
-        else:
+        except:
             route_numbers = []
         start_time = Time.parse(row['start_time'], context.timezone, context.accurate_seconds)
         end_time = Time.parse(row['end_time'], context.timezone, context.accurate_seconds)
@@ -66,7 +68,7 @@ class Record:
     @property
     def is_available(self):
         '''Checks if this record has an associated block'''
-        return self.block is not None
+        return self.block_id is None or self.block is not None
     
     @property
     def routes(self):

--- a/models/trip.py
+++ b/models/trip.py
@@ -26,8 +26,8 @@ class Trip:
     id: str
     route_id: str
     service_id: str
-    block_id: str
-    direction_id: int
+    block_id: str | None
+    direction_id: int | None
     shape_id: str
     headsign: str
     
@@ -72,7 +72,9 @@ class Trip:
     @property
     def block(self):
         '''Returns the block associated with this trip'''
-        return self.system.get_block(self.block_id)
+        if self.block_id:
+            return self.system.get_block(self.block_id)
+        return None
     
     @property
     def service(self):

--- a/repositories/impl/record.py
+++ b/repositories/impl/record.py
@@ -9,6 +9,7 @@ from models.context import Context
 from models.date import Date
 from models.record import Record
 from models.time import Time
+from models.trip import Trip
 from models.vehicle import Vehicle
 
 @dataclass(slots=True)
@@ -34,6 +35,23 @@ class RecordRepository:
         self.create_trip(record_id, trip_id)
         return record_id
     
+    def create_from_trip(self, allocation_id: int, date: Date, trip: Trip, time: Time):
+        '''Inserts a new record into the database based on a single trip'''
+        record_id = self.database.insert(
+            table='record',
+            values={
+                'allocation_id': allocation_id,
+                'date': date.format_db(),
+                'route_numbers': trip.route.number if trip.route else None,
+                'start_time': trip.start_time.format_db(),
+                'end_time': trip.end_time.format_db(),
+                'first_seen': time.format_db(),
+                'last_seen': time.format_db()
+            }
+        )
+        self.create_trip(record_id, trip.id)
+        return record_id
+    
     def create_trip(self, record_id: int, trip_id: str):
         '''Inserts a new trip record into the database'''
         self.database.insert(
@@ -56,6 +74,30 @@ class RecordRepository:
             }
         )
     
+    def merge(self, record: Record, trip: Trip, time: Time):
+        '''Updates a non-block record based on a trip'''
+        route_numbers = record.route_numbers
+        if trip.route and trip.route.number not in route_numbers:
+            route_numbers.append(trip.route.number)
+        start_time = record.start_time
+        if not trip.start_time.is_unknown and (start_time.is_unknown or trip.start_time < start_time):
+            start_time = trip.start_time
+        end_time = record.end_time
+        if not trip.end_time.is_unknown and (end_time.is_unknown or trip.end_time > end_time):
+            end_time = trip.end_time
+        self.database.update(
+            table='record',
+            values={
+                'route_numbers': ', '.join(route_numbers),
+                'start_time': start_time.format_db(),
+                'end_time': end_time.format_db(),
+                'last_seen': time.format_db()
+            },
+            filters={
+                'record_id': record.id
+            }
+        )
+    
     def find_all(self, context: Context, vehicle_id: str | None = None, block_id: str | None = None, trip_id: str | None = None, limit: int | None = None, page: int | None = None) -> list[Record]:
         '''Returns all records that match the given context, vehicle, block, and trip'''
         joins = {
@@ -75,7 +117,7 @@ class RecordRepository:
             }
             filters['trip_record.trip_id'] = trip_id
         return self.database.select(
-            table='record', 
+            table='record',
             columns={
                 'allocation.agency_id': 'agency_id',
                 'allocation.vehicle_id': 'vehicle_id',

--- a/repositories/impl/trip.py
+++ b/repositories/impl/trip.py
@@ -16,6 +16,10 @@ class TripRepository:
         '''Inserts a new trip into the database'''
         if not row:
             return
+        try:
+            direction_id = int(row['direction_id'])
+        except:
+            direction_id = None
         self.database.insert(
             table='trip',
             values={
@@ -23,8 +27,8 @@ class TripRepository:
                 'trip_id': row['trip_id'],
                 'route_id': row['route_id'],
                 'service_id': row['service_id'],
-                'block_id': row['block_id'],
-                'direction_id': int(row['direction_id']),
+                'block_id': row.get('block_id'),
+                'direction_id': direction_id,
                 'shape_id': row['shape_id'],
                 'headsign': row['trip_headsign']
             }

--- a/services/impl/gtfs.py
+++ b/services/impl/gtfs.py
@@ -84,15 +84,15 @@ class GTFSService:
         trips = repositories.trip.find_all(context)
         context.system.trips = {t.id: t for t in trips}
         
-        block_trips = {}
-        for trip in trips:
-            block_trips.setdefault(trip.block_id, []).append(trip)
-        
         routes = repositories.route.find_all(context)
         context.system.routes = {r.id: r for r in routes}
         context.system.routes_by_number = {r.number: r for r in routes}
         
-        context.system.blocks = {id: Block(context.agency, context.system, id, trips) for id, trips in block_trips.items()}
+        if context.enable_blocks:
+            block_trips = {}
+            for trip in trips:
+                block_trips.setdefault(trip.block_id, []).append(trip)
+            context.system.blocks = {id: Block(context.agency, context.system, id, trips) for id, trips in block_trips.items()}
         
         context.system.gtfs_loaded = True
         context.system.reset_caches()

--- a/services/impl/realtime.py
+++ b/services/impl/realtime.py
@@ -105,21 +105,39 @@ class RealtimeService:
                     first_record = None
                     last_record = None
                 
-                if position.trip and position.block_id and position.block:
-                    assignment = repositories.assignment.find(position.block_id, allocation_id, date)
-                    if not assignment or assignment.allocation_id != allocation_id:
-                        repositories.assignment.delete_all(block_id=position.block_id)
-                        repositories.assignment.delete_all(allocation_id=allocation_id)
-                        repositories.assignment.create(position.block_id, allocation_id, date)
-                    
-                    if last_record and last_record.date == date and last_record.block_id == position.block_id:
+                if context.enable_blocks:
+                    if position.trip and position.block_id and position.block:
+                        assignment = repositories.assignment.find(position.block_id, allocation_id, date)
+                        if not assignment or assignment.allocation_id != allocation_id:
+                            repositories.assignment.delete_all(block_id=position.block_id)
+                            repositories.assignment.delete_all(allocation_id=allocation_id)
+                            repositories.assignment.create(position.block_id, allocation_id, date)
+                        
+                        if last_record and last_record.date == date and last_record.block_id == position.block_id:
+                            record_id = last_record.id
+                            repositories.record.update(last_record.id, time)
+                            trip_ids = repositories.record.find_trip_ids(last_record.id)
+                            if position.trip_id not in trip_ids:
+                                repositories.record.create_trip(last_record.id, position.trip_id)
+                        else:
+                            record_id = repositories.record.create(allocation_id, date, position.block, time, position.trip_id)
+                        
+                        if not first_record:
+                            repositories.allocation.set_first_record(allocation_id, record_id)
+                        if not last_record or last_record.id != record_id:
+                            repositories.allocation.set_last_record(allocation_id, record_id)
+                elif position.trip:
+                    trip = position.trip
+                    if last_record and last_record.date == date:
                         record_id = last_record.id
-                        repositories.record.update(last_record.id, time)
                         trip_ids = repositories.record.find_trip_ids(last_record.id)
-                        if position.trip_id not in trip_ids:
+                        if position.trip_id in trip_ids:
+                            repositories.record.update(last_record.id, time)
+                        else:
+                            repositories.record.merge(last_record, trip, time)
                             repositories.record.create_trip(last_record.id, position.trip_id)
                     else:
-                        record_id = repositories.record.create(allocation_id, date, position.block, time, position.trip_id)
+                        record_id = repositories.record.create_from_trip(allocation_id, date, trip, time)
                     
                     if not first_record:
                         repositories.allocation.set_first_record(allocation_id, record_id)

--- a/views/components/realtime_row.tpl
+++ b/views/components/realtime_row.tpl
@@ -22,7 +22,6 @@
         <td class="desktop-only">{{ position.context }}</td>
     % end
     % if trip:
-        % block = trip.block
         <td>
             <div class="column">
                 % include('components/headsign', departure=position.departure)
@@ -39,6 +38,7 @@
             </div>
         </td>
         % if enable_blocks:
+            % block = trip.block
             <td class="non-mobile">
                 % if block:
                     <a href="{{ block.url() }}">{{ block.id }}</a>
@@ -49,7 +49,7 @@
             % include('components/trip')
         </td>
     % else:
-        <td colspan="3">
+        <td colspan="{{ '3' if enable_blocks else '2' }}">
             <div class="column">
                 <div class="lighter-text">Not In Service</div>
                 % if stop:

--- a/views/components/route_list.tpl
+++ b/views/components/route_list.tpl
@@ -1,5 +1,5 @@
 <div class="route-list">
-    % for route in routes:
+    % for route in sorted([r for r in routes if r]):
         % include('components/route', include_link=True, include_tooltip=True, compact=True)
     % end
 </div>

--- a/views/pages/history/first_seen.tpl
+++ b/views/pages/history/first_seen.tpl
@@ -113,15 +113,17 @@
                                         % if record:
                                             <td>
                                                 <div class="column stretch">
-                                                    <div class="row space-between">
-                                                        % if record.is_available:
-                                                            % block = record.block
-                                                            <a href="{{ block.url() }}">{{ block.id }}</a>
-                                                        % else:
-                                                            <span>{{ record.block_id }}</span>
-                                                        % end
-                                                        % include('components/record_warnings')
-                                                    </div>
+                                                    % if record.block_id:
+                                                        <div class="row space-between">
+                                                            % if record.is_available:
+                                                                % block = record.block
+                                                                <a href="{{ block.url() }}">{{ block.id }}</a>
+                                                            % else:
+                                                                <span>{{ record.block_id }}</span>
+                                                            % end
+                                                            % include('components/record_warnings')
+                                                        </div>
+                                                    % end
                                                     <div class="non-desktop">
                                                         % include('components/route_list', routes=record.routes)
                                                     </div>

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -291,15 +291,17 @@
                                                     % if record:
                                                         <td>
                                                             <div class="column stretch">
-                                                                <div class="row space-between">
-                                                                    % if record.is_available:
-                                                                        % block = record.block
-                                                                        <a href="{{ block.url() }}">{{ block.id }}</a>
-                                                                    % else:
-                                                                        <span>{{ record.block_id }}</span>
-                                                                    % end
-                                                                    % include('components/record_warnings')
-                                                                </div>
+                                                                % if record.block_id:
+                                                                    <div class="row space-between">
+                                                                        % if record.is_available:
+                                                                            % block = record.block
+                                                                            <a href="{{ block.url() }}">{{ block.id }}</a>
+                                                                        % else:
+                                                                            <span>{{ record.block_id }}</span>
+                                                                        % end
+                                                                        % include('components/record_warnings')
+                                                                    </div>
+                                                                % end
                                                                 <div class="non-desktop">
                                                                     % include('components/route_list', routes=record.routes)
                                                                 </div>

--- a/views/pages/realtime/routes.tpl
+++ b/views/pages/realtime/routes.tpl
@@ -95,7 +95,6 @@
                                         % include('components/year_model', year_model=vehicle.year_model)
                                     </td>
                                     % trip = position.trip
-                                    % block = trip.block
                                     % stop = position.stop
                                     <td>
                                         <div class="column">
@@ -113,8 +112,11 @@
                                         </div>
                                     </td>
                                     % if route.context.enable_blocks:
+                                        % block = trip.block
                                         <td class="non-mobile">
-                                            <a href="{{ block.url() }}">{{ block.id }}</a>
+                                            % if block:
+                                                <a href="{{ block.url() }}">{{ block.id }}</a>
+                                            % end
                                         </td>
                                     % end
                                     <td class="non-mobile">

--- a/views/pages/realtime/speed.tpl
+++ b/views/pages/realtime/speed.tpl
@@ -71,7 +71,6 @@
                         % end
                         <td class="desktop-only no-wrap">{{ position.speed }} km/h</td>
                         % if trip:
-                            % block = trip.block
                             <td>
                                 <div class="column">
                                     % include('components/headsign', departure=position.departure)
@@ -89,6 +88,7 @@
                                 </div>
                             </td>
                             % if context.enable_blocks:
+                                % block = trip.block
                                 <td class="non-mobile">
                                     % if block:
                                         <a href="{{ block.url() }}">{{ block.id }}</a>
@@ -99,7 +99,7 @@
                                 % include('components/trip')
                             </td>
                         % else:
-                            <td colspan="3">
+                            <td colspan="{{ '3' if context.enable_blocks else '2' }}">
                                 <div class="column">
                                     <span class="lighter-text">Not In Service</span>
                                     <span class="non-desktop smaller-font no-wrap">{{ position.speed }} km/h</span>


### PR DESCRIPTION
Porting over this feature from ABTracker. Original MR: https://github.com/bumblesquashs/bctracker/pull/284

Basically unchanged, however I did not include the migration script since we don't have any existing agencies/systems that need this. Change is mainly being brought over for consistency and so it's functional if we ever do full realtime for an agency without blocks (eg BCF).