### PR TITLE
Remove internal URL logic

### DIFF
--- a/views/base.tpl
+++ b/views/base.tpl
@@ -157,7 +157,7 @@
                 return a
             }
             
-            function getURL(agencyID, systemID, path, internal=false, params=null) {
+            function getURL(agencyID, systemID, path, params=null) {
                 let url;
                 const query = [];
                 
@@ -168,13 +168,13 @@
                 }
                 
                 if (systemID) {
-                    if ((internal && currentSystemID === null) || "{{ settings.system_domain is None }}" === "True") {
+                    if ("{{ settings.system_domain is None }}" === "True") {
                         query.push("system=" + systemID);
                     } else {
                         url = "{{ settings.system_domain }}".format(systemID, path);
                     }
                 } else if (agencyID) {
-                    if ((internal && currentAgencyID === null) || "{{ settings.agency_domain is None }}" === "True") {
+                    if ("{{ settings.agency_domain is None }}" === "True") {
                         query.push("agency=" + agencyID);
                     } else {
                         url = "{{ settings.agency_domain }}".format(agencyID, path);

--- a/views/pages/admin/logs.tpl
+++ b/views/pages/admin/logs.tpl
@@ -52,7 +52,7 @@
                 </div>
                 <script>
                     function setLevel(level) {
-                        window.location = getURL(currentAgencyID, currentSystemID, "admin/logs", false, {
+                        window.location = getURL(currentAgencyID, currentSystemID, "admin/logs", {
                             "level": level
                         });
                     }

--- a/views/pages/admin/management.tpl
+++ b/views/pages/admin/management.tpl
@@ -158,43 +158,43 @@
 <script>
     function reloadDecorations() {
         const request = new XMLHttpRequest();
-        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/reload-decorations", true), true);
+        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/reload-decorations"), true);
         request.send();
     }
     
     function reloadOrders() {
         const request = new XMLHttpRequest();
-        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/reload-orders", true), true);
+        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/reload-orders"), true);
         request.send();
     }
     
     function reloadSystems() {
         const request = new XMLHttpRequest();
-        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/reload-systems", true), true);
+        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/reload-systems"), true);
         request.send();
     }
     
     function reloadThemes() {
         const request = new XMLHttpRequest();
-        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/reload-themes", true), true);
+        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/reload-themes"), true);
         request.send();
     }
     
     function restartCron() {
         const request = new XMLHttpRequest();
-        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/restart-cron", true), true);
+        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/restart-cron"), true);
         request.send();
     }
     
     function backupDatabase() {
         const request = new XMLHttpRequest();
-        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/backup-database", true), true);
+        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/backup-database"), true);
         request.send();
     }
     
     function resetCache(resetSystemID) {
         const request = new XMLHttpRequest();
-        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/reset-cache/" + resetSystemID, true), true);
+        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/reset-cache/" + resetSystemID), true);
         request.onload = function() {
             location.reload();
         }
@@ -203,13 +203,13 @@
     
     function reloadGTFS(reloadSystemID) {
         const request = new XMLHttpRequest();
-        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/reload-gtfs/" + reloadSystemID, true), true);
+        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/reload-gtfs/" + reloadSystemID), true);
         request.send();
     }
     
     function reloadRealtime(reloadSystemID) {
         const request = new XMLHttpRequest();
-        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/reload-realtime/" + reloadSystemID, true), true);
+        request.open("POST", getURL(currentAgencyID, currentSystemID, "api/admin/reload-realtime/" + reloadSystemID), true);
         request.send();
     }
 </script>

--- a/views/pages/history/last_seen.tpl
+++ b/views/pages/history/last_seen.tpl
@@ -60,7 +60,7 @@
                 % end
                 <script>
                     function setDays(days) {
-                        window.location = getURL(currentAgencyID, currentSystemID, "history", false, {
+                        window.location = getURL(currentAgencyID, currentSystemID, "history", {
                             "days": days
                         });
                     }

--- a/views/pages/history/transfers.tpl
+++ b/views/pages/history/transfers.tpl
@@ -40,7 +40,7 @@
                         </div>
                         <script>
                             function setFilter(filter) {
-                                window.location = getURL(currentAgencyID, currentSystemID, "history/transfers", false, {
+                                window.location = getURL(currentAgencyID, currentSystemID, "history/transfers", {
                                     "filter": filter
                                 });
                             }

--- a/views/pages/home.tpl
+++ b/views/pages/home.tpl
@@ -70,7 +70,7 @@
                         let value = document.getElementById('stop_search').value;
                         if (value.length > 0) {
                             if (isNaN(value)) {
-                                window.location = getURL(currentAgencyID, currentSystemID, "stops", false, {
+                                window.location = getURL(currentAgencyID, currentSystemID, "stops", {
                                     "search": value
                                 });
                             } else {

--- a/views/pages/map.tpl
+++ b/views/pages/map.tpl
@@ -530,7 +530,7 @@
                 continue;
             }
             const request = new XMLHttpRequest();
-            request.open("GET", getURL(null, position.system_id, "api/shape/" + position.shape_id, true), true);
+            request.open("GET", getURL(null, position.system_id, "api/shape/" + position.shape_id), true);
             request.responseType = "json";
             request.onload = function() {
                 if (request.status === 200) {
@@ -588,7 +588,7 @@
                 shapes[shapeID].setVisible(true);
             } else {
                 const request = new XMLHttpRequest();
-                request.open("GET", getURL(null, position.system_id, "api/shape/" + position.shape_id, true), true);
+                request.open("GET", getURL(null, position.system_id, "api/shape/" + position.shape_id), true);
                 request.responseType = "json";
                 request.onload = function() {
                     if (request.status === 200) {
@@ -684,7 +684,7 @@
         if (key in cachedStops) {
             updateStopMarkers(key);
         } else {
-            const url = getURL(currentAgencyID, currentSystemID, "api/stops", true, {
+            const url = getURL(currentAgencyID, currentSystemID, "api/stops", {
                 "lat": lat,
                 "lon": lon,
                 "size": size

--- a/views/pages/nearby.tpl
+++ b/views/pages/nearby.tpl
@@ -171,7 +171,7 @@
     
     <script>
         function onSuccess(position) {
-            window.location = getURL(currentAgencyID, currentSystemID, "nearby", false, {
+            window.location = getURL(currentAgencyID, currentSystemID, "nearby", {
                 lat: position.coords.latitude,
                 lon: position.coords.longitude
             });

--- a/views/pages/stops/stops.tpl
+++ b/views/pages/stops/stops.tpl
@@ -45,7 +45,7 @@
         
         function updateFilters() {
             const search = document.getElementById('stop_id_search').value;
-            window.location = getURL(currentAgencyID, currentSystemID, "stops", false, {
+            window.location = getURL(currentAgencyID, currentSystemID, "stops", {
                 "search": search.length === 0 ? null : search,
                 "routes": routesFilter.size === 0 ? null : Array.from(routesFilter).sort().join(","),
                 "sort": sort === "name" ? null : sort,


### PR DESCRIPTION
Our nginx config has been updated to allow cross-origin requests, so a page on `bctracker.ca` can make a request to `victoria.bctracker.ca` and vice versa. This means we no longer need the old `internal=true/false` logic for URLs made in JS. The parameter has been removed from the function definition and any places that didn't use the default value.