### PR TITLE
Map marker icon improvements

### DIFF
--- a/server.py
+++ b/server.py
@@ -20,7 +20,7 @@ import services
 import settings
 
 # Increase the version to force CSS reload
-VERSION = 70
+VERSION = 71
 
 random = Random()
 

--- a/style/dark.css
+++ b/style/dark.css
@@ -75,24 +75,9 @@
     --image-color: #EF9744;
 }
 
-.marker .bearing {
-    filter: brightness(80%);
-}
-
 .marker .icon {
-    filter: brightness(80%);
-}
-
-.marker .icon.adherence {
-    filter: unset;
-}
-
-.marker .icon.occupancy {
-    filter: unset;
-}
-
-.marker .icon.speed {
     color: #FFFFFF;
+    --image-color: #FFFFFF;
 }
 
 .modified-service {

--- a/style/light.css
+++ b/style/light.css
@@ -67,8 +67,9 @@
     --image-color: #FF9A3A;
 }
 
-.marker .icon.speed {
+.marker .icon {
     color: #FFFFFF;
+    --image-color: #FFFFFF;
 }
 
 .modified-service {

--- a/style/main.css
+++ b/style/main.css
@@ -1215,13 +1215,31 @@ table tr.table-button {
     text-decoration: none;
 }
 
-.marker .icon.vehicle_route {
+.marker .icon.route-number {
     font-weight: bold;
     text-align: center;
     line-height: 24px;
     font-size: 11pt;
     vertical-align: middle;
     text-decoration: none;
+}
+
+.marker .icon.vehicle-route {
+    font-weight: bold;
+    text-align: center;
+    line-height: 8px;
+    font-size: 7pt;
+    vertical-align: middle;
+    text-decoration: none;
+    --image-size: 18px;
+}
+
+.marker .icon.vehicle-route .column {
+    margin-top: -1px;
+}
+
+.marker .icon.vehicle-route .number {
+    margin-top: -1px;
 }
 
 .marker .icon.occupancy {

--- a/style/themes/bc-ferries.dark.css
+++ b/style/themes/bc-ferries.dark.css
@@ -369,15 +369,6 @@ table tr.table-button:hover {
 .marker .icon {
     background-color: #003769;
     border-color: #000E1A;
-    --image-color: #FFFFFF;
-}
-
-.marker .icon.route .number {
-    color: #FFFFFF;
-}
-
-.marker .icon.vehicle_route {
-    color: #FFFFFF;
 }
 
 .news-post {

--- a/style/themes/bc-ferries.light.css
+++ b/style/themes/bc-ferries.light.css
@@ -360,15 +360,6 @@ table tr.table-button:hover {
 .marker .icon {
     border-color: #FFFFFF;
     background-color: #003769;
-    --image-color: #FFFFFF;
-}
-
-.marker .icon.route .number {
-    color: #FFFFFF;
-}
-
-.marker .icon.vehicle_route {
-    color: #FFFFFF;
 }
 
 .news-post {

--- a/style/themes/bc-hydro.css
+++ b/style/themes/bc-hydro.css
@@ -354,15 +354,6 @@ table tr.table-button:hover {
 .marker .icon {
     border-color: #FFFFFF;
     background-color: #61C315;
-    --image-color: #FFFFFF;
-}
-
-.marker .icon.route .number {
-    color: #FFFFFF;
-}
-
-.marker .icon.vehicle_route {
-    color: #FFFFFF;
 }
 
 .news-post {

--- a/style/themes/bc-transit-classic.css
+++ b/style/themes/bc-transit-classic.css
@@ -358,15 +358,6 @@ table tr.table-button:hover {
 .marker .icon {
     border-color: #FFFFFF;
     background-color: #E20000;
-    --image-color: #FFFFFF;
-}
-
-.marker .icon.route .number {
-    color: #FFFFFF;
-}
-
-.marker .icon.vehicle_route {
-    color: #FFFFFF;
 }
 
 .news-post {

--- a/style/themes/bc-transit-green.dark.css
+++ b/style/themes/bc-transit-green.dark.css
@@ -380,15 +380,6 @@ table tr.table-button:hover {
 .marker .icon {
     background-color: #00A200;
     border-color: #2F2F2F;
-    --image-color: #FFFFFF;
-}
-
-.marker .icon.route .number {
-    color: #FFFFFF;
-}
-
-.marker .icon.vehicle_route {
-    color: #FFFFFF;
 }
 
 .news-post {

--- a/style/themes/bc-transit-green.light.css
+++ b/style/themes/bc-transit-green.light.css
@@ -371,15 +371,6 @@ table tr.table-button:hover {
 .marker .icon {
     border-color: #FFFFFF;
     background-color: #00A200;
-    --image-color: #FFFFFF;
-}
-
-.marker .icon.route .number {
-    color: #FFFFFF;
-}
-
-.marker .icon.vehicle_route {
-    color: #FFFFFF;
 }
 
 .news-post {

--- a/style/themes/bc-transit.dark.css
+++ b/style/themes/bc-transit.dark.css
@@ -374,7 +374,11 @@ table tr.table-button:hover {
     color: #FFFFFF;
 }
 
-.marker .icon.vehicle_route {
+.marker .icon.route-number {
+    color: #FFFFFF;
+}
+
+.marker .icon.vehicle-route {
     color: #FFFFFF;
 }
 

--- a/style/themes/bc-transit.light.css
+++ b/style/themes/bc-transit.light.css
@@ -358,15 +358,6 @@ table tr.table-button:hover {
 .marker .icon {
     border-color: #FFFFFF;
     background-color: #48A348;
-    --image-color: #FFFFFF;
-}
-
-.marker .icon.route .number {
-    color: #FFFFFF;
-}
-
-.marker .icon.vehicle_route {
-    color: #FFFFFF;
 }
 
 .news-post {

--- a/style/themes/broome-county.css
+++ b/style/themes/broome-county.css
@@ -338,15 +338,6 @@ table tr.table-button:hover {
 .marker .icon {
     border-color: #FFFFFF;
     background-color: #165ABE;
-    --image-color: #FFFFFF;
-}
-
-.marker .icon.route .number {
-    color: #FFFFFF;
-}
-
-.marker .icon.vehicle_route {
-    color: #FFFFFF;
 }
 
 .news-post {

--- a/style/themes/christmas.css
+++ b/style/themes/christmas.css
@@ -360,15 +360,6 @@ table tr.table-button:hover {
 .marker .icon {
     border-color: #FFFFFF;
     background-color: #D70000;
-    --image-color: #FFFFFF;
-}
-
-.marker .icon.route .number {
-    color: #FFFFFF;
-}
-
-.marker .icon.vehicle_route {
-    color: #FFFFFF;
 }
 
 .news-post {

--- a/style/themes/ghost.css
+++ b/style/themes/ghost.css
@@ -343,15 +343,6 @@ table tr.table-button:hover {
 .marker .icon {
     border-color: #FFFFFF;
     background-color: #888888;
-    --image-color: #FFFFFF;
-}
-
-.marker .icon.route .number {
-    color: #FFFFFF;
-}
-
-.marker .icon.vehicle_route {
-    color: #FFFFFF;
 }
 
 .news-post {

--- a/style/themes/halloween.css
+++ b/style/themes/halloween.css
@@ -367,15 +367,6 @@ table tr.table-button:hover {
 .marker .icon {
     background-color: #FF6C00;
     border-color: #2F2F2F;
-    --image-color: #FFFFFF;
-}
-
-.marker .icon.route .number {
-    color: #FFFFFF;
-}
-
-.marker .icon.vehicle_route {
-    color: #FFFFFF;
 }
 
 .news-post {

--- a/style/themes/pride.dark.css
+++ b/style/themes/pride.dark.css
@@ -357,15 +357,6 @@ table tr.table-button:hover {
 .marker .icon {
     border-color: #000000;
     background-color: #000000;
-    --image-color: #FFFFFF;
-}
-
-.marker .icon.route .number {
-    color: #FFFFFF;
-}
-
-.marker .icon.vehicle_route {
-    color: #FFFFFF;
 }
 
 .news-post {

--- a/style/themes/pride.light.css
+++ b/style/themes/pride.light.css
@@ -355,15 +355,6 @@ table tr.table-button:hover {
 .marker .icon {
     border-color: #FFFFFF;
     background-color: #000000;
-    --image-color: #FFFFFF;
-}
-
-.marker .icon.route .number {
-    color: #FFFFFF;
-}
-
-.marker .icon.vehicle_route {
-    color: #FFFFFF;
 }
 
 .news-post {

--- a/style/themes/tcomm.css
+++ b/style/themes/tcomm.css
@@ -509,20 +509,6 @@ table tr.table-button:hover {
 .marker .icon {
     border-color: #FFFFFF;
     background-color: #5393c5;
-    --image-color: #FFFFFF;
-}
-
-.marker .icon.route .number {
-    color: #FFFFFF;
-    text-shadow: none;
-}
-
-.marker .icon.vehicle_route {
-    color: #FFFFFF;
-    text-shadow: none;
-}
-
-.marker .icon.adherence {
     text-shadow: none;
 }
 

--- a/style/themes/uta.css
+++ b/style/themes/uta.css
@@ -354,15 +354,6 @@ table tr.table-button:hover {
 .marker .icon {
     border-color: #FFFFFF;
     background-color: #7E3704;
-    --image-color: #FFFFFF;
-}
-
-.marker .icon.route .number {
-    color: #FFFFFF;
-}
-
-.marker .icon.vehicle_route {
-    color: #FFFFFF;
 }
 
 .news-post {

--- a/views/components/map.tpl
+++ b/views/components/map.tpl
@@ -149,13 +149,16 @@
             element.appendChild(icon);
             
             if (vehicleMarkerStyle === "route") {
-                icon.classList.add("vehicle_route");
+                icon.classList.add("route-number");
+                icon.innerHTML += position.route_number;
+                icon.style.backgroundColor = "#" + position.colour;
+            } else if (vehicleMarkerStyle === "vehicle-type") {
                 if (position.lat === 0 && position.lon === 0) {
-                    icon.innerHTML += getSVG("fish");
+                    icon.innerHTML = getSVG("fish");
                 } else if (adherence && adherence.value <= -66) {
-                    icon.innerHTML += getSVG("snail");
+                    icon.innerHTML = getSVG("snail");
                 } else {
-                    icon.innerHTML += position.route_number;
+                    icon.innerHTML = getSVG(position.vehicle_icon);
                 }
                 icon.style.backgroundColor = "#" + position.colour;
             } else if (vehicleMarkerStyle === "mini") {
@@ -165,22 +168,14 @@
             } else if (vehicleMarkerStyle === "adherence") {
                 icon.classList.add("adherence");
                 if (adherence === undefined || adherence === null) {
-                    if (position.lat === 0 && position.lon === 0) {
-                        icon.innerHTML += getSVG("fish");
-                    } else if (position.route_number === "NIS") {
+                    if (position.route_number === "NIS") {
                         icon.innerHTML += "NIS";
                     } else {
                         icon.innerHTML += "N/A"
                     }
                 } else {
-                    if (position.lat === 0 && position.lon === 0) {
-                        icon.innerHTML += getSVG("fish");
-                    } else if (adherence.value <= -66) {
-                        icon.innerHTML += getSVG("snail");
-                    } else {
-                        icon.innerHTML += adherence.value;
-                    }
                     icon.classList.add(adherence.status_class);
+                    icon.innerHTML += adherence.value;
                     const adherenceValue = parseInt(adherence.value);
                     if (adherenceValue >= 100 || adherenceValue <= -100) {
                         icon.classList.add("smaller-font");
@@ -189,13 +184,7 @@
             } else if (vehicleMarkerStyle === "occupancy" && position.occupancy_icon) {
                 icon.classList.add("occupancy");
                 icon.classList.add(position.occupancy_status_class);
-                if (position.lat === 0 && position.lon === 0) {
-                    icon.innerHTML += getSVG("fish");
-                } else if (adherence && adherence.value <= -66) {
-                    icon.innerHTML += getSVG("snail");
-                } else {
-                    icon.innerHTML += getSVG(position.occupancy_icon);
-                }
+                icon.innerHTML += getSVG(position.occupancy_icon);
             } else if (vehicleMarkerStyle === "livery" && position.livery) {
                 icon.classList.add("livery");
                 icon.innerHTML = '<img src="/img/liveries/' + position.livery  +'.png" />';
@@ -204,13 +193,21 @@
                 icon.innerHTML = position.speed + '<div class="units">km/h</div>';
                 icon.style.backgroundColor = "#" + position.colour;
             } else {
+                icon.classList.add("vehicle-route");
+                const column = document.createElement("div");
+                column.className = "column center gap-0";
                 if (position.lat === 0 && position.lon === 0) {
-                    icon.innerHTML += getSVG("fish");
+                    column.innerHTML = getSVG("fish");
                 } else if (adherence && adherence.value <= -66) {
-                    icon.innerHTML += getSVG("snail");
+                    column.innerHTML = getSVG("snail");
                 } else {
-                    icon.innerHTML += getSVG(position.vehicle_icon);
+                    column.innerHTML = getSVG(position.vehicle_icon);
                 }
+                const routeElement = document.createElement("div");
+                routeElement.className = "number";
+                routeElement.innerHTML = position.route_number;
+                column.appendChild(routeElement);
+                icon.appendChild(column);
                 icon.style.backgroundColor = "#" + position.colour;
             }
             

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -72,6 +72,10 @@
                 <div class="options-container">
                     <div class="option" onclick="setVehicleMarkerStyle('default')">
                         <div id="vehicle-marker-style-default" class="radio-button {{ 'selected' if not vehicle_marker_style or vehicle_marker_style == 'default' else '' }}"></div>
+                        <div>Default</div>
+                    </div>
+                    <div class="option" onclick="setVehicleMarkerStyle('vehicle-type')">
+                        <div id="vehicle-marker-style-vehicle-type" class="radio-button {{ 'selected' if vehicle_marker_style == 'vehicle-type' else '' }}"></div>
                         <div>Vehicle Type</div>
                     </div>
                     <div class="option" onclick="setVehicleMarkerStyle('mini')">
@@ -230,13 +234,16 @@
             element.appendChild(icon);
             
             if (vehicleMarkerStyle === "route") {
-                icon.classList.add("vehicle_route");
+                icon.classList.add("route-number");
+                icon.innerHTML += position.route_number;
+                icon.style.backgroundColor = "#" + position.colour;
+            } else if (vehicleMarkerStyle === "vehicle-type") {
                 if (position.lat === 0 && position.lon === 0) {
-                    icon.innerHTML += getSVG("fish");
+                    icon.innerHTML = getSVG("fish");
                 } else if (adherence && adherence.value <= -66) {
-                    icon.innerHTML += getSVG("snail");
+                    icon.innerHTML = getSVG("snail");
                 } else {
-                    icon.innerHTML += position.route_number;
+                    icon.innerHTML = getSVG(position.vehicle_icon);
                 }
                 icon.style.backgroundColor = "#" + position.colour;
             } else if (vehicleMarkerStyle === "mini") {
@@ -246,22 +253,14 @@
             } else if (vehicleMarkerStyle === "adherence") {
                 icon.classList.add("adherence");
                 if (adherence === undefined || adherence === null) {
-                    if (position.lat === 0 && position.lon === 0) {
-                        icon.innerHTML += getSVG("fish");
-                    } else if (position.route_number === "NIS") {
+                    if (position.route_number === "NIS") {
                         icon.innerHTML += "NIS";
                     } else {
                         icon.innerHTML += "N/A"
                     }
                 } else {
-                    if (position.lat === 0 && position.lon === 0) {
-                        icon.innerHTML += getSVG("fish");
-                    } else if (adherence.value <= -66) {
-                        icon.innerHTML += getSVG("snail");
-                    } else {
-                        icon.innerHTML += adherence.value;
-                    }
                     icon.classList.add(adherence.status_class);
+                    icon.innerHTML += adherence.value;
                     const adherenceValue = parseInt(adherence.value);
                     if (adherenceValue >= 100 || adherenceValue <= -100) {
                         icon.classList.add("smaller-font");
@@ -270,13 +269,7 @@
             } else if (vehicleMarkerStyle === "occupancy" && position.occupancy_icon) {
                 icon.classList.add("occupancy");
                 icon.classList.add(position.occupancy_status_class);
-                if (position.lat === 0 && position.lon === 0) {
-                    icon.innerHTML += getSVG("fish");
-                } else if (adherence && adherence.value <= -66) {
-                    icon.innerHTML += getSVG("snail");
-                } else {
-                    icon.innerHTML += getSVG(position.occupancy_icon);
-                }
+                icon.innerHTML += getSVG(position.occupancy_icon);
             } else if (vehicleMarkerStyle === "livery" && position.livery) {
                 icon.classList.add("livery");
                 icon.innerHTML = '<img src="/img/liveries/' + position.livery  +'.png" />';
@@ -285,13 +278,21 @@
                 icon.innerHTML = position.speed + '<div class="units">km/h</div>';
                 icon.style.backgroundColor = "#" + position.colour;
             } else {
+                icon.classList.add("vehicle-route");
+                const column = document.createElement("div");
+                column.className = "column center gap-0";
                 if (position.lat === 0 && position.lon === 0) {
-                    icon.innerHTML += getSVG("fish");
+                    column.innerHTML = getSVG("fish");
                 } else if (adherence && adherence.value <= -66) {
-                    icon.innerHTML += getSVG("snail");
+                    column.innerHTML = getSVG("snail");
                 } else {
-                    icon.innerHTML += getSVG(position.vehicle_icon);
+                    column.innerHTML = getSVG(position.vehicle_icon);
                 }
+                const routeElement = document.createElement("div");
+                routeElement.className = "number";
+                routeElement.innerHTML = position.route_number;
+                column.appendChild(routeElement);
+                icon.appendChild(column);
                 icon.style.backgroundColor = "#" + position.colour;
             }
             
@@ -492,9 +493,15 @@
     }
     
     function setVehicleMarkerStyle(style) {
-        document.getElementById("vehicle-marker-style-" + vehicleMarkerStyle).classList.remove("selected");
+        const oldElement = document.getElementById("vehicle-marker-style-" + vehicleMarkerStyle);
+        if (oldElement !== null) {
+            oldElement.classList.remove("selected");
+        }
         vehicleMarkerStyle = style;
-        document.getElementById("vehicle-marker-style-" + style).classList.add("selected");
+        const newElement = document.getElementById("vehicle-marker-style-" + style);
+        if (newElement !== null) {
+            newElement.classList.add("selected");
+        }
         setCookie("vehicle_marker_style", style);
         updateMap(false);
     }

--- a/views/pages/personalize.tpl
+++ b/views/pages/personalize.tpl
@@ -158,6 +158,10 @@
                 <div class="options-container">
                     <div class="option" onclick="setVehicleMarkerStyle('default')">
                         <div class="radio-button {{ 'selected' if not vehicle_marker_style or vehicle_marker_style == 'default' else '' }}"></div>
+                        <div>Default</div>
+                    </div>
+                    <div class="option" onclick="setVehicleMarkerStyle('vehicle-type')">
+                        <div class="radio-button {{ 'selected' if vehicle_marker_style == 'vehicle-type' else '' }}"></div>
                         <div>Vehicle Type</div>
                     </div>
                     <div class="option" onclick="setVehicleMarkerStyle('mini')">


### PR DESCRIPTION
By default the map marker icon for vehicles now shows both the vehicle type and route stacked together.

The existing route number option still works the exact same as before, showing the number in the entire marker space. The vehicle type icon option is also still available, but is no longer the default selection.

Did a bit of CSS cleanup to simplify some of the themes since they all apply white for the text/icon. Can still be overridden by themes down the road if needed, but this removes plenty of boilerplate.

Also removed the slight darkening on the icons in dark themes - still looks good but helps the colours pop just a bit more.

All changes apply to both the main map page, as well as map previews and full-screen maps for various entities.

<img width="783" height="716" alt="Screenshot 2026-08-19 at 23 47 26" src="https://github.com/user-attachments/assets/c0fcb766-e5af-48b7-bf62-6a44ce0600ff" />
<img width="1022" height="708" alt="Screenshot 2026-08-19 at 23 47 40" src="https://github.com/user-attachments/assets/360741f0-79b7-461c-a636-046c1ffff698" />
<img width="517" height="336" alt="Screenshot 2026-08-19 at 23 47 52" src="https://github.com/user-attachments/assets/06cd3faa-efa4-43df-b832-75a5e270abde" />
